### PR TITLE
feat(brain): phase 2 ciiu taxonomy context

### DIFF
--- a/src/brain/__tests__/ciiu-taxonomy/CiiuActivity.test.ts
+++ b/src/brain/__tests__/ciiu-taxonomy/CiiuActivity.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+
+const validData = {
+  code: '4711',
+  titulo: 'Comercio al por menor en establecimientos no especializados',
+  seccion: 'G',
+  division: '47',
+  grupo: '471',
+  tituloSeccion: 'Comercio',
+  tituloDivision: 'Comercio al por menor',
+  tituloGrupo: 'Establecimientos no especializados',
+  macroSector: 'Servicios',
+}
+
+describe('CiiuActivity', () => {
+  it('creates a valid activity exposing all fields via getters', () => {
+    const a = CiiuActivity.create(validData)
+    expect(a.code).toBe('4711')
+    expect(a.titulo).toBe(validData.titulo)
+    expect(a.seccion).toBe('G')
+    expect(a.division).toBe('47')
+    expect(a.grupo).toBe('471')
+    expect(a.tituloSeccion).toBe('Comercio')
+    expect(a.tituloDivision).toBe('Comercio al por menor')
+    expect(a.tituloGrupo).toBe('Establecimientos no especializados')
+    expect(a.macroSector).toBe('Servicios')
+  })
+
+  it('defaults macroSector to null when omitted', () => {
+    const { macroSector: _omit, ...rest } = validData
+    const a = CiiuActivity.create(rest)
+    expect(a.macroSector).toBeNull()
+  })
+
+  it('treats explicit null macroSector as null', () => {
+    const a = CiiuActivity.create({ ...validData, macroSector: null })
+    expect(a.macroSector).toBeNull()
+  })
+
+  it('throws when code is not 4 digits', () => {
+    expect(() => CiiuActivity.create({ ...validData, code: '47' })).toThrow(
+      /4 digits/,
+    )
+    expect(() => CiiuActivity.create({ ...validData, code: '47111' })).toThrow(
+      /4 digits/,
+    )
+    expect(() => CiiuActivity.create({ ...validData, code: 'abcd' })).toThrow(
+      /4 digits/,
+    )
+  })
+
+  it('throws when seccion is not a single uppercase letter', () => {
+    expect(() => CiiuActivity.create({ ...validData, seccion: 'XX' })).toThrow(
+      /single uppercase letter/,
+    )
+    expect(() => CiiuActivity.create({ ...validData, seccion: 'g' })).toThrow(
+      /single uppercase letter/,
+    )
+    expect(() => CiiuActivity.create({ ...validData, seccion: '1' })).toThrow(
+      /single uppercase letter/,
+    )
+  })
+
+  it('throws when division is not 2 digits', () => {
+    expect(() => CiiuActivity.create({ ...validData, division: '4' })).toThrow(
+      /2 digits/,
+    )
+    expect(() =>
+      CiiuActivity.create({ ...validData, division: '477' }),
+    ).toThrow(/2 digits/)
+  })
+
+  it('inherits identity equality from Entity (equal when codes match)', () => {
+    const a = CiiuActivity.create(validData)
+    const b = CiiuActivity.create({ ...validData, titulo: 'distinto' })
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('considers activities different when codes differ', () => {
+    const a = CiiuActivity.create({ ...validData, code: '4711' })
+    const b = CiiuActivity.create({ ...validData, code: '4712' })
+    expect(a.equals(b)).toBe(false)
+  })
+})

--- a/src/brain/__tests__/ciiu-taxonomy/FindCiiuByCode.test.ts
+++ b/src/brain/__tests__/ciiu-taxonomy/FindCiiuByCode.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { FindCiiuByCode } from '@/ciiu-taxonomy/application/use-cases/FindCiiuByCode'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+
+const seedActivity = CiiuActivity.create({
+  code: '4711',
+  titulo: 'Comercio al por menor',
+  seccion: 'G',
+  division: '47',
+  grupo: '471',
+  tituloSeccion: 'Comercio',
+  tituloDivision: 'Comercio al por menor',
+  tituloGrupo: 'Establecimientos no especializados',
+  macroSector: 'Servicios',
+})
+
+describe('FindCiiuByCode', () => {
+  it('returns the activity when the code exists', async () => {
+    const repo = new InMemoryCiiuTaxonomyRepository([seedActivity])
+    const useCase = new FindCiiuByCode(repo)
+
+    const { activity } = await useCase.execute({ code: '4711' })
+
+    expect(activity).not.toBeNull()
+    expect(activity!.code).toBe('4711')
+    expect(activity!.titulo).toBe('Comercio al por menor')
+  })
+
+  it('returns null when the code does not exist', async () => {
+    const repo = new InMemoryCiiuTaxonomyRepository([seedActivity])
+    const useCase = new FindCiiuByCode(repo)
+
+    const { activity } = await useCase.execute({ code: '9999' })
+
+    expect(activity).toBeNull()
+  })
+})

--- a/src/brain/__tests__/ciiu-taxonomy/SupabaseCiiuTaxonomyRepository.test.ts
+++ b/src/brain/__tests__/ciiu-taxonomy/SupabaseCiiuTaxonomyRepository.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SupabaseCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown }
+
+/**
+ * Fake PostgrestClient. The real client returns a thenable query builder from
+ * `.from(...).select(...)...`. We mimic that by returning `this` from every
+ * chainable method and exposing `then` so `await builder` resolves with the
+ * value set via `setNext`. Terminal `.maybeSingle()` returns the same value.
+ */
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    maybeSingle: vi.fn(),
+    upsert: vi.fn(),
+    then: (onF: (r: Resolved) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of ['from', 'select', 'eq', 'in', 'upsert'] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  code: '4711',
+  titulo_actividad:
+    'Comercio al por menor en establecimientos no especializados',
+  seccion: 'G',
+  division: '47',
+  grupo: '471',
+  titulo_seccion: 'Comercio',
+  titulo_division: 'Comercio al por menor',
+  titulo_grupo: 'Establecimientos no especializados',
+  macro_sector: 'Servicios',
+}
+
+describe('SupabaseCiiuTaxonomyRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseCiiuTaxonomyRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseCiiuTaxonomyRepository(fake.db)
+  })
+
+  describe('findByCode', () => {
+    it('returns a CiiuActivity entity when row exists', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const activity = await repo.findByCode('4711')
+      expect(activity).not.toBeNull()
+      expect(activity).toBeInstanceOf(CiiuActivity)
+      expect(activity!.code).toBe('4711')
+      expect(activity!.tituloSeccion).toBe('Comercio')
+      expect(fake.spies.from).toHaveBeenCalledWith('ciiu_taxonomy')
+      expect(fake.spies.eq).toHaveBeenCalledWith('code', '4711')
+      expect(fake.spies.maybeSingle).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns null when no row found', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findByCode('9999')).toBeNull()
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('db down') })
+      await expect(repo.findByCode('4711')).rejects.toThrow(/db down/)
+    })
+  })
+
+  describe('findByCodes', () => {
+    it('short-circuits with empty array when no codes given', async () => {
+      const result = await repo.findByCodes([])
+      expect(result).toEqual([])
+      expect(fake.spies.from).not.toHaveBeenCalled()
+    })
+
+    it('maps rows to entities', async () => {
+      fake.setNext({
+        data: [validRow, { ...validRow, code: '4712' }],
+        error: null,
+      })
+      const result = await repo.findByCodes(['4711', '4712'])
+      expect(result).toHaveLength(2)
+      expect(result.map((a) => a.code)).toEqual(['4711', '4712'])
+      expect(fake.spies.in).toHaveBeenCalledWith('code', ['4711', '4712'])
+    })
+
+    it('returns empty array when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findByCodes(['4711'])).toEqual([])
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findByCodes(['4711'])).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('findBySection', () => {
+    it('queries by seccion and maps results', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findBySection('G')
+      expect(result).toHaveLength(1)
+      expect(result[0].seccion).toBe('G')
+      expect(fake.spies.eq).toHaveBeenCalledWith('seccion', 'G')
+    })
+  })
+
+  describe('findByDivision', () => {
+    it('queries by division', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      await repo.findByDivision('47')
+      expect(fake.spies.eq).toHaveBeenCalledWith('division', '47')
+    })
+  })
+
+  describe('findByGrupo', () => {
+    it('queries by grupo', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      await repo.findByGrupo('471')
+      expect(fake.spies.eq).toHaveBeenCalledWith('grupo', '471')
+    })
+  })
+
+  describe('saveAll', () => {
+    it('upserts rows mapped from entities with onConflict on code', async () => {
+      fake.setNext({ data: null, error: null })
+      const a = CiiuActivity.create({
+        code: '4711',
+        titulo: 'T',
+        seccion: 'G',
+        division: '47',
+        grupo: '471',
+        tituloSeccion: 'S',
+        tituloDivision: 'D',
+        tituloGrupo: 'GR',
+        macroSector: 'M',
+      })
+      await repo.saveAll([a])
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(1)
+      const [rows, opts] = fake.spies.upsert.mock.calls[0]
+      expect(rows).toEqual([
+        {
+          code: '4711',
+          titulo_actividad: 'T',
+          seccion: 'G',
+          division: '47',
+          grupo: '471',
+          titulo_seccion: 'S',
+          titulo_division: 'D',
+          titulo_grupo: 'GR',
+          macro_sector: 'M',
+        },
+      ])
+      expect(opts).toEqual({ onConflict: 'code' })
+    })
+
+    it('chunks payloads of more than 500 rows into multiple upserts', async () => {
+      fake.setNext({ data: null, error: null })
+      const activities = Array.from({ length: 1100 }, (_, i) =>
+        CiiuActivity.create({
+          code: String(1000 + i).padStart(4, '0'),
+          titulo: 't',
+          seccion: 'G',
+          division: '47',
+          grupo: '471',
+          tituloSeccion: 's',
+          tituloDivision: 'd',
+          tituloGrupo: 'gr',
+        }),
+      )
+      await repo.saveAll(activities)
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(3)
+      expect(fake.spies.upsert.mock.calls[0][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[1][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[2][0]).toHaveLength(100)
+    })
+
+    it('does nothing for empty array', async () => {
+      await repo.saveAll([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on supabase error mid-chunk', async () => {
+      fake.setNext({ data: null, error: new Error('insert failed') })
+      const a = CiiuActivity.create({
+        code: '4711',
+        titulo: 'T',
+        seccion: 'G',
+        division: '47',
+        grupo: '471',
+        tituloSeccion: 'S',
+        tituloDivision: 'D',
+        tituloGrupo: 'GR',
+      })
+      await expect(repo.saveAll([a])).rejects.toThrow(/insert failed/)
+    })
+  })
+})

--- a/src/brain/__tests__/shared/infrastructure/gemini/GeminiAdapter.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/gemini/GeminiAdapter.test.ts
@@ -1,35 +1,145 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-try {
-  process.loadEnvFile()
-} catch {
-  // .env not present — fall back to process.env as-is
-}
+// vi.hoisted lifts these initialisations to run BEFORE the auto-hoisted
+// vi.mock calls below — without it, the mock factory would close over
+// uninitialised `const` bindings and throw at import time.
+const { generateContentMock, getGenerativeModelMock, GoogleGenerativeAIMock } =
+  vi.hoisted(() => {
+    const generateContentMock = vi.fn()
+    const getGenerativeModelMock = vi.fn(() => ({
+      generateContent: generateContentMock,
+    }))
+    // Regular function expression — arrows lack [[Construct]] so they can't
+    // be invoked with `new GoogleGenerativeAI(key)`.
+    const GoogleGenerativeAIMock = vi.fn(function () {
+      return { getGenerativeModel: getGenerativeModelMock }
+    })
+    return {
+      generateContentMock,
+      getGenerativeModelMock,
+      GoogleGenerativeAIMock,
+    }
+  })
 
-const hasKey = !!process.env.GEMINI_API_KEY
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: GoogleGenerativeAIMock,
+}))
 
-describe.skipIf(!hasKey)('GeminiAdapter (real API)', () => {
-  it('generateText returns non-empty string', async () => {
-    const { GeminiAdapter } =
-      await import('@/shared/infrastructure/gemini/GeminiAdapter')
-    const adapter = new GeminiAdapter()
-    const out = await adapter.generateText('Di "hola" en una palabra')
-    expect(out.toLowerCase()).toContain('hola')
-  }, 30_000)
+vi.mock('@/shared/infrastructure/env', () => ({
+  env: {
+    GEMINI_API_KEY: 'test-api-key',
+    GEMINI_CHAT_MODEL: 'gemini-test-model',
+  },
+}))
 
-  it('inferStructured parses JSON', async () => {
-    const { GeminiAdapter } =
-      await import('@/shared/infrastructure/gemini/GeminiAdapter')
-    const adapter = new GeminiAdapter()
-    const out = await adapter.inferStructured(
-      'Devuelve JSON con la forma { "ok": true }. Solo el JSON, sin prosa.',
-      (raw) => {
-        if (typeof raw !== 'object' || raw === null || !('ok' in raw)) {
-          throw new Error('invalid')
-        }
-        return raw as { ok: boolean }
-      },
-    )
-    expect(out.ok).toBe(true)
-  }, 30_000)
+import { GeminiAdapter } from '@/shared/infrastructure/gemini/GeminiAdapter'
+
+describe('GeminiAdapter', () => {
+  beforeEach(() => {
+    generateContentMock.mockReset()
+    getGenerativeModelMock.mockClear()
+    GoogleGenerativeAIMock.mockClear()
+  })
+
+  describe('constructor', () => {
+    it('initialises the SDK client with the configured API key', () => {
+      new GeminiAdapter()
+      expect(GoogleGenerativeAIMock).toHaveBeenCalledWith('test-api-key')
+    })
+  })
+
+  describe('generateText', () => {
+    it('queries the configured model with the prompt and returns text()', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => 'hola mundo' },
+      })
+
+      const adapter = new GeminiAdapter()
+      const out = await adapter.generateText('di hola')
+
+      expect(out).toBe('hola mundo')
+      expect(getGenerativeModelMock).toHaveBeenCalledWith({
+        model: 'gemini-test-model',
+      })
+      expect(generateContentMock).toHaveBeenCalledWith('di hola')
+    })
+
+    it('propagates errors from the SDK', async () => {
+      generateContentMock.mockRejectedValue(new Error('rate limited'))
+      const adapter = new GeminiAdapter()
+      await expect(adapter.generateText('p')).rejects.toThrow(/rate limited/)
+    })
+  })
+
+  describe('inferStructured', () => {
+    it('parses raw JSON output and passes it to the validator', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => '{"ok": true, "n": 42}' },
+      })
+      const validator = vi.fn((raw) => raw as { ok: boolean; n: number })
+
+      const adapter = new GeminiAdapter()
+      const out = await adapter.inferStructured('p', validator)
+
+      expect(validator).toHaveBeenCalledWith({ ok: true, n: 42 })
+      expect(out).toEqual({ ok: true, n: 42 })
+    })
+
+    it('strips ```json ... ``` fences before parsing', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => '```json\n{"ok": true}\n```' },
+      })
+      const adapter = new GeminiAdapter()
+      const out = await adapter.inferStructured(
+        'p',
+        (raw) => raw as { ok: boolean },
+      )
+      expect(out.ok).toBe(true)
+    })
+
+    it('strips trailing whitespace before parsing', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => '   {"ok": true}   \n' },
+      })
+      const adapter = new GeminiAdapter()
+      const out = await adapter.inferStructured(
+        'p',
+        (raw) => raw as { ok: boolean },
+      )
+      expect(out.ok).toBe(true)
+    })
+
+    it('throws a descriptive error when the model returns non-JSON', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => 'lo siento, no puedo' },
+      })
+      const adapter = new GeminiAdapter()
+      await expect(adapter.inferStructured('p', (raw) => raw)).rejects.toThrow(
+        /non-JSON/,
+      )
+    })
+
+    it('returns whatever the validator returns (transformations supported)', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => '{"x": 21}' },
+      })
+      const adapter = new GeminiAdapter()
+      const out = await adapter.inferStructured('p', (raw) => ({
+        doubled: (raw as { x: number }).x * 2,
+      }))
+      expect(out).toEqual({ doubled: 42 })
+    })
+
+    it('propagates validator errors', async () => {
+      generateContentMock.mockResolvedValue({
+        response: { text: () => '{"x": 1}' },
+      })
+      const adapter = new GeminiAdapter()
+      await expect(
+        adapter.inferStructured('p', () => {
+          throw new Error('schema mismatch')
+        }),
+      ).rejects.toThrow(/schema mismatch/)
+    })
+  })
 })

--- a/src/brain/eslint.config.mjs
+++ b/src/brain/eslint.config.mjs
@@ -8,6 +8,24 @@ export default defineConfig([
   {
     rules: {
       'no-console': 'error',
+      // Force `import type` for type-only symbols. Closes the Bun ESM gotcha
+      // discovered in Phase 2: `bun run X.ts` errors on mixed value+type
+      // imports while `nest start` (SWC) silently elides the type. Auto-fix
+      // splits offenders into separate value vs type-only import statements.
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+      ],
+      // Honour the `_`-prefix convention for intentionally unused symbols
+      // (e.g. `const { drop: _omit, ...rest } = obj` or stub method args).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   globalIgnores(['dist/**', 'coverage/**', 'node_modules/**']),

--- a/src/brain/package.json
+++ b/src/brain/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "seed:ciiu": "bun run src/seeds/seed-ciiu-taxonomy.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/src/brain/src/app.module.ts
+++ b/src/brain/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { SharedModule } from './shared/shared.module'
+import { CiiuTaxonomyModule } from './ciiu-taxonomy/ciiu-taxonomy.module'
 import { HealthController } from './shared/infrastructure/health/health.controller'
 
 @Module({
-  imports: [ScheduleModule.forRoot(), SharedModule],
+  imports: [ScheduleModule.forRoot(), SharedModule, CiiuTaxonomyModule],
   controllers: [HealthController],
 })
 export class AppModule {}

--- a/src/brain/src/ciiu-taxonomy/application/use-cases/FindCiiuByCode.ts
+++ b/src/brain/src/ciiu-taxonomy/application/use-cases/FindCiiuByCode.ts
@@ -1,10 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common'
-import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
-import {
-  CIIU_TAXONOMY_REPOSITORY,
-  CiiuTaxonomyRepository,
-} from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
-import { UseCase } from '@/shared/domain/UseCase'
+import type { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import type { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import { CIIU_TAXONOMY_REPOSITORY } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
 
 interface FindCiiuByCodeInput {
   code: string

--- a/src/brain/src/ciiu-taxonomy/application/use-cases/FindCiiuByCode.ts
+++ b/src/brain/src/ciiu-taxonomy/application/use-cases/FindCiiuByCode.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import {
+  CIIU_TAXONOMY_REPOSITORY,
+  CiiuTaxonomyRepository,
+} from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import { UseCase } from '@/shared/domain/UseCase'
+
+interface FindCiiuByCodeInput {
+  code: string
+}
+
+interface FindCiiuByCodeOutput {
+  activity: CiiuActivity | null
+}
+
+@Injectable()
+export class FindCiiuByCode implements UseCase<
+  FindCiiuByCodeInput,
+  FindCiiuByCodeOutput
+> {
+  constructor(
+    @Inject(CIIU_TAXONOMY_REPOSITORY)
+    private readonly repo: CiiuTaxonomyRepository,
+  ) {}
+
+  async execute(input: FindCiiuByCodeInput): Promise<FindCiiuByCodeOutput> {
+    return { activity: await this.repo.findByCode(input.code) }
+  }
+}

--- a/src/brain/src/ciiu-taxonomy/ciiu-taxonomy.module.ts
+++ b/src/brain/src/ciiu-taxonomy/ciiu-taxonomy.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { FindCiiuByCode } from './application/use-cases/FindCiiuByCode'
+import { CIIU_TAXONOMY_REPOSITORY } from './domain/repositories/CiiuTaxonomyRepository'
+import { SupabaseCiiuTaxonomyRepository } from './infrastructure/repositories/SupabaseCiiuTaxonomyRepository'
+
+@Module({
+  providers: [
+    {
+      provide: CIIU_TAXONOMY_REPOSITORY,
+      useClass: SupabaseCiiuTaxonomyRepository,
+    },
+    FindCiiuByCode,
+  ],
+  exports: [CIIU_TAXONOMY_REPOSITORY, FindCiiuByCode],
+})
+export class CiiuTaxonomyModule {}

--- a/src/brain/src/ciiu-taxonomy/domain/entities/CiiuActivity.ts
+++ b/src/brain/src/ciiu-taxonomy/domain/entities/CiiuActivity.ts
@@ -1,0 +1,86 @@
+import { Entity } from '@/shared/domain/Entity'
+
+interface CiiuActivityProps {
+  titulo: string
+  seccion: string
+  division: string
+  grupo: string
+  tituloSeccion: string
+  tituloDivision: string
+  tituloGrupo: string
+  macroSector: string | null
+}
+
+export interface CiiuActivityInput {
+  code: string
+  titulo: string
+  seccion: string
+  division: string
+  grupo: string
+  tituloSeccion: string
+  tituloDivision: string
+  tituloGrupo: string
+  macroSector?: string | null
+}
+
+export class CiiuActivity extends Entity<string> {
+  private readonly props: CiiuActivityProps
+
+  private constructor(code: string, props: CiiuActivityProps) {
+    super(code)
+    this.props = Object.freeze(props)
+  }
+
+  static create(data: CiiuActivityInput): CiiuActivity {
+    if (!/^\d{4}$/.test(data.code)) {
+      throw new Error(`CIIU code must be 4 digits, got: ${data.code}`)
+    }
+    if (!/^[A-Z]$/.test(data.seccion)) {
+      throw new Error(
+        `CIIU seccion must be a single uppercase letter, got: ${data.seccion}`,
+      )
+    }
+    if (!/^\d{2}$/.test(data.division)) {
+      throw new Error(`CIIU division must be 2 digits, got: ${data.division}`)
+    }
+
+    return new CiiuActivity(data.code, {
+      titulo: data.titulo,
+      seccion: data.seccion,
+      division: data.division,
+      grupo: data.grupo,
+      tituloSeccion: data.tituloSeccion,
+      tituloDivision: data.tituloDivision,
+      tituloGrupo: data.tituloGrupo,
+      macroSector: data.macroSector ?? null,
+    })
+  }
+
+  get code(): string {
+    return this._id
+  }
+  get titulo(): string {
+    return this.props.titulo
+  }
+  get seccion(): string {
+    return this.props.seccion
+  }
+  get division(): string {
+    return this.props.division
+  }
+  get grupo(): string {
+    return this.props.grupo
+  }
+  get tituloSeccion(): string {
+    return this.props.tituloSeccion
+  }
+  get tituloDivision(): string {
+    return this.props.tituloDivision
+  }
+  get tituloGrupo(): string {
+    return this.props.tituloGrupo
+  }
+  get macroSector(): string | null {
+    return this.props.macroSector
+  }
+}

--- a/src/brain/src/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository.ts
@@ -1,0 +1,12 @@
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+
+export const CIIU_TAXONOMY_REPOSITORY = Symbol('CIIU_TAXONOMY_REPOSITORY')
+
+export interface CiiuTaxonomyRepository {
+  findByCode(code: string): Promise<CiiuActivity | null>
+  findByCodes(codes: string[]): Promise<CiiuActivity[]>
+  findBySection(seccion: string): Promise<CiiuActivity[]>
+  findByDivision(division: string): Promise<CiiuActivity[]>
+  findByGrupo(grupo: string): Promise<CiiuActivity[]>
+  saveAll(activities: CiiuActivity[]): Promise<void>
+}

--- a/src/brain/src/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository.ts
@@ -1,4 +1,4 @@
-import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import type { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
 
 export const CIIU_TAXONOMY_REPOSITORY = Symbol('CIIU_TAXONOMY_REPOSITORY')
 

--- a/src/brain/src/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository.ts
@@ -1,0 +1,36 @@
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+
+export class InMemoryCiiuTaxonomyRepository implements CiiuTaxonomyRepository {
+  private store = new Map<string, CiiuActivity>()
+
+  constructor(seed: CiiuActivity[] = []) {
+    for (const a of seed) this.store.set(a.code, a)
+  }
+
+  async findByCode(code: string): Promise<CiiuActivity | null> {
+    return this.store.get(code) ?? null
+  }
+
+  async findByCodes(codes: string[]): Promise<CiiuActivity[]> {
+    return codes
+      .map((c) => this.store.get(c))
+      .filter((a): a is CiiuActivity => a !== undefined)
+  }
+
+  async findBySection(seccion: string): Promise<CiiuActivity[]> {
+    return [...this.store.values()].filter((a) => a.seccion === seccion)
+  }
+
+  async findByDivision(division: string): Promise<CiiuActivity[]> {
+    return [...this.store.values()].filter((a) => a.division === division)
+  }
+
+  async findByGrupo(grupo: string): Promise<CiiuActivity[]> {
+    return [...this.store.values()].filter((a) => a.grupo === grupo)
+  }
+
+  async saveAll(activities: CiiuActivity[]): Promise<void> {
+    for (const a of activities) this.store.set(a.code, a)
+  }
+}

--- a/src/brain/src/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository.ts
@@ -1,5 +1,5 @@
-import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
-import { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import type { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import type { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
 
 export class InMemoryCiiuTaxonomyRepository implements CiiuTaxonomyRepository {
   private store = new Map<string, CiiuActivity>()

--- a/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
-import { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import type { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
 import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
 import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
 

--- a/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
@@ -1,0 +1,109 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import {
+  BrainSupabaseClient,
+  SUPABASE_CLIENT,
+} from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'ciiu_taxonomy'
+const CHUNK_SIZE = 500
+
+interface CiiuTaxonomyRow {
+  code: string
+  titulo_actividad: string
+  seccion: string
+  division: string
+  grupo: string
+  titulo_seccion: string
+  titulo_division: string
+  titulo_grupo: string
+  macro_sector: string | null
+}
+
+@Injectable()
+export class SupabaseCiiuTaxonomyRepository implements CiiuTaxonomyRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async findByCode(code: string): Promise<CiiuActivity | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('code', code)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as CiiuTaxonomyRow) : null
+  }
+
+  async findByCodes(codes: string[]): Promise<CiiuActivity[]> {
+    if (codes.length === 0) return []
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .in('code', codes)
+    if (error) throw error
+    return ((data ?? []) as CiiuTaxonomyRow[]).map((r) => this.toEntity(r))
+  }
+
+  async findBySection(seccion: string): Promise<CiiuActivity[]> {
+    return this.findManyByEq('seccion', seccion)
+  }
+
+  async findByDivision(division: string): Promise<CiiuActivity[]> {
+    return this.findManyByEq('division', division)
+  }
+
+  async findByGrupo(grupo: string): Promise<CiiuActivity[]> {
+    return this.findManyByEq('grupo', grupo)
+  }
+
+  async saveAll(activities: CiiuActivity[]): Promise<void> {
+    if (activities.length === 0) return
+    const rows: CiiuTaxonomyRow[] = activities.map((a) => ({
+      code: a.code,
+      titulo_actividad: a.titulo,
+      seccion: a.seccion,
+      division: a.division,
+      grupo: a.grupo,
+      titulo_seccion: a.tituloSeccion,
+      titulo_division: a.tituloDivision,
+      titulo_grupo: a.tituloGrupo,
+      macro_sector: a.macroSector,
+    }))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'code' })
+      if (error) throw error
+    }
+  }
+
+  private async findManyByEq(
+    column: 'seccion' | 'division' | 'grupo',
+    value: string,
+  ): Promise<CiiuActivity[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq(column, value)
+    if (error) throw error
+    return ((data ?? []) as CiiuTaxonomyRow[]).map((r) => this.toEntity(r))
+  }
+
+  private toEntity(row: CiiuTaxonomyRow): CiiuActivity {
+    return CiiuActivity.create({
+      code: row.code,
+      titulo: row.titulo_actividad,
+      seccion: row.seccion,
+      division: row.division,
+      grupo: row.grupo,
+      tituloSeccion: row.titulo_seccion,
+      tituloDivision: row.titulo_division,
+      tituloGrupo: row.titulo_grupo,
+      macroSector: row.macro_sector,
+    })
+  }
+}

--- a/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
+++ b/src/brain/src/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository.ts
@@ -1,10 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
 import { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
-import {
-  BrainSupabaseClient,
-  SUPABASE_CLIENT,
-} from '@/shared/infrastructure/supabase/SupabaseClient'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
 
 const TABLE = 'ciiu_taxonomy'
 const CHUNK_SIZE = 500

--- a/src/brain/src/seeds/seed-ciiu-taxonomy.ts
+++ b/src/brain/src/seeds/seed-ciiu-taxonomy.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+import { CsvLoader } from '@/shared/infrastructure/csv/CsvLoader'
+import { DataPaths } from '@/shared/infrastructure/path/DataPaths'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { createBrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+import { SupabaseCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/SupabaseCiiuTaxonomyRepository'
+
+interface CiiuRow {
+  code: string
+  seccion: string
+  division: string
+  grupo: string
+  titulo_actividad: string
+  titulo_seccion: string
+  titulo_division: string
+  titulo_grupo: string
+  macro_sector?: string
+}
+
+export interface SeedResult {
+  inserted: number
+  skipped: number
+  repo: SupabaseCiiuTaxonomyRepository
+}
+
+// CIIU_DIAN.csv ships with a second pseudo-header row (`Clase,,,Grupo,...`)
+// after the real header. Filter anything whose code isn't a 4-digit string
+// before handing it to the entity factory — same invariant as CiiuActivity.
+const VALID_CODE = /^\d{4}$/
+
+export async function seedCiiuTaxonomy(): Promise<SeedResult> {
+  const rows = await CsvLoader.load<CiiuRow>(DataPaths.ciiuDianCsv)
+
+  let skipped = 0
+  const activities: CiiuActivity[] = []
+  for (const r of rows) {
+    if (!VALID_CODE.test(r.code ?? '')) {
+      skipped++
+      continue
+    }
+    activities.push(
+      CiiuActivity.create({
+        code: r.code,
+        titulo: r.titulo_actividad,
+        seccion: r.seccion,
+        division: r.division,
+        grupo: r.grupo,
+        tituloSeccion: r.titulo_seccion,
+        tituloDivision: r.titulo_division,
+        tituloGrupo: r.titulo_grupo,
+        macroSector: r.macro_sector?.trim() || null,
+      }),
+    )
+  }
+
+  const repo = new SupabaseCiiuTaxonomyRepository(createBrainSupabaseClient())
+  await repo.saveAll(activities)
+  return { inserted: activities.length, skipped, repo }
+}
+
+if (require.main === module) {
+  seedCiiuTaxonomy()
+    .then(async ({ inserted, skipped, repo }) => {
+      console.log(
+        `✅ Seeded ${inserted} CIIU activities (skipped ${skipped} non-numeric rows)`,
+      )
+      const probe = await repo.findByCode('4711')
+      console.log(
+        probe
+          ? `🔎 Round-trip OK — 4711 → "${probe.titulo}" (seccion ${probe.seccion} / ${probe.tituloSeccion})`
+          : '⚠️  Round-trip FAILED — code 4711 not found after seed',
+      )
+      process.exit(probe ? 0 : 1)
+    })
+    .catch((err) => {
+      console.error('❌ Seed failed:', err)
+      process.exit(1)
+    })
+}

--- a/src/brain/src/shared/infrastructure/gemini/GeminiAdapter.ts
+++ b/src/brain/src/shared/infrastructure/gemini/GeminiAdapter.ts
@@ -1,5 +1,5 @@
 import { GoogleGenerativeAI } from '@google/generative-ai'
-import { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
 import { env } from '@/shared/infrastructure/env'
 
 export class GeminiAdapter implements GeminiPort {

--- a/src/brain/src/shared/infrastructure/gemini/StubGeminiAdapter.ts
+++ b/src/brain/src/shared/infrastructure/gemini/StubGeminiAdapter.ts
@@ -1,4 +1,4 @@
-import { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
 
 export class StubGeminiAdapter implements GeminiPort {
   constructor(

--- a/src/brain/src/shared/infrastructure/supabase/SupabaseClient.ts
+++ b/src/brain/src/shared/infrastructure/supabase/SupabaseClient.ts
@@ -1,4 +1,4 @@
-import { Provider } from '@nestjs/common'
+import type { Provider } from '@nestjs/common'
 import { PostgrestClient } from '@supabase/postgrest-js'
 import { env } from '@/shared/infrastructure/env'
 import type { Database } from './database.types'

--- a/src/front/core/users/infrastructure/repositories/InMemoryUserRepository.ts
+++ b/src/front/core/users/infrastructure/repositories/InMemoryUserRepository.ts
@@ -1,4 +1,4 @@
-import { User } from '@/core/users/domain/entities/User'
+import type { User } from '@/core/users/domain/entities/User'
 import type { UserRepository } from '@/core/users/domain/repositories/UserRepository'
 
 /**

--- a/src/front/eslint.config.mjs
+++ b/src/front/eslint.config.mjs
@@ -25,6 +25,22 @@ const eslintConfig = defineConfig([
   {
     rules: {
       'no-console': 'error',
+      // Force `import type` for type-only symbols. Aligns with brain workspace
+      // (which needs it for Bun-run scripts) and prepares the front for any
+      // future strict-mode bundlers.
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+      ],
+      // Honour the `_`-prefix convention for intentionally unused symbols.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   // Override default ignores of eslint-config-next.


### PR DESCRIPTION
## Summary
- Phase 2 del [plan del brain clustering engine](docs/2026-04-25-brain-clustering-engine-implementation.md). 3 SDD tasks + 1 seed adelantado de Phase 7 + 1 hardening de lint + 1 fix de test flake.
- Nuevo bounded context `ciiu-taxonomy` (hexagonal): entity `CiiuActivity` (4-digit code + sección/división/grupo invariantes en factory), port `CiiuTaxonomyRepository`, `SupabaseCiiuTaxonomyRepository` con upsert chunked (500 rows), `InMemoryCiiuTaxonomyRepository` para tests, use case `FindCiiuByCode`, módulo wireado en `AppModule`.
- Seed `bun --filter brain seed:ciiu` carga `docs/hackathon/DATA/CIIU_DIAN.csv` → Supabase y verifica round-trip leyendo `code='4711'` post-insert. **502 actividades insertadas, 1 fila skippeada** (segundo header del CSV).
- Hardening de lint global (workspaces front + brain): `@typescript-eslint/consistent-type-imports` (auto-fix split de value vs type imports — cierra el gotcha de Bun ESM strict) + `no-unused-vars` con `^_` ignore pattern.
- `GeminiAdapter.test.ts` reescrito con `vi.mock` + `vi.hoisted` — antes pegaba al API real y se rompía con quota 429 (free tier 20/día). Ahora 9 tests mockeados, cero dependencia de network.

## Test plan
- [x] `bun --filter brain test:run` → **48/48 verde** (eran 17 en Phase 1; Phase 2 suma 24 de ciiu-taxonomy + 7 de Gemini mockeado)
- [x] `bun --filter front test:run` → 80/80 verde (sin regresiones)
- [x] `bun --filter brain typecheck` → clean
- [x] `bun --filter brain lint` y `bun --filter front lint` → clean
- [x] Pre-push hook (test suite completo) pasa sin `--no-verify`
- [x] Smoke boot: `bun --filter brain start:dev` → `CiiuTaxonomyModule dependencies initialized`, `GET /api/health` → `{"status":"ok"}` en `:3000`
- [x] Seed end-to-end: `bun --filter brain seed:ciiu` → `✅ Seeded 502 CIIU activities (skipped 1 non-numeric rows)` + `🔎 Round-trip OK — 4711 → "Comercio al por menor en establecimientos no especializados..."`

## Notas para el reviewer

**Decisión: adelantamos Task 7.1 (seed) dentro de Phase 2.** El plan original lo agrupa todo en Phase 7 ("Seeds"). Lo movimos acá para validar el adapter contra Supabase real (no sólo mocks) y dejar el contexto CIIU realmente operativo para Phases 3-5 que lo van a leer. Trade-off explícito: rompe la estructura "Phase N = código, Phase 7 = seeds" del plan, pero el commit está separado.

**Gotcha del CSV**: `CIIU_DIAN.csv` ships con doble header. Fila 1 es el real, fila 2 es pseudo-header (`Clase,,,Grupo,Descripción,...`) que `CiiuActivity.create()` rechaza. El seed filtra defensivamente con `^\d{4}$` antes de mapear. Total real: **502 actividades** (no 700+ como decía el plan).

**Decisión técnica sobre `verbatimModuleSyntax: true`**: lo intenté en `tsconfig.base.json` para hacer el check de tipos a nivel compiler. Lo descarté: incompatible con `module: commonjs` que Nest requiere (19 errores TS1287/1295), y revela typings rotos pre-existentes en `@supabase/realtime-js` del front. La regla ESLint `consistent-type-imports` ya cubre el 90% del valor (corre en lint-staged pre-commit). Migrar brain a `module: nodenext` queda como follow-up si lo necesitamos.

**Subjects de commits van lowercase** (commitlint rule `subject-case: lowercase`). El plan los tenía con `DIAN` capitalizado; bajamos a "dian" para pasar el hook.

**Side win del fix de Gemini**: la suite del brain bajó de ~3.4s a ~400ms al sacar las llamadas al API real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)