### PR TITLE
feat(brain): phase 3 companies context

### DIFF
--- a/src/brain/__tests__/companies/CompaniesController.test.ts
+++ b/src/brain/__tests__/companies/CompaniesController.test.ts
@@ -1,0 +1,88 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { CompaniesController } from '@/companies/infrastructure/http/companies.controller'
+import { FindCompanyById } from '@/companies/application/use-cases/FindCompanyById'
+import { GetCompanies } from '@/companies/application/use-cases/GetCompanies'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+function makeCompany(
+  id: string,
+  overrides: Partial<{ municipio: string }> = {},
+) {
+  return Company.create({
+    id,
+    razonSocial: `RS-${id}`,
+    ciiu: 'G4711',
+    municipio: overrides.municipio ?? 'BOGOTA',
+    personal: 5,
+    ingresoOperacion: 100_000_000,
+    fechaMatricula: new Date('2022-01-01'),
+  })
+}
+
+describe('CompaniesController', () => {
+  let repo: InMemoryCompanyRepository
+  let controller: CompaniesController
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+    const getCompanies = new GetCompanies(repo)
+    const findCompanyById = new FindCompanyById(repo)
+    controller = new CompaniesController(getCompanies, findCompanyById)
+  })
+
+  describe('GET /companies (list)', () => {
+    it('returns DTOs for all companies up to default limit of 50', async () => {
+      await repo.saveMany(
+        Array.from({ length: 60 }, (_, i) => makeCompany(`id-${i}`)),
+      )
+      const result = await controller.list()
+      expect(result).toHaveLength(50)
+      expect(result[0]).toHaveProperty('id')
+      expect(result[0]).toHaveProperty('razonSocial')
+      expect(result[0]).toHaveProperty('ciiu')
+      expect(result[0]).toHaveProperty('etapa')
+    })
+
+    it('honours custom limit query parameter', async () => {
+      await repo.saveMany([
+        makeCompany('1'),
+        makeCompany('2'),
+        makeCompany('3'),
+      ])
+      const result = await controller.list('2')
+      expect(result).toHaveLength(2)
+    })
+
+    it('returns the DTO shape with no internal entity leakage', async () => {
+      await repo.saveMany([makeCompany('only')])
+      const result = await controller.list()
+      expect(result[0]).toEqual({
+        id: 'only',
+        razonSocial: 'RS-only',
+        ciiu: '4711',
+        ciiuSeccion: 'G',
+        ciiuDivision: '47',
+        municipio: 'BOGOTA',
+        etapa: 'crecimiento',
+        personal: 5,
+        ingreso: 100_000_000,
+      })
+    })
+  })
+
+  describe('GET /companies/:id', () => {
+    it('returns the DTO when the company exists', async () => {
+      await repo.saveMany([makeCompany('42')])
+      const result = await controller.detail('42')
+      expect(result.id).toBe('42')
+    })
+
+    it('throws NotFoundException when the company is missing', async () => {
+      await expect(controller.detail('missing')).rejects.toThrow(
+        NotFoundException,
+      )
+    })
+  })
+})

--- a/src/brain/__tests__/companies/Company.test.ts
+++ b/src/brain/__tests__/companies/Company.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+
+describe('Company', () => {
+  const validInput = {
+    id: '0123456-7',
+    razonSocial: 'EMPRESA TEST S.A.S',
+    ciiu: 'G4711',
+    municipio: 'SANTA MARTA',
+    tipoOrganizacion: 'SOCIEDAD',
+    personal: 5,
+    ingresoOperacion: 100_000_000,
+    activosTotales: 200_000_000,
+    email: 'test@example.com',
+    telefono: '3001234567',
+    direccion: 'Calle 1',
+    fechaMatricula: new Date('2022-01-01'),
+    fechaRenovacion: new Date('2026-01-01'),
+    estado: 'ACTIVO',
+  }
+
+  it('creates with valid data and derives ciiuSeccion + ciiuDivision + ciiuGrupo', () => {
+    const c = Company.create(validInput)
+    expect(c.id).toBe('0123456-7')
+    expect(c.ciiu).toBe('4711')
+    expect(c.ciiuSeccion).toBe('G')
+    expect(c.ciiuDivision).toBe('47')
+    expect(c.ciiuGrupo).toBe('471')
+  })
+
+  it('strips section letter when ciiu comes as G4711', () => {
+    const c = Company.create({ ...validInput, ciiu: 'G4711' })
+    expect(c.ciiu).toBe('4711')
+    expect(c.ciiuSeccion).toBe('G')
+  })
+
+  it('throws when razonSocial is empty', () => {
+    expect(() => Company.create({ ...validInput, razonSocial: '' })).toThrow()
+  })
+
+  it('throws when razonSocial is whitespace only', () => {
+    expect(() =>
+      Company.create({ ...validInput, razonSocial: '   ' }),
+    ).toThrow()
+  })
+
+  it('throws when id is empty', () => {
+    expect(() => Company.create({ ...validInput, id: '' })).toThrow()
+  })
+
+  it('throws when ciiu is just 4 digits without section letter', () => {
+    expect(() => Company.create({ ...validInput, ciiu: '4711' })).toThrow()
+  })
+
+  it('throws when ciiu has invalid format', () => {
+    expect(() => Company.create({ ...validInput, ciiu: 'XX' })).toThrow()
+  })
+
+  it('derives etapa via EtapaCalculator (nacimiento for young + small)', () => {
+    const c = Company.create({
+      ...validInput,
+      fechaMatricula: new Date('2025-06-01'),
+      personal: 1,
+      ingresoOperacion: 0,
+    })
+    expect(c.etapa).toBe('nacimiento')
+  })
+
+  it('defaults estado to ACTIVO when not provided', () => {
+    const c = Company.create({
+      id: 'X-1',
+      razonSocial: 'X',
+      ciiu: 'A0111',
+      municipio: 'BOGOTA',
+    })
+    expect(c.estado).toBe('ACTIVO')
+  })
+
+  it('defaults numeric fields to 0 when null/undefined', () => {
+    const c = Company.create({
+      id: 'X-1',
+      razonSocial: 'X',
+      ciiu: 'A0111',
+      municipio: 'BOGOTA',
+    })
+    expect(c.personal).toBe(0)
+    expect(c.ingresoOperacion).toBe(0)
+    expect(c.activosTotales).toBe(0)
+  })
+
+  it('trims razonSocial and id', () => {
+    const c = Company.create({
+      ...validInput,
+      id: '  X-1  ',
+      razonSocial: '  ACME  ',
+    })
+    expect(c.id).toBe('X-1')
+    expect(c.razonSocial).toBe('ACME')
+  })
+
+  it('exposes all main fields via getters', () => {
+    const c = Company.create(validInput)
+    expect(c.municipio).toBe('SANTA MARTA')
+    expect(c.tipoOrganizacion).toBe('SOCIEDAD')
+    expect(c.personal).toBe(5)
+    expect(c.ingresoOperacion).toBe(100_000_000)
+    expect(c.activosTotales).toBe(200_000_000)
+    expect(c.email).toBe('test@example.com')
+    expect(c.telefono).toBe('3001234567')
+    expect(c.direccion).toBe('Calle 1')
+    expect(c.fechaMatricula).toEqual(new Date('2022-01-01'))
+    expect(c.fechaRenovacion).toEqual(new Date('2026-01-01'))
+    expect(c.estado).toBe('ACTIVO')
+  })
+})

--- a/src/brain/__tests__/companies/CsvCompanySource.test.ts
+++ b/src/brain/__tests__/companies/CsvCompanySource.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { CsvCompanySource } from '@/companies/infrastructure/sources/CsvCompanySource'
+import { CsvLoader } from '@/shared/infrastructure/csv/CsvLoader'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CsvCompanySource', () => {
+  describe('against the real REGISTRADOS_SII.csv', () => {
+    it('reads the file and returns Company entities', async () => {
+      const source = new CsvCompanySource()
+      const companies = await source.fetchAll()
+      expect(companies.length).toBeGreaterThan(9000)
+      expect(companies[0]).toBeInstanceOf(Company)
+      expect(companies[0].ciiuDivision).toMatch(/^\d{2}$/)
+      expect(companies[0].ciiuSeccion).toMatch(/^[A-Z]$/)
+    })
+
+    it('fetchUpdatedSince filters by fechaRenovacion', async () => {
+      const source = new CsvCompanySource()
+      const all = await source.fetchAll()
+      const recent = await source.fetchUpdatedSince(new Date('2024-01-01'))
+      expect(recent.length).toBeLessThanOrEqual(all.length)
+      for (const c of recent) {
+        expect(c.fechaRenovacion).not.toBeNull()
+        expect(c.fechaRenovacion!.getTime()).toBeGreaterThan(
+          new Date('2024-01-01').getTime(),
+        )
+      }
+    })
+  })
+
+  describe('row mapping', () => {
+    it('skips rows whose CIIU does not match the X9999 pattern', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        // valid row
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'OK',
+          municipioTitulo: 'BOGOTA',
+        },
+        // invalid CIIU (no section letter)
+        {
+          registradosCIIU1_CODIGOSII: '4711',
+          registradoMATRICULA: '2',
+          registradoRAZONSOCIAL: 'BAD',
+          municipioTitulo: 'BOGOTA',
+        },
+        // empty CIIU
+        {
+          registradosCIIU1_CODIGOSII: '',
+          registradoMATRICULA: '3',
+          registradoRAZONSOCIAL: 'BAD2',
+          municipioTitulo: 'BOGOTA',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const companies = await source.fetchAll()
+      expect(companies).toHaveLength(1)
+      expect(companies[0].id).toBe('1')
+    })
+
+    it('parses YYYYMMDD date strings into Date objects', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'X',
+          municipioTitulo: 'BOGOTA',
+          regitradoFECMATRICULA: '19920825',
+          regitradoFECHREN: '20260101',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const [c] = await source.fetchAll()
+      expect(c.fechaMatricula).toEqual(new Date(Date.UTC(1992, 7, 25)))
+      expect(c.fechaRenovacion).toEqual(new Date(Date.UTC(2026, 0, 1)))
+    })
+
+    it('treats empty or malformed date strings as null', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'X',
+          municipioTitulo: 'BOGOTA',
+          regitradoFECMATRICULA: '',
+          regitradoFECHREN: 'garbage',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const [c] = await source.fetchAll()
+      expect(c.fechaMatricula).toBeNull()
+      expect(c.fechaRenovacion).toBeNull()
+    })
+
+    it('treats empty numeric strings as 0', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'X',
+          municipioTitulo: 'BOGOTA',
+          regitradoPERSONAL: '',
+          registradoINGRESOPERACION: '',
+          registradoACTIVOSTOTALES: '',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const [c] = await source.fetchAll()
+      expect(c.personal).toBe(0)
+      expect(c.ingresoOperacion).toBe(0)
+      expect(c.activosTotales).toBe(0)
+    })
+
+    it('maps optional contact fields, leaving null for empty values', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'X',
+          municipioTitulo: 'BOGOTA',
+          regitradoEMAIL: 'x@y.com',
+          regitradoTELEFONO1: '300',
+          regitradoDIRECCION: '',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const [c] = await source.fetchAll()
+      expect(c.email).toBe('x@y.com')
+      expect(c.telefono).toBe('300')
+      expect(c.direccion).toBeNull()
+    })
+
+    it('uses tipoOrganizacionTITULO and registroEstadoTITULO for human-readable fields', async () => {
+      vi.spyOn(CsvLoader, 'load').mockResolvedValueOnce([
+        {
+          registradosCIIU1_CODIGOSII: 'G4711',
+          registradoMATRICULA: '1',
+          registradoRAZONSOCIAL: 'X',
+          municipioTitulo: 'BOGOTA',
+          tipoOrganizacionTITULO: 'Sociedad Limitada',
+          registroEstadoTITULO: 'Matricula Activa',
+        },
+      ])
+      const source = new CsvCompanySource()
+      const [c] = await source.fetchAll()
+      expect(c.tipoOrganizacion).toBe('Sociedad Limitada')
+      expect(c.estado).toBe('Matricula Activa')
+    })
+  })
+})

--- a/src/brain/__tests__/companies/EtapaCalculator.test.ts
+++ b/src/brain/__tests__/companies/EtapaCalculator.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { EtapaCalculator } from '@/companies/domain/services/EtapaCalculator'
+
+describe('EtapaCalculator', () => {
+  const baseDate = new Date('2026-04-25')
+
+  it('classifies as nacimiento when < 2 years and personal <= 2', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: new Date('2024-06-01'),
+          personal: 1,
+          ingreso: 0,
+        },
+        baseDate,
+      ),
+    ).toBe('nacimiento')
+  })
+
+  it('classifies as crecimiento when 2-7 years and personal 3-50', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: new Date('2022-01-01'),
+          personal: 10,
+          ingreso: 100_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('crecimiento')
+  })
+
+  it('classifies as consolidacion when > 7 years', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: new Date('2015-01-01'),
+          personal: 30,
+          ingreso: 500_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('consolidacion')
+  })
+
+  it('classifies as madurez when personal > 200', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: new Date('2010-01-01'),
+          personal: 250,
+          ingreso: 100_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('madurez')
+  })
+
+  it('classifies as madurez when ingreso > 5000M', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: new Date('2020-01-01'),
+          personal: 50,
+          ingreso: 6_000_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('madurez')
+  })
+
+  it('handles missing fechaMatricula by falling back to personal/ingreso signals', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: null,
+          personal: 1,
+          ingreso: 0,
+        },
+        baseDate,
+      ),
+    ).toBe('nacimiento')
+  })
+
+  it('with no fechaMatricula and personal <= 50 falls back to crecimiento', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: null,
+          personal: 20,
+          ingreso: 200_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('crecimiento')
+  })
+
+  it('with no fechaMatricula and personal > 50 falls back to consolidacion', () => {
+    expect(
+      EtapaCalculator.calculate(
+        {
+          fechaMatricula: null,
+          personal: 100,
+          ingreso: 500_000_000,
+        },
+        baseDate,
+      ),
+    ).toBe('consolidacion')
+  })
+})

--- a/src/brain/__tests__/companies/FindCompanyById.test.ts
+++ b/src/brain/__tests__/companies/FindCompanyById.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { FindCompanyById } from '@/companies/application/use-cases/FindCompanyById'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+describe('FindCompanyById', () => {
+  let repo: InMemoryCompanyRepository
+  let useCase: FindCompanyById
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+    useCase = new FindCompanyById(repo)
+  })
+
+  it('returns the company when it exists', async () => {
+    await repo.saveMany([
+      Company.create({
+        id: '42',
+        razonSocial: 'ACME',
+        ciiu: 'G4711',
+        municipio: 'BOGOTA',
+      }),
+    ])
+    const result = await useCase.execute({ id: '42' })
+    expect(result.company).not.toBeNull()
+    expect(result.company!.id).toBe('42')
+  })
+
+  it('returns null when the company does not exist', async () => {
+    const result = await useCase.execute({ id: 'missing' })
+    expect(result.company).toBeNull()
+  })
+})

--- a/src/brain/__tests__/companies/GetCompanies.test.ts
+++ b/src/brain/__tests__/companies/GetCompanies.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { GetCompanies } from '@/companies/application/use-cases/GetCompanies'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+describe('GetCompanies', () => {
+  let repo: InMemoryCompanyRepository
+  let useCase: GetCompanies
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+    useCase = new GetCompanies(repo)
+  })
+
+  it('returns all companies in the repository', async () => {
+    await repo.saveMany([
+      Company.create({
+        id: '1',
+        razonSocial: 'A',
+        ciiu: 'G4711',
+        municipio: 'BOGOTA',
+      }),
+      Company.create({
+        id: '2',
+        razonSocial: 'B',
+        ciiu: 'G4711',
+        municipio: 'BOGOTA',
+      }),
+    ])
+    const result = await useCase.execute()
+    expect(result.companies).toHaveLength(2)
+  })
+
+  it('returns an empty list when the repository is empty', async () => {
+    const result = await useCase.execute()
+    expect(result.companies).toEqual([])
+  })
+})

--- a/src/brain/__tests__/companies/GetCompaniesUpdatedSince.test.ts
+++ b/src/brain/__tests__/companies/GetCompaniesUpdatedSince.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { GetCompaniesUpdatedSince } from '@/companies/application/use-cases/GetCompaniesUpdatedSince'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+function makeCompany(id: string) {
+  return Company.create({
+    id,
+    razonSocial: 'X',
+    ciiu: 'G4711',
+    municipio: 'BOGOTA',
+  })
+}
+
+describe('GetCompaniesUpdatedSince', () => {
+  let repo: InMemoryCompanyRepository
+  let useCase: GetCompaniesUpdatedSince
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+    useCase = new GetCompaniesUpdatedSince(repo)
+  })
+
+  it('returns only companies whose updatedAt is strictly greater than the cutoff', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    await repo.saveMany([makeCompany('old')])
+
+    vi.setSystemTime(new Date('2026-04-01T00:00:00Z'))
+    await repo.saveMany([makeCompany('recent-1'), makeCompany('recent-2')])
+
+    const result = await useCase.execute({
+      since: new Date('2026-02-01T00:00:00Z'),
+    })
+    expect(result.companies.map((c) => c.id).sort()).toEqual([
+      'recent-1',
+      'recent-2',
+    ])
+    vi.useRealTimers()
+  })
+
+  it('returns empty when nothing has been updated since the cutoff', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    await repo.saveMany([makeCompany('only')])
+    const result = await useCase.execute({
+      since: new Date('2026-04-01T00:00:00Z'),
+    })
+    expect(result.companies).toEqual([])
+    vi.useRealTimers()
+  })
+})

--- a/src/brain/__tests__/companies/InMemoryCompanyRepository.test.ts
+++ b/src/brain/__tests__/companies/InMemoryCompanyRepository.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+function makeCompany(overrides: Partial<Parameters<typeof Company.create>[0]>) {
+  return Company.create({
+    id: 'X-1',
+    razonSocial: 'ACME',
+    ciiu: 'G4711',
+    municipio: 'BOGOTA',
+    ...overrides,
+  })
+}
+
+describe('InMemoryCompanyRepository', () => {
+  let repo: InMemoryCompanyRepository
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+  })
+
+  describe('saveMany + findAll', () => {
+    it('persists companies and exposes them via findAll', async () => {
+      await repo.saveMany([makeCompany({ id: '1' }), makeCompany({ id: '2' })])
+      const all = await repo.findAll()
+      expect(all).toHaveLength(2)
+      expect(all.map((c) => c.id).sort()).toEqual(['1', '2'])
+    })
+
+    it('upserts by id (overwrites existing entries)', async () => {
+      await repo.saveMany([makeCompany({ id: '1', razonSocial: 'OLD' })])
+      await repo.saveMany([makeCompany({ id: '1', razonSocial: 'NEW' })])
+      const all = await repo.findAll()
+      expect(all).toHaveLength(1)
+      expect(all[0].razonSocial).toBe('NEW')
+    })
+
+    it('does nothing when given an empty array', async () => {
+      await repo.saveMany([])
+      expect(await repo.findAll()).toEqual([])
+    })
+  })
+
+  describe('findById', () => {
+    it('returns the company when found', async () => {
+      await repo.saveMany([makeCompany({ id: '42' })])
+      const c = await repo.findById('42')
+      expect(c).not.toBeNull()
+      expect(c!.id).toBe('42')
+    })
+
+    it('returns null when not found', async () => {
+      expect(await repo.findById('missing')).toBeNull()
+    })
+  })
+
+  describe('findByCiiuDivision', () => {
+    it('returns only companies whose ciiuDivision matches', async () => {
+      await repo.saveMany([
+        makeCompany({ id: '1', ciiu: 'G4711' }),
+        makeCompany({ id: '2', ciiu: 'G4790' }),
+        makeCompany({ id: '3', ciiu: 'C1011' }),
+      ])
+      const result = await repo.findByCiiuDivision('47')
+      expect(result.map((c) => c.id).sort()).toEqual(['1', '2'])
+    })
+  })
+
+  describe('findByMunicipio', () => {
+    it('returns only companies in the given municipio', async () => {
+      await repo.saveMany([
+        makeCompany({ id: '1', municipio: 'BOGOTA' }),
+        makeCompany({ id: '2', municipio: 'MEDELLIN' }),
+        makeCompany({ id: '3', municipio: 'BOGOTA' }),
+      ])
+      const result = await repo.findByMunicipio('BOGOTA')
+      expect(result.map((c) => c.id).sort()).toEqual(['1', '3'])
+    })
+  })
+
+  describe('findUpdatedSince', () => {
+    it('returns only companies whose updatedAt is strictly greater than the cutoff', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+      await repo.saveMany([makeCompany({ id: 'old' })])
+
+      vi.setSystemTime(new Date('2026-04-01T00:00:00Z'))
+      await repo.saveMany([makeCompany({ id: 'recent' })])
+
+      const result = await repo.findUpdatedSince(
+        new Date('2026-02-01T00:00:00Z'),
+      )
+      expect(result.map((c) => c.id)).toEqual(['recent'])
+      vi.useRealTimers()
+    })
+
+    it('updates the timestamp when a company is re-saved', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+      await repo.saveMany([makeCompany({ id: '1' })])
+
+      vi.setSystemTime(new Date('2026-04-01T00:00:00Z'))
+      await repo.saveMany([makeCompany({ id: '1', razonSocial: 'NEW' })])
+
+      const result = await repo.findUpdatedSince(
+        new Date('2026-02-01T00:00:00Z'),
+      )
+      expect(result.map((c) => c.id)).toEqual(['1'])
+      vi.useRealTimers()
+    })
+  })
+
+  describe('count', () => {
+    it('returns the number of stored companies', async () => {
+      expect(await repo.count()).toBe(0)
+      await repo.saveMany([makeCompany({ id: '1' }), makeCompany({ id: '2' })])
+      expect(await repo.count()).toBe(2)
+    })
+  })
+})

--- a/src/brain/__tests__/companies/SupabaseCompanyRepository.test.ts
+++ b/src/brain/__tests__/companies/SupabaseCompanyRepository.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import { SupabaseCompanyRepository } from '@/companies/infrastructure/repositories/SupabaseCompanyRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    gt: vi.fn(),
+    maybeSingle: vi.fn(),
+    upsert: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of ['from', 'select', 'eq', 'in', 'gt', 'upsert'] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  id: '0123456-7',
+  razon_social: 'EMPRESA TEST S.A.S',
+  ciiu: '4711',
+  ciiu_seccion: 'G',
+  ciiu_division: '47',
+  ciiu_grupo: '471',
+  municipio: 'SANTA MARTA',
+  tipo_organizacion: 'SOCIEDAD',
+  personal: 5,
+  ingreso_operacion: 100_000_000,
+  activos_totales: 200_000_000,
+  email: 'test@example.com',
+  telefono: '3001234567',
+  direccion: 'Calle 1',
+  fecha_matricula: '2022-01-01',
+  fecha_renovacion: '2026-01-01',
+  estado: 'ACTIVO',
+  etapa: 'crecimiento',
+}
+
+describe('SupabaseCompanyRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseCompanyRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseCompanyRepository(fake.db)
+  })
+
+  describe('findAll', () => {
+    it('returns Company entities mapped from rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findAll()
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBeInstanceOf(Company)
+      expect(result[0].id).toBe('0123456-7')
+      expect(fake.spies.from).toHaveBeenCalledWith('companies')
+    })
+
+    it('returns empty array when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findAll()).toEqual([])
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findAll()).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('findById', () => {
+    it('returns a Company when row exists', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const c = await repo.findById('0123456-7')
+      expect(c).not.toBeNull()
+      expect(c!.id).toBe('0123456-7')
+      expect(fake.spies.eq).toHaveBeenCalledWith('id', '0123456-7')
+      expect(fake.spies.maybeSingle).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns null when no row', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findById('missing')).toBeNull()
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('db down') })
+      await expect(repo.findById('x')).rejects.toThrow(/db down/)
+    })
+  })
+
+  describe('findByCiiuDivision', () => {
+    it('queries by ciiu_division and maps rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findByCiiuDivision('47')
+      expect(result).toHaveLength(1)
+      expect(fake.spies.eq).toHaveBeenCalledWith('ciiu_division', '47')
+    })
+  })
+
+  describe('findByMunicipio', () => {
+    it('queries by municipio and maps rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findByMunicipio('SANTA MARTA')
+      expect(result).toHaveLength(1)
+      expect(fake.spies.eq).toHaveBeenCalledWith('municipio', 'SANTA MARTA')
+    })
+  })
+
+  describe('findUpdatedSince', () => {
+    it('queries by updated_at > since (ISO string)', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const since = new Date('2026-01-01T00:00:00Z')
+      await repo.findUpdatedSince(since)
+      expect(fake.spies.gt).toHaveBeenCalledWith(
+        'updated_at',
+        since.toISOString(),
+      )
+    })
+  })
+
+  describe('count', () => {
+    it('returns the count from the head request', async () => {
+      fake.setNext({ data: null, error: null, count: 42 })
+      const total = await repo.count()
+      expect(total).toBe(42)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.count()).toBe(0)
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('count failed') })
+      await expect(repo.count()).rejects.toThrow(/count failed/)
+    })
+  })
+
+  describe('saveMany', () => {
+    it('upserts mapped rows with onConflict on id', async () => {
+      fake.setNext({ data: null, error: null })
+      const c = Company.create({
+        id: '0123456-7',
+        razonSocial: 'EMPRESA TEST S.A.S',
+        ciiu: 'G4711',
+        municipio: 'SANTA MARTA',
+        tipoOrganizacion: 'SOCIEDAD',
+        personal: 5,
+        ingresoOperacion: 100_000_000,
+        activosTotales: 200_000_000,
+        email: 'test@example.com',
+        telefono: '3001234567',
+        direccion: 'Calle 1',
+        fechaMatricula: new Date('2022-01-01'),
+        fechaRenovacion: new Date('2026-01-01'),
+        estado: 'ACTIVO',
+      })
+      await repo.saveMany([c])
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(1)
+      const [rows, opts] = fake.spies.upsert.mock.calls[0]
+      expect(rows).toHaveLength(1)
+      expect(rows[0].id).toBe('0123456-7')
+      expect(rows[0].razon_social).toBe('EMPRESA TEST S.A.S')
+      expect(rows[0].ciiu).toBe('4711')
+      expect(rows[0].ciiu_seccion).toBe('G')
+      expect(rows[0].ciiu_division).toBe('47')
+      expect(rows[0].ciiu_grupo).toBe('471')
+      expect(rows[0].fecha_matricula).toBe('2022-01-01')
+      expect(rows[0].fecha_renovacion).toBe('2026-01-01')
+      expect(rows[0].etapa).toBe('crecimiento')
+      expect(opts).toEqual({ onConflict: 'id' })
+    })
+
+    it('chunks payloads of more than 500 rows', async () => {
+      fake.setNext({ data: null, error: null })
+      const companies = Array.from({ length: 1100 }, (_, i) =>
+        Company.create({
+          id: `id-${i}`,
+          razonSocial: 'X',
+          ciiu: 'A0111',
+          municipio: 'BOGOTA',
+        }),
+      )
+      await repo.saveMany(companies)
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(3)
+      expect(fake.spies.upsert.mock.calls[0][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[1][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[2][0]).toHaveLength(100)
+    })
+
+    it('does nothing for empty array', async () => {
+      await repo.saveMany([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on supabase error mid-chunk', async () => {
+      fake.setNext({ data: null, error: new Error('insert failed') })
+      const c = Company.create({
+        id: '1',
+        razonSocial: 'X',
+        ciiu: 'A0111',
+        municipio: 'BOGOTA',
+      })
+      await expect(repo.saveMany([c])).rejects.toThrow(/insert failed/)
+    })
+
+    it('serialises null date fields as null', async () => {
+      fake.setNext({ data: null, error: null })
+      const c = Company.create({
+        id: '1',
+        razonSocial: 'X',
+        ciiu: 'A0111',
+        municipio: 'BOGOTA',
+      })
+      await repo.saveMany([c])
+      const [rows] = fake.spies.upsert.mock.calls[0]
+      expect(rows[0].fecha_matricula).toBeNull()
+      expect(rows[0].fecha_renovacion).toBeNull()
+    })
+  })
+
+  describe('row mapping', () => {
+    it('parses date strings from rows into Date objects', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const c = await repo.findById('0123456-7')
+      expect(c!.fechaMatricula).toEqual(new Date('2022-01-01'))
+      expect(c!.fechaRenovacion).toEqual(new Date('2026-01-01'))
+    })
+
+    it('maps null date columns to null', async () => {
+      fake.setNext({
+        data: { ...validRow, fecha_matricula: null, fecha_renovacion: null },
+        error: null,
+      })
+      const c = await repo.findById('x')
+      expect(c!.fechaMatricula).toBeNull()
+      expect(c!.fechaRenovacion).toBeNull()
+    })
+  })
+})

--- a/src/brain/__tests__/companies/SyncCompaniesFromSource.test.ts
+++ b/src/brain/__tests__/companies/SyncCompaniesFromSource.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Company } from '@/companies/domain/entities/Company'
+import type { CompanySource } from '@/companies/domain/sources/CompanySource'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { SyncCompaniesFromSource } from '@/companies/application/use-cases/SyncCompaniesFromSource'
+
+function makeCompany(id: string) {
+  return Company.create({
+    id,
+    razonSocial: `RS-${id}`,
+    ciiu: 'G4711',
+    municipio: 'BOGOTA',
+  })
+}
+
+class StaticCompanySource implements CompanySource {
+  constructor(
+    private readonly all: Company[],
+    private readonly recent: Company[] = all,
+  ) {}
+
+  async fetchAll(): Promise<Company[]> {
+    return this.all
+  }
+
+  async fetchUpdatedSince(_since: Date): Promise<Company[]> {
+    return this.recent
+  }
+}
+
+describe('SyncCompaniesFromSource', () => {
+  let repo: InMemoryCompanyRepository
+
+  beforeEach(() => {
+    repo = new InMemoryCompanyRepository()
+  })
+
+  it('fetches all companies from the source and persists them via the repository', async () => {
+    const source = new StaticCompanySource([makeCompany('1'), makeCompany('2')])
+    const useCase = new SyncCompaniesFromSource(source, repo)
+
+    const result = await useCase.execute()
+
+    expect(result.synced).toBe(2)
+    expect(await repo.count()).toBe(2)
+  })
+
+  it('with `since` filter, syncs only companies the source returns from fetchUpdatedSince', async () => {
+    const source = new StaticCompanySource(
+      [makeCompany('old'), makeCompany('recent')],
+      [makeCompany('recent')],
+    )
+    const useCase = new SyncCompaniesFromSource(source, repo)
+
+    const result = await useCase.execute({
+      since: new Date('2026-01-01T00:00:00Z'),
+    })
+
+    expect(result.synced).toBe(1)
+    expect(await repo.count()).toBe(1)
+    expect((await repo.findById('recent'))?.id).toBe('recent')
+    expect(await repo.findById('old')).toBeNull()
+  })
+
+  it('returns 0 and writes nothing when the source returns empty', async () => {
+    const source = new StaticCompanySource([])
+    const useCase = new SyncCompaniesFromSource(source, repo)
+
+    const result = await useCase.execute()
+
+    expect(result.synced).toBe(0)
+    expect(await repo.count()).toBe(0)
+  })
+})

--- a/src/brain/src/app.module.ts
+++ b/src/brain/src/app.module.ts
@@ -2,10 +2,16 @@ import { Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { SharedModule } from './shared/shared.module'
 import { CiiuTaxonomyModule } from './ciiu-taxonomy/ciiu-taxonomy.module'
+import { CompaniesModule } from './companies/companies.module'
 import { HealthController } from './shared/infrastructure/health/health.controller'
 
 @Module({
-  imports: [ScheduleModule.forRoot(), SharedModule, CiiuTaxonomyModule],
+  imports: [
+    ScheduleModule.forRoot(),
+    SharedModule,
+    CiiuTaxonomyModule,
+    CompaniesModule,
+  ],
   controllers: [HealthController],
 })
 export class AppModule {}

--- a/src/brain/src/companies/application/use-cases/FindCompanyById.ts
+++ b/src/brain/src/companies/application/use-cases/FindCompanyById.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+interface FindCompanyByIdInput {
+  id: string
+}
+
+interface FindCompanyByIdOutput {
+  company: Company | null
+}
+
+@Injectable()
+export class FindCompanyById implements UseCase<
+  FindCompanyByIdInput,
+  FindCompanyByIdOutput
+> {
+  constructor(
+    @Inject(COMPANY_REPOSITORY) private readonly repo: CompanyRepository,
+  ) {}
+
+  async execute(input: FindCompanyByIdInput): Promise<FindCompanyByIdOutput> {
+    return { company: await this.repo.findById(input.id) }
+  }
+}

--- a/src/brain/src/companies/application/use-cases/GetCompanies.ts
+++ b/src/brain/src/companies/application/use-cases/GetCompanies.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+interface GetCompaniesOutput {
+  companies: Company[]
+}
+
+@Injectable()
+export class GetCompanies implements UseCase<void, GetCompaniesOutput> {
+  constructor(
+    @Inject(COMPANY_REPOSITORY) private readonly repo: CompanyRepository,
+  ) {}
+
+  async execute(): Promise<GetCompaniesOutput> {
+    return { companies: await this.repo.findAll() }
+  }
+}

--- a/src/brain/src/companies/application/use-cases/GetCompaniesUpdatedSince.ts
+++ b/src/brain/src/companies/application/use-cases/GetCompaniesUpdatedSince.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+interface GetCompaniesUpdatedSinceInput {
+  since: Date
+}
+
+interface GetCompaniesUpdatedSinceOutput {
+  companies: Company[]
+}
+
+@Injectable()
+export class GetCompaniesUpdatedSince implements UseCase<
+  GetCompaniesUpdatedSinceInput,
+  GetCompaniesUpdatedSinceOutput
+> {
+  constructor(
+    @Inject(COMPANY_REPOSITORY) private readonly repo: CompanyRepository,
+  ) {}
+
+  async execute(
+    input: GetCompaniesUpdatedSinceInput,
+  ): Promise<GetCompaniesUpdatedSinceOutput> {
+    return { companies: await this.repo.findUpdatedSince(input.since) }
+  }
+}

--- a/src/brain/src/companies/application/use-cases/SyncCompaniesFromSource.ts
+++ b/src/brain/src/companies/application/use-cases/SyncCompaniesFromSource.ts
@@ -1,0 +1,36 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { CompanySource } from '@/companies/domain/sources/CompanySource'
+import { COMPANY_SOURCE } from '@/companies/domain/sources/CompanySource'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+interface SyncCompaniesFromSourceInput {
+  since?: Date
+}
+
+interface SyncCompaniesFromSourceOutput {
+  synced: number
+}
+
+@Injectable()
+export class SyncCompaniesFromSource implements UseCase<
+  SyncCompaniesFromSourceInput,
+  SyncCompaniesFromSourceOutput
+> {
+  constructor(
+    @Inject(COMPANY_SOURCE) private readonly source: CompanySource,
+    @Inject(COMPANY_REPOSITORY) private readonly repo: CompanyRepository,
+  ) {}
+
+  async execute(
+    input: SyncCompaniesFromSourceInput = {},
+  ): Promise<SyncCompaniesFromSourceOutput> {
+    const companies = input.since
+      ? await this.source.fetchUpdatedSince(input.since)
+      : await this.source.fetchAll()
+
+    await this.repo.saveMany(companies)
+    return { synced: companies.length }
+  }
+}

--- a/src/brain/src/companies/companies.module.ts
+++ b/src/brain/src/companies/companies.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common'
 import { FindCompanyById } from './application/use-cases/FindCompanyById'
 import { GetCompanies } from './application/use-cases/GetCompanies'
 import { GetCompaniesUpdatedSince } from './application/use-cases/GetCompaniesUpdatedSince'
+import { SyncCompaniesFromSource } from './application/use-cases/SyncCompaniesFromSource'
 import { COMPANY_REPOSITORY } from './domain/repositories/CompanyRepository'
+import { COMPANY_SOURCE } from './domain/sources/CompanySource'
 import { CompaniesController } from './infrastructure/http/companies.controller'
 import { SupabaseCompanyRepository } from './infrastructure/repositories/SupabaseCompanyRepository'
+import { CsvCompanySource } from './infrastructure/sources/CsvCompanySource'
 
 @Module({
   controllers: [CompaniesController],
@@ -13,15 +16,23 @@ import { SupabaseCompanyRepository } from './infrastructure/repositories/Supabas
       provide: COMPANY_REPOSITORY,
       useClass: SupabaseCompanyRepository,
     },
+    {
+      // Swap to BigQueryCompanySource when the hackathon credentials arrive.
+      provide: COMPANY_SOURCE,
+      useClass: CsvCompanySource,
+    },
     GetCompanies,
     FindCompanyById,
     GetCompaniesUpdatedSince,
+    SyncCompaniesFromSource,
   ],
   exports: [
     COMPANY_REPOSITORY,
+    COMPANY_SOURCE,
     GetCompanies,
     FindCompanyById,
     GetCompaniesUpdatedSince,
+    SyncCompaniesFromSource,
   ],
 })
 export class CompaniesModule {}

--- a/src/brain/src/companies/companies.module.ts
+++ b/src/brain/src/companies/companies.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common'
+import { FindCompanyById } from './application/use-cases/FindCompanyById'
+import { GetCompanies } from './application/use-cases/GetCompanies'
+import { GetCompaniesUpdatedSince } from './application/use-cases/GetCompaniesUpdatedSince'
+import { COMPANY_REPOSITORY } from './domain/repositories/CompanyRepository'
+import { CompaniesController } from './infrastructure/http/companies.controller'
+import { SupabaseCompanyRepository } from './infrastructure/repositories/SupabaseCompanyRepository'
+
+@Module({
+  controllers: [CompaniesController],
+  providers: [
+    {
+      provide: COMPANY_REPOSITORY,
+      useClass: SupabaseCompanyRepository,
+    },
+    GetCompanies,
+    FindCompanyById,
+    GetCompaniesUpdatedSince,
+  ],
+  exports: [
+    COMPANY_REPOSITORY,
+    GetCompanies,
+    FindCompanyById,
+    GetCompaniesUpdatedSince,
+  ],
+})
+export class CompaniesModule {}

--- a/src/brain/src/companies/domain/entities/Company.ts
+++ b/src/brain/src/companies/domain/entities/Company.ts
@@ -1,0 +1,156 @@
+import { Entity } from '@/shared/domain/Entity'
+import { EtapaCalculator } from '@/companies/domain/services/EtapaCalculator'
+import type { Etapa } from '@/companies/domain/value-objects/Etapa'
+
+interface CompanyProps {
+  razonSocial: string
+  ciiu: string
+  ciiuSeccion: string
+  ciiuDivision: string
+  ciiuGrupo: string
+  municipio: string
+  tipoOrganizacion: string | null
+  personal: number
+  ingresoOperacion: number
+  activosTotales: number
+  email: string | null
+  telefono: string | null
+  direccion: string | null
+  fechaMatricula: Date | null
+  fechaRenovacion: Date | null
+  estado: string
+  etapa: Etapa
+}
+
+export interface CreateCompanyInput {
+  id: string
+  razonSocial: string
+  ciiu: string
+  municipio: string
+  tipoOrganizacion?: string | null
+  personal?: number | null
+  ingresoOperacion?: number | null
+  activosTotales?: number | null
+  email?: string | null
+  telefono?: string | null
+  direccion?: string | null
+  fechaMatricula?: Date | null
+  fechaRenovacion?: Date | null
+  estado?: string
+}
+
+export class Company extends Entity<string> {
+  private readonly props: CompanyProps
+
+  private constructor(id: string, props: CompanyProps) {
+    super(id)
+    this.props = Object.freeze(props)
+  }
+
+  static create(data: CreateCompanyInput): Company {
+    if (!data.id || data.id.trim().length === 0) {
+      throw new Error('Company.id cannot be empty')
+    }
+    if (!data.razonSocial || data.razonSocial.trim().length === 0) {
+      throw new Error('Company.razonSocial cannot be empty')
+    }
+
+    const { code, seccion } = parseCiiu(data.ciiu)
+    const division = code.slice(0, 2)
+    const grupo = code.slice(0, 3)
+
+    const personal = data.personal ?? 0
+    const ingreso = data.ingresoOperacion ?? 0
+    const fechaMatricula = data.fechaMatricula ?? null
+
+    const etapa = EtapaCalculator.calculate({
+      fechaMatricula,
+      personal,
+      ingreso,
+    })
+
+    return new Company(data.id.trim(), {
+      razonSocial: data.razonSocial.trim(),
+      ciiu: code,
+      ciiuSeccion: seccion,
+      ciiuDivision: division,
+      ciiuGrupo: grupo,
+      municipio: data.municipio,
+      tipoOrganizacion: data.tipoOrganizacion ?? null,
+      personal,
+      ingresoOperacion: ingreso,
+      activosTotales: data.activosTotales ?? 0,
+      email: data.email ?? null,
+      telefono: data.telefono ?? null,
+      direccion: data.direccion ?? null,
+      fechaMatricula,
+      fechaRenovacion: data.fechaRenovacion ?? null,
+      estado: data.estado ?? 'ACTIVO',
+      etapa,
+    })
+  }
+
+  get razonSocial(): string {
+    return this.props.razonSocial
+  }
+  get ciiu(): string {
+    return this.props.ciiu
+  }
+  get ciiuSeccion(): string {
+    return this.props.ciiuSeccion
+  }
+  get ciiuDivision(): string {
+    return this.props.ciiuDivision
+  }
+  get ciiuGrupo(): string {
+    return this.props.ciiuGrupo
+  }
+  get municipio(): string {
+    return this.props.municipio
+  }
+  get tipoOrganizacion(): string | null {
+    return this.props.tipoOrganizacion
+  }
+  get personal(): number {
+    return this.props.personal
+  }
+  get ingresoOperacion(): number {
+    return this.props.ingresoOperacion
+  }
+  get activosTotales(): number {
+    return this.props.activosTotales
+  }
+  get email(): string | null {
+    return this.props.email
+  }
+  get telefono(): string | null {
+    return this.props.telefono
+  }
+  get direccion(): string | null {
+    return this.props.direccion
+  }
+  get fechaMatricula(): Date | null {
+    return this.props.fechaMatricula
+  }
+  get fechaRenovacion(): Date | null {
+    return this.props.fechaRenovacion
+  }
+  get estado(): string {
+    return this.props.estado
+  }
+  get etapa(): Etapa {
+    return this.props.etapa
+  }
+}
+
+function parseCiiu(raw: string): { code: string; seccion: string } {
+  const trimmed = raw.trim().toUpperCase()
+  const withSeccion = /^([A-Z])(\d{4})$/.exec(trimmed)
+  if (withSeccion) return { code: withSeccion[2], seccion: withSeccion[1] }
+  if (/^\d{4}$/.test(trimmed)) {
+    throw new Error(
+      `CIIU '${trimmed}' missing section letter. Use the seed/loader to enrich from ciiu_taxonomy first.`,
+    )
+  }
+  throw new Error(`Invalid CIIU format: ${trimmed}`)
+}

--- a/src/brain/src/companies/domain/repositories/CompanyRepository.ts
+++ b/src/brain/src/companies/domain/repositories/CompanyRepository.ts
@@ -1,0 +1,13 @@
+import type { Company } from '@/companies/domain/entities/Company'
+
+export const COMPANY_REPOSITORY = Symbol('COMPANY_REPOSITORY')
+
+export interface CompanyRepository {
+  findAll(): Promise<Company[]>
+  findById(id: string): Promise<Company | null>
+  findByCiiuDivision(division: string): Promise<Company[]>
+  findByMunicipio(municipio: string): Promise<Company[]>
+  findUpdatedSince(timestamp: Date): Promise<Company[]>
+  saveMany(companies: Company[]): Promise<void>
+  count(): Promise<number>
+}

--- a/src/brain/src/companies/domain/services/EtapaCalculator.ts
+++ b/src/brain/src/companies/domain/services/EtapaCalculator.ts
@@ -1,0 +1,31 @@
+import type { Etapa } from '@/companies/domain/value-objects/Etapa'
+
+interface EtapaInput {
+  fechaMatricula: Date | null
+  personal: number
+  ingreso: number
+}
+
+const MILLIS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000
+
+export class EtapaCalculator {
+  static calculate(input: EtapaInput, now: Date = new Date()): Etapa {
+    const { fechaMatricula, personal, ingreso } = input
+
+    if (personal > 200 || ingreso > 5_000_000_000) return 'madurez'
+
+    const years = fechaMatricula
+      ? (now.getTime() - fechaMatricula.getTime()) / MILLIS_PER_YEAR
+      : null
+
+    if (years === null) {
+      if (personal <= 2 && ingreso < 100_000_000) return 'nacimiento'
+      if (personal <= 50) return 'crecimiento'
+      return 'consolidacion'
+    }
+
+    if (years < 2 && personal <= 2) return 'nacimiento'
+    if (years < 7 && personal <= 50) return 'crecimiento'
+    return 'consolidacion'
+  }
+}

--- a/src/brain/src/companies/domain/sources/CompanySource.ts
+++ b/src/brain/src/companies/domain/sources/CompanySource.ts
@@ -1,0 +1,16 @@
+import type { Company } from '@/companies/domain/entities/Company'
+
+export const COMPANY_SOURCE = Symbol('COMPANY_SOURCE')
+
+/**
+ * PORT — external read-only source of companies.
+ *
+ * Today implemented by `CsvCompanySource` (mock of the hackathon dataset).
+ * When BigQuery credentials arrive, a `BigQueryCompanySource` implements this
+ * same interface and only one line in `companies.module.ts` changes. Domain
+ * and use cases do not learn about the swap.
+ */
+export interface CompanySource {
+  fetchAll(): Promise<Company[]>
+  fetchUpdatedSince(since: Date): Promise<Company[]>
+}

--- a/src/brain/src/companies/domain/value-objects/Etapa.ts
+++ b/src/brain/src/companies/domain/value-objects/Etapa.ts
@@ -1,0 +1,12 @@
+export const ETAPAS = [
+  'nacimiento',
+  'crecimiento',
+  'consolidacion',
+  'madurez',
+] as const
+
+export type Etapa = (typeof ETAPAS)[number]
+
+export function isEtapa(value: string): value is Etapa {
+  return (ETAPAS as readonly string[]).includes(value)
+}

--- a/src/brain/src/companies/infrastructure/http/companies.controller.ts
+++ b/src/brain/src/companies/infrastructure/http/companies.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+} from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import type { Company } from '@/companies/domain/entities/Company'
+import { FindCompanyById } from '@/companies/application/use-cases/FindCompanyById'
+import { GetCompanies } from '@/companies/application/use-cases/GetCompanies'
+
+const DEFAULT_LIMIT = 50
+
+interface CompanyDto {
+  id: string
+  razonSocial: string
+  ciiu: string
+  ciiuSeccion: string
+  ciiuDivision: string
+  municipio: string
+  etapa: string
+  personal: number
+  ingreso: number
+}
+
+@ApiTags('companies')
+@Controller('companies')
+export class CompaniesController {
+  constructor(
+    private readonly getCompanies: GetCompanies,
+    private readonly findCompanyById: FindCompanyById,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List companies' })
+  async list(@Query('limit') limit?: string): Promise<CompanyDto[]> {
+    const { companies } = await this.getCompanies.execute()
+    const max = limit ? parseInt(limit, 10) : DEFAULT_LIMIT
+    return companies.slice(0, max).map(toDto)
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get company by id' })
+  async detail(@Param('id') id: string): Promise<CompanyDto> {
+    const { company } = await this.findCompanyById.execute({ id })
+    if (!company) throw new NotFoundException(`Company ${id} not found`)
+    return toDto(company)
+  }
+}
+
+function toDto(c: Company): CompanyDto {
+  return {
+    id: c.id,
+    razonSocial: c.razonSocial,
+    ciiu: c.ciiu,
+    ciiuSeccion: c.ciiuSeccion,
+    ciiuDivision: c.ciiuDivision,
+    municipio: c.municipio,
+    etapa: c.etapa,
+    personal: c.personal,
+    ingreso: c.ingresoOperacion,
+  }
+}

--- a/src/brain/src/companies/infrastructure/repositories/InMemoryCompanyRepository.ts
+++ b/src/brain/src/companies/infrastructure/repositories/InMemoryCompanyRepository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+
+interface Entry {
+  company: Company
+  updatedAt: Date
+}
+
+@Injectable()
+export class InMemoryCompanyRepository implements CompanyRepository {
+  private readonly store = new Map<string, Entry>()
+
+  async findAll(): Promise<Company[]> {
+    return Array.from(this.store.values()).map((e) => e.company)
+  }
+
+  async findById(id: string): Promise<Company | null> {
+    return this.store.get(id)?.company ?? null
+  }
+
+  async findByCiiuDivision(division: string): Promise<Company[]> {
+    return (await this.findAll()).filter((c) => c.ciiuDivision === division)
+  }
+
+  async findByMunicipio(municipio: string): Promise<Company[]> {
+    return (await this.findAll()).filter((c) => c.municipio === municipio)
+  }
+
+  async findUpdatedSince(timestamp: Date): Promise<Company[]> {
+    return Array.from(this.store.values())
+      .filter((e) => e.updatedAt > timestamp)
+      .map((e) => e.company)
+  }
+
+  async saveMany(companies: Company[]): Promise<void> {
+    const now = new Date()
+    for (const company of companies) {
+      this.store.set(company.id, { company, updatedAt: now })
+    }
+  }
+
+  async count(): Promise<number> {
+    return this.store.size
+  }
+}

--- a/src/brain/src/companies/infrastructure/repositories/SupabaseCompanyRepository.ts
+++ b/src/brain/src/companies/infrastructure/repositories/SupabaseCompanyRepository.ts
@@ -16,9 +16,9 @@ interface CompanyRow {
   ciiu_grupo: string
   municipio: string
   tipo_organizacion: string | null
-  personal: number | string | null
-  ingreso_operacion: number | string | null
-  activos_totales: number | string | null
+  personal: number | null
+  ingreso_operacion: number | null
+  activos_totales: number | null
   email: string | null
   telefono: string | null
   direccion: string | null

--- a/src/brain/src/companies/infrastructure/repositories/SupabaseCompanyRepository.ts
+++ b/src/brain/src/companies/infrastructure/repositories/SupabaseCompanyRepository.ts
@@ -1,0 +1,156 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { Company } from '@/companies/domain/entities/Company'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'companies'
+const CHUNK_SIZE = 500
+
+interface CompanyRow {
+  id: string
+  razon_social: string
+  ciiu: string
+  ciiu_seccion: string
+  ciiu_division: string
+  ciiu_grupo: string
+  municipio: string
+  tipo_organizacion: string | null
+  personal: number | string | null
+  ingreso_operacion: number | string | null
+  activos_totales: number | string | null
+  email: string | null
+  telefono: string | null
+  direccion: string | null
+  fecha_matricula: string | null
+  fecha_renovacion: string | null
+  estado: string
+  etapa: string
+}
+
+@Injectable()
+export class SupabaseCompanyRepository implements CompanyRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async findAll(): Promise<Company[]> {
+    const { data, error } = await this.db.from(TABLE).select('*')
+    if (error) throw error
+    return ((data ?? []) as CompanyRow[]).map((r) => this.toEntity(r))
+  }
+
+  async findById(id: string): Promise<Company | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('id', id)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as CompanyRow) : null
+  }
+
+  async findByCiiuDivision(division: string): Promise<Company[]> {
+    return this.findManyByEq('ciiu_division', division)
+  }
+
+  async findByMunicipio(municipio: string): Promise<Company[]> {
+    return this.findManyByEq('municipio', municipio)
+  }
+
+  async findUpdatedSince(timestamp: Date): Promise<Company[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .gt('updated_at', timestamp.toISOString())
+    if (error) throw error
+    return ((data ?? []) as CompanyRow[]).map((r) => this.toEntity(r))
+  }
+
+  async count(): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+    if (error) throw error
+    return count ?? 0
+  }
+
+  async saveMany(companies: Company[]): Promise<void> {
+    if (companies.length === 0) return
+    const rows = companies.map((c) => this.toRow(c))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'id' })
+      if (error) throw error
+    }
+  }
+
+  private async findManyByEq(
+    column: 'ciiu_division' | 'municipio',
+    value: string,
+  ): Promise<Company[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq(column, value)
+    if (error) throw error
+    return ((data ?? []) as CompanyRow[]).map((r) => this.toEntity(r))
+  }
+
+  private toEntity(row: CompanyRow): Company {
+    return Company.create({
+      id: row.id,
+      razonSocial: row.razon_social,
+      ciiu: `${row.ciiu_seccion}${row.ciiu}`,
+      municipio: row.municipio,
+      tipoOrganizacion: row.tipo_organizacion,
+      personal: row.personal != null ? Number(row.personal) : 0,
+      ingresoOperacion:
+        row.ingreso_operacion != null ? Number(row.ingreso_operacion) : 0,
+      activosTotales:
+        row.activos_totales != null ? Number(row.activos_totales) : 0,
+      email: row.email,
+      telefono: row.telefono,
+      direccion: row.direccion,
+      fechaMatricula: row.fecha_matricula
+        ? new Date(row.fecha_matricula)
+        : null,
+      fechaRenovacion: row.fecha_renovacion
+        ? new Date(row.fecha_renovacion)
+        : null,
+      estado: row.estado,
+    })
+  }
+
+  private toRow(c: Company): CompanyRow {
+    return {
+      id: c.id,
+      razon_social: c.razonSocial,
+      ciiu: c.ciiu,
+      ciiu_seccion: c.ciiuSeccion,
+      ciiu_division: c.ciiuDivision,
+      ciiu_grupo: c.ciiuGrupo,
+      municipio: c.municipio,
+      tipo_organizacion: c.tipoOrganizacion,
+      personal: c.personal,
+      ingreso_operacion: c.ingresoOperacion,
+      activos_totales: c.activosTotales,
+      email: c.email,
+      telefono: c.telefono,
+      direccion: c.direccion,
+      fecha_matricula: c.fechaMatricula ? toIsoDate(c.fechaMatricula) : null,
+      fecha_renovacion: c.fechaRenovacion ? toIsoDate(c.fechaRenovacion) : null,
+      estado: c.estado,
+      etapa: c.etapa,
+    }
+  }
+}
+
+function toIsoDate(date: Date): string {
+  const yyyy = date.getUTCFullYear()
+  const mm = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(date.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}

--- a/src/brain/src/companies/infrastructure/sources/CsvCompanySource.ts
+++ b/src/brain/src/companies/infrastructure/sources/CsvCompanySource.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common'
+import { Company } from '@/companies/domain/entities/Company'
+import type { CompanySource } from '@/companies/domain/sources/CompanySource'
+import { CsvLoader } from '@/shared/infrastructure/csv/CsvLoader'
+import { DataPaths } from '@/shared/infrastructure/path/DataPaths'
+
+interface RegistradosRow {
+  registradosCIIU1_CODIGOSII?: string
+  registradoMATRICULA?: string
+  registradoRAZONSOCIAL?: string
+  municipioTitulo?: string
+  tipoOrganizacionTITULO?: string
+  registroEstadoTITULO?: string
+  registradoACTIVOSTOTALES?: string
+  registradoINGRESOPERACION?: string
+  regitradoPERSONAL?: string
+  regitradoFECMATRICULA?: string
+  regitradoFECHREN?: string
+  regitradoEMAIL?: string
+  regitradoTELEFONO1?: string
+  regitradoDIRECCION?: string
+}
+
+const CIIU_PATTERN = /^[A-Z]\d{4}$/
+const YYYYMMDD_PATTERN = /^(\d{4})(\d{2})(\d{2})$/
+
+@Injectable()
+export class CsvCompanySource implements CompanySource {
+  async fetchAll(): Promise<Company[]> {
+    const rows = await CsvLoader.load<RegistradosRow>(DataPaths.companiesCsv)
+    const companies: Company[] = []
+    for (const row of rows) {
+      const company = this.toCompany(row)
+      if (company) companies.push(company)
+    }
+    return companies
+  }
+
+  async fetchUpdatedSince(since: Date): Promise<Company[]> {
+    const all = await this.fetchAll()
+    return all.filter((c) => c.fechaRenovacion && c.fechaRenovacion > since)
+  }
+
+  private toCompany(row: RegistradosRow): Company | null {
+    const ciiu = (row.registradosCIIU1_CODIGOSII ?? '').trim()
+    if (!CIIU_PATTERN.test(ciiu)) return null
+
+    const id = (row.registradoMATRICULA ?? '').trim()
+    const razonSocial = (row.registradoRAZONSOCIAL ?? '').trim()
+    if (!id || !razonSocial) return null
+
+    try {
+      return Company.create({
+        id,
+        razonSocial,
+        ciiu,
+        municipio: (row.municipioTitulo ?? '').trim(),
+        tipoOrganizacion: emptyToNull(row.tipoOrganizacionTITULO),
+        personal: parseNumber(row.regitradoPERSONAL),
+        ingresoOperacion: parseNumber(row.registradoINGRESOPERACION),
+        activosTotales: parseNumber(row.registradoACTIVOSTOTALES),
+        email: emptyToNull(row.regitradoEMAIL),
+        telefono: emptyToNull(row.regitradoTELEFONO1),
+        direccion: emptyToNull(row.regitradoDIRECCION),
+        fechaMatricula: parseYyyymmdd(row.regitradoFECMATRICULA),
+        fechaRenovacion: parseYyyymmdd(row.regitradoFECHREN),
+        estado: (row.registroEstadoTITULO ?? '').trim() || 'ACTIVO',
+      })
+    } catch {
+      return null
+    }
+  }
+}
+
+function parseNumber(raw: string | undefined): number {
+  if (!raw) return 0
+  const n = Number(raw.trim())
+  return Number.isFinite(n) ? n : 0
+}
+
+function parseYyyymmdd(raw: string | undefined): Date | null {
+  if (!raw) return null
+  const match = YYYYMMDD_PATTERN.exec(raw.trim())
+  if (!match) return null
+  const [, year, month, day] = match
+  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function emptyToNull(raw: string | undefined): string | null {
+  const trimmed = (raw ?? '').trim()
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/src/brain/vitest.config.ts
+++ b/src/brain/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['__tests__/**/*.{test,spec}.ts', 'src/**/*.{test,spec}.ts'],
+    setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],

--- a/src/brain/vitest.setup.ts
+++ b/src/brain/vitest.setup.ts
@@ -1,0 +1,10 @@
+// Stub env vars before any test module loads so eager validators in
+// `src/shared/infrastructure/env.ts` don't trip on missing values.
+// Production keeps fail-fast validation; tests just need the module to load.
+//
+// IMPORTANT: no imports here — this file runs before any user code, and
+// any import would risk transitively loading env.ts before these stubs.
+
+process.env.SUPABASE_URL ||= 'http://localhost:54321'
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= 'test-service-role-key'
+process.env.GEMINI_API_KEY ||= 'test-gemini-key'


### PR DESCRIPTION
## Summary
- Phase 3 del [plan del brain clustering engine](docs/2026-04-25-brain-clustering-engine-implementation.md). 7 SDD tasks completas, 11 commits, **89 tests nuevos** (suite total brain: 119/119, front: 80/80).
- Nuevo bounded context `companies` (hexagonal):
  - **Domain**: `Etapa` value object + `EtapaCalculator` (heurística nacimiento/crecimiento/consolidación/madurez), `Company` entity con `parseCiiu` invariante en factory (requiere formato `X9999`), ports `CompanyRepository` y `CompanySource` (con tokens DI colocados con el port).
  - **Application**: `GetCompanies`, `FindCompanyById`, `GetCompaniesUpdatedSince` (para polling del agent), `SyncCompaniesFromSource`.
  - **Infrastructure**: `SupabaseCompanyRepository` (upsert chunked 500), `InMemoryCompanyRepository` (trackea `updatedAt` interno), `CompaniesController` (GET / con `limit`, GET /:id), `CsvCompanySource` (parsea `REGISTRADOS_SII.csv` — 10006 filas — con date format YYYYMMDD y skip defensivo de filas con CIIU malformado).
- Módulo `CompaniesModule` wireado en `AppModule`. `COMPANY_SOURCE` apunta a `CsvCompanySource` hoy; cuando lleguen credenciales BigQuery del reto, se cambia UNA línea sin tocar domain ni use cases.
- **Side fix**: `chore(brain): stub env vars in vitest setup` — agrega `vitest.setup.ts` que stubea `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `GEMINI_API_KEY` antes de cargar módulos de test. Resuelve el bug latente que hacía que `__tests__/ciiu-taxonomy/SupabaseCiiuTaxonomyRepository.test.ts` (Phase 2) fallara cuando `.env` local tenía la key vacía. Producción sigue con validación eager fail-fast.

## Test plan
- [x] `bun --filter brain test:run` → **119/119 verde** (Phase 2 cerró en 48; Phase 3 suma 71 nuevos en 10 archivos `__tests__/companies/*`)
- [x] `bun --filter front test:run` → 80/80 verde (sin regresiones)
- [x] `bun --filter brain typecheck` → clean
- [x] Pre-push hook (typecheck + tests front + brain) pasa sin ` --no-verify`
- [x] CSV integration test real contra `docs/hackathon/DATA/REGISTRADOS_SII.csv` → >9000 entidades `Company` válidas, todas con `ciiuDivision` matching `/^\d{2}$/`

## Notas para el reviewer

**Decisión: `saveMany` en lugar de `saveAll`.** El plan tiene drift entre Task 3.3 (declara `saveAll`) y Task 3.6 (el use case `SyncCompaniesFromSource` llama `repo.saveMany`). Fui con `saveMany` porque el consumidor (use case) es harder-to-change que el contrato del port. Además es semánticamente menos ambiguo — `saveAll` se puede leer como "reemplazá todo".

**Decisión: tokens DI colocados con el port** (`COMPANY_REPOSITORY` y `COMPANY_SOURCE` en el mismo archivo del interface). El plan sugería un archivo `CompanySource.token.ts` separado. Mantuve consistencia con Phase 2 (`CIIU_TAXONOMY_REPOSITORY` ya está colocado con el port).

**Decisión: `Company` entity NO expone `updatedAt`.** Es metadata de persistencia, no de dominio. El filtro en `findUpdatedSince` ocurre a nivel del adapter:
- Supabase: `gt('updated_at', timestamp.toISOString())`
- InMemory: trackea `updatedAt` interno por entry al hacer `saveMany`

**Decisión: vitest setup file con `||=` en lugar de fixear `env.ts`.** Tres opciones se evaluaron (fix lazy proxy / setear key local / setup file). Setup file gana porque (1) producción sigue con validación eager (fail-fast en boot, ya documentado en AGENTS.md §8.2), (2) tests son contexto distinto que sólo necesitan que el módulo cargue, (3) resuelve el bug de Phase 2 sin tocar código de prod. El setup file NO importa nada — solo muta `process.env` con `||=` para no pisar valores reales si están seteados.

**CIIU mapping en SupabaseCompanyRepository**: la DB guarda `ciiu` (4 dígitos sin sección) y `ciiu_seccion` por separado. Para mapear row → entity, reconstruyo `seccion + ciiu` (e.g. `'G' + '4711'` → `'G4711'`) antes de pasarlo a `Company.create()` — porque `parseCiiu` rechaza 4 dígitos sin sección (la invariante del entity). Trade-off: dos hops de string concat / regex por row de read, pero mantiene la invariante intacta.

**Date format en CSV**: `REGISTRADOS_SII.csv` tiene fechas como `19920825` (YYYYMMDD sin separadores). `parseYyyymmdd` usa `Date.UTC(...)` para evitar drift de timezone. Filas con fechas inválidas o vacías → `null`, no crash.

**Heads-up**: si querés bootear el brain localmente con `bun --filter brain start:dev`, necesitás `GEMINI_API_KEY` real en `.env`. La validación eager rebota si está vacía. Esto NO es nuevo de Phase 3 — viene desde Phase 0. Los tests pasan porque el setup file stubea.