### PR TITLE
feat(brain): phase 4 clusters context

### DIFF
--- a/src/brain/__tests__/clusters/Cluster.test.ts
+++ b/src/brain/__tests__/clusters/Cluster.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import {
+  CLUSTER_TYPES,
+  isClusterType,
+} from '@/clusters/domain/value-objects/ClusterType'
+
+describe('ClusterType', () => {
+  it('exposes the 4 valid types', () => {
+    expect(CLUSTER_TYPES).toEqual([
+      'predefined',
+      'heuristic-division',
+      'heuristic-grupo',
+      'heuristic-municipio',
+    ])
+  })
+
+  it('isClusterType narrows valid values', () => {
+    expect(isClusterType('predefined')).toBe(true)
+    expect(isClusterType('heuristic-grupo')).toBe(true)
+    expect(isClusterType('foo')).toBe(false)
+  })
+})
+
+describe('Cluster', () => {
+  const baseValid = {
+    id: 'pred-7',
+    codigo: 'LOGISTICA',
+    titulo: 'Logística',
+    descripcion: 'Cluster predefinido de logística',
+    tipo: 'predefined' as const,
+    memberCount: 12,
+  }
+
+  it('creates a predefined cluster without geographic/CIIU fields', () => {
+    const c = Cluster.create(baseValid)
+    expect(c.id).toBe('pred-7')
+    expect(c.tipo).toBe('predefined')
+    expect(c.titulo).toBe('Logística')
+    expect(c.ciiuDivision).toBeNull()
+    expect(c.ciiuGrupo).toBeNull()
+    expect(c.municipio).toBeNull()
+    expect(c.memberCount).toBe(12)
+  })
+
+  it('throws when titulo is empty', () => {
+    expect(() => Cluster.create({ ...baseValid, titulo: '' })).toThrow()
+  })
+
+  it('throws when titulo is whitespace only', () => {
+    expect(() => Cluster.create({ ...baseValid, titulo: '   ' })).toThrow()
+  })
+
+  it('throws when id is empty', () => {
+    expect(() => Cluster.create({ ...baseValid, id: '' })).toThrow()
+  })
+
+  it('throws when codigo is empty', () => {
+    expect(() => Cluster.create({ ...baseValid, codigo: '' })).toThrow()
+  })
+
+  it('throws when memberCount is negative', () => {
+    expect(() => Cluster.create({ ...baseValid, memberCount: -1 })).toThrow()
+  })
+
+  it('defaults memberCount to 0 when not provided', () => {
+    const { memberCount: _omit, ...rest } = baseValid
+    const c = Cluster.create(rest)
+    expect(c.memberCount).toBe(0)
+  })
+
+  describe('heuristic-division', () => {
+    it('creates with ciiuDivision + municipio', () => {
+      const c = Cluster.create({
+        id: 'div-47-SANTA_MARTA',
+        codigo: '47-SANTA_MARTA',
+        titulo: 'Comercio al por menor en SANTA MARTA',
+        descripcion: 'Empresas con CIIU división 47 en SANTA MARTA',
+        tipo: 'heuristic-division',
+        ciiuDivision: '47',
+        municipio: 'SANTA MARTA',
+        memberCount: 6,
+      })
+      expect(c.tipo).toBe('heuristic-division')
+      expect(c.ciiuDivision).toBe('47')
+      expect(c.municipio).toBe('SANTA MARTA')
+    })
+
+    it('throws when ciiuDivision is missing', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'div-47-X',
+          codigo: '47-X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-division',
+          municipio: 'SANTA MARTA',
+          memberCount: 6,
+        }),
+      ).toThrow(/ciiuDivision/i)
+    })
+  })
+
+  describe('heuristic-grupo', () => {
+    it('creates with ciiuDivision + ciiuGrupo + municipio', () => {
+      const c = Cluster.create({
+        id: 'grp-477-SANTA_MARTA',
+        codigo: '477-SANTA_MARTA',
+        titulo: 'Comercio de productos farmacéuticos en SANTA MARTA',
+        descripcion: null,
+        tipo: 'heuristic-grupo',
+        ciiuDivision: '47',
+        ciiuGrupo: '477',
+        municipio: 'SANTA MARTA',
+        memberCount: 12,
+      })
+      expect(c.ciiuGrupo).toBe('477')
+    })
+
+    it('throws when ciiuGrupo is missing', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'grp-477-X',
+          codigo: '477-X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-grupo',
+          ciiuDivision: '47',
+          municipio: 'SANTA MARTA',
+          memberCount: 10,
+        }),
+      ).toThrow(/ciiuGrupo/i)
+    })
+
+    it('throws when ciiuDivision is missing', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'grp-477-X',
+          codigo: '477-X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-grupo',
+          ciiuGrupo: '477',
+          municipio: 'SANTA MARTA',
+          memberCount: 10,
+        }),
+      ).toThrow(/ciiuDivision/i)
+    })
+
+    it('throws when ciiuGrupo does not start with ciiuDivision digits', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'grp-477-X',
+          codigo: '477-X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-grupo',
+          ciiuDivision: '48',
+          ciiuGrupo: '477',
+          municipio: 'SANTA MARTA',
+          memberCount: 10,
+        }),
+      ).toThrow(/grupo.*division/i)
+    })
+
+    it('throws when municipio is missing', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'grp-477-X',
+          codigo: '477-X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-grupo',
+          ciiuDivision: '47',
+          ciiuGrupo: '477',
+          memberCount: 10,
+        }),
+      ).toThrow(/municipio/i)
+    })
+  })
+
+  describe('heuristic-municipio', () => {
+    it('creates with municipio only', () => {
+      const c = Cluster.create({
+        id: 'mun-SANTA_MARTA',
+        codigo: 'SANTA_MARTA',
+        titulo: 'Empresas en SANTA MARTA',
+        descripcion: null,
+        tipo: 'heuristic-municipio',
+        municipio: 'SANTA MARTA',
+        memberCount: 50,
+      })
+      expect(c.tipo).toBe('heuristic-municipio')
+      expect(c.municipio).toBe('SANTA MARTA')
+    })
+
+    it('throws when municipio is missing', () => {
+      expect(() =>
+        Cluster.create({
+          id: 'mun-X',
+          codigo: 'X',
+          titulo: 'X',
+          descripcion: null,
+          tipo: 'heuristic-municipio',
+          memberCount: 10,
+        }),
+      ).toThrow(/municipio/i)
+    })
+  })
+
+  it('exposes macroSector and descripcion via getters', () => {
+    const c = Cluster.create({
+      ...baseValid,
+      descripcion: 'desc',
+      macroSector: 'COMERCIO',
+    })
+    expect(c.descripcion).toBe('desc')
+    expect(c.macroSector).toBe('COMERCIO')
+  })
+
+  it('defaults macroSector and descripcion to null', () => {
+    const c = Cluster.create(baseValid)
+    expect(c.descripcion).toBe('Cluster predefinido de logística')
+    const c2 = Cluster.create({ ...baseValid, descripcion: null })
+    expect(c2.descripcion).toBeNull()
+    expect(c2.macroSector).toBeNull()
+  })
+
+  it('trims id, codigo, titulo', () => {
+    const c = Cluster.create({
+      ...baseValid,
+      id: '  pred-7  ',
+      codigo: '  LOGISTICA  ',
+      titulo: '  Logística  ',
+    })
+    expect(c.id).toBe('pred-7')
+    expect(c.codigo).toBe('LOGISTICA')
+    expect(c.titulo).toBe('Logística')
+  })
+})

--- a/src/brain/__tests__/clusters/ClustersController.test.ts
+++ b/src/brain/__tests__/clusters/ClustersController.test.ts
@@ -1,0 +1,161 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { ExplainCluster } from '@/clusters/application/use-cases/ExplainCluster'
+import { GenerateClusters } from '@/clusters/application/use-cases/GenerateClusters'
+import { GetCompanyClusters } from '@/clusters/application/use-cases/GetCompanyClusters'
+import { HeuristicClusterer } from '@/clusters/application/services/HeuristicClusterer'
+import { PredefinedClusterMatcher } from '@/clusters/application/services/PredefinedClusterMatcher'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+import { ClustersController } from '@/clusters/infrastructure/http/clusters.controller'
+import { CompanyClustersController } from '@/clusters/infrastructure/http/company-clusters.controller'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+function makeCompany(id: string, ciiu = 'G4711'): Company {
+  return Company.create({
+    id,
+    razonSocial: `RS-${id}`,
+    ciiu,
+    municipio: 'SANTA MARTA',
+  })
+}
+
+async function seedTaxonomy(): Promise<InMemoryCiiuTaxonomyRepository> {
+  const repo = new InMemoryCiiuTaxonomyRepository()
+  await repo.saveAll([
+    CiiuActivity.create({
+      code: '4711',
+      titulo: 'Tiendas',
+      seccion: 'G',
+      division: '47',
+      grupo: '471',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio en establecimientos',
+    }),
+  ])
+  return repo
+}
+
+describe('ClustersController', () => {
+  let companyRepo: InMemoryCompanyRepository
+  let clusterRepo: InMemoryClusterRepository
+  let membershipRepo: InMemoryClusterMembershipRepository
+  let mappingRepo: InMemoryClusterCiiuMappingRepository
+  let ciiuRepo: InMemoryCiiuTaxonomyRepository
+  let controller: ClustersController
+
+  beforeEach(async () => {
+    companyRepo = new InMemoryCompanyRepository()
+    clusterRepo = new InMemoryClusterRepository()
+    membershipRepo = new InMemoryClusterMembershipRepository()
+    mappingRepo = new InMemoryClusterCiiuMappingRepository()
+    ciiuRepo = await seedTaxonomy()
+
+    const generate = new GenerateClusters(
+      companyRepo,
+      clusterRepo,
+      membershipRepo,
+      new PredefinedClusterMatcher(mappingRepo),
+      new HeuristicClusterer(ciiuRepo),
+    )
+    const explain = new ExplainCluster(
+      clusterRepo,
+      membershipRepo,
+      companyRepo,
+      new StubGeminiAdapter('AI desc'),
+    )
+    controller = new ClustersController(generate, explain, clusterRepo)
+  })
+
+  describe('POST /clusters/generate', () => {
+    it('runs the generator and returns stats', async () => {
+      await mappingRepo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+      await clusterRepo.saveMany([
+        Cluster.create({
+          id: 'pred-1',
+          codigo: 'C1',
+          titulo: 'C1',
+          tipo: 'predefined',
+        }),
+      ])
+      await companyRepo.saveMany(
+        Array.from({ length: 6 }, (_, i) => makeCompany(`c-${i}`)),
+      )
+      const stats = await controller.generate()
+      expect(stats.predefinedClusters).toBe(1)
+      expect(stats.totalMemberships).toBeGreaterThan(0)
+    })
+  })
+
+  describe('GET /clusters/:id/explain', () => {
+    it('returns the cached descripcion when present', async () => {
+      await clusterRepo.saveMany([
+        Cluster.create({
+          id: 'pred-1',
+          codigo: 'C1',
+          titulo: 'C1',
+          descripcion: 'cached',
+          tipo: 'predefined',
+        }),
+      ])
+      const result = await controller.explain('pred-1')
+      expect(result.description).toBe('cached')
+    })
+
+    it('throws NotFoundException when cluster does not exist', async () => {
+      await expect(controller.explain('missing')).rejects.toThrow(
+        NotFoundException,
+      )
+    })
+  })
+})
+
+describe('CompanyClustersController', () => {
+  let clusterRepo: InMemoryClusterRepository
+  let membershipRepo: InMemoryClusterMembershipRepository
+  let controller: CompanyClustersController
+
+  beforeEach(() => {
+    clusterRepo = new InMemoryClusterRepository()
+    membershipRepo = new InMemoryClusterMembershipRepository()
+    controller = new CompanyClustersController(
+      new GetCompanyClusters(membershipRepo, clusterRepo),
+    )
+  })
+
+  it('returns DTOs for clusters that contain the company', async () => {
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'pred-1',
+        codigo: 'C1',
+        titulo: 'C1',
+        tipo: 'predefined',
+      }),
+    ])
+    await membershipRepo.saveMany([{ clusterId: 'pred-1', companyId: 'c-1' }])
+    const result = await controller.list('c-1')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'pred-1',
+      codigo: 'C1',
+      titulo: 'C1',
+      descripcion: null,
+      tipo: 'predefined',
+      ciiuDivision: null,
+      ciiuGrupo: null,
+      municipio: null,
+      memberCount: 0,
+    })
+  })
+
+  it('returns empty array when company has no memberships', async () => {
+    expect(await controller.list('missing')).toEqual([])
+  })
+})

--- a/src/brain/__tests__/clusters/ExplainCluster.test.ts
+++ b/src/brain/__tests__/clusters/ExplainCluster.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ExplainCluster } from '@/clusters/application/use-cases/ExplainCluster'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+function makeCompany(id: string, razonSocial = 'X SAS'): Company {
+  return Company.create({
+    id,
+    razonSocial,
+    ciiu: 'G4711',
+    municipio: 'SANTA MARTA',
+  })
+}
+
+describe('ExplainCluster', () => {
+  let clusterRepo: InMemoryClusterRepository
+  let membershipRepo: InMemoryClusterMembershipRepository
+  let companyRepo: InMemoryCompanyRepository
+  let gemini: StubGeminiAdapter
+  let useCase: ExplainCluster
+
+  beforeEach(() => {
+    clusterRepo = new InMemoryClusterRepository()
+    membershipRepo = new InMemoryClusterMembershipRepository()
+    companyRepo = new InMemoryCompanyRepository()
+    gemini = new StubGeminiAdapter('AI generated description')
+    useCase = new ExplainCluster(
+      clusterRepo,
+      membershipRepo,
+      companyRepo,
+      gemini,
+    )
+  })
+
+  it('returns cached descripcion without calling Gemini when present', async () => {
+    let calls = 0
+    const trackingGemini = {
+      generateText: async () => {
+        calls++
+        return 'should not be called'
+      },
+      inferStructured: async () => ({}) as never,
+    }
+    useCase = new ExplainCluster(
+      clusterRepo,
+      membershipRepo,
+      companyRepo,
+      trackingGemini,
+    )
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'pred-1',
+        codigo: 'C1',
+        titulo: 'C1',
+        descripcion: 'cached desc',
+        tipo: 'predefined',
+      }),
+    ])
+
+    const { description } = await useCase.execute({ clusterId: 'pred-1' })
+
+    expect(description).toBe('cached desc')
+    expect(calls).toBe(0)
+  })
+
+  it('calls Gemini and persists descripcion when missing', async () => {
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'div-47-X',
+        codigo: '47-X',
+        titulo: 'Comercio en X',
+        descripcion: null,
+        tipo: 'heuristic-division',
+        ciiuDivision: '47',
+        municipio: 'X',
+        memberCount: 5,
+      }),
+    ])
+    await companyRepo.saveMany([
+      makeCompany('c-1', 'ACME SAS'),
+      makeCompany('c-2', 'BETA SA'),
+    ])
+    await membershipRepo.saveMany([
+      { clusterId: 'div-47-X', companyId: 'c-1' },
+      { clusterId: 'div-47-X', companyId: 'c-2' },
+    ])
+
+    const { description } = await useCase.execute({ clusterId: 'div-47-X' })
+
+    expect(description).toBe('AI generated description')
+    const updated = await clusterRepo.findById('div-47-X')
+    expect(updated!.descripcion).toBe('AI generated description')
+  })
+
+  it('builds the prompt with cluster + sample companies', async () => {
+    let captured = ''
+    const capturingGemini = {
+      generateText: async (p: string) => {
+        captured = p
+        return 'desc'
+      },
+      inferStructured: async () => ({}) as never,
+    }
+    useCase = new ExplainCluster(
+      clusterRepo,
+      membershipRepo,
+      companyRepo,
+      capturingGemini,
+    )
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'div-47-X',
+        codigo: '47-X',
+        titulo: 'Comercio en X',
+        descripcion: null,
+        tipo: 'heuristic-division',
+        ciiuDivision: '47',
+        municipio: 'BARRANQUILLA',
+        memberCount: 2,
+      }),
+    ])
+    await companyRepo.saveMany([makeCompany('c-1', 'ACME SAS')])
+    await membershipRepo.saveMany([{ clusterId: 'div-47-X', companyId: 'c-1' }])
+
+    await useCase.execute({ clusterId: 'div-47-X' })
+
+    expect(captured).toContain('Comercio en X')
+    expect(captured).toContain('heuristic-division')
+    expect(captured).toContain('BARRANQUILLA')
+    expect(captured).toContain('ACME SAS')
+  })
+
+  it('throws when cluster does not exist', async () => {
+    await expect(useCase.execute({ clusterId: 'missing' })).rejects.toThrow(
+      /missing/,
+    )
+  })
+})

--- a/src/brain/__tests__/clusters/GenerateClusters.test.ts
+++ b/src/brain/__tests__/clusters/GenerateClusters.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { GenerateClusters } from '@/clusters/application/use-cases/GenerateClusters'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { HeuristicClusterer } from '@/clusters/application/services/HeuristicClusterer'
+import { PredefinedClusterMatcher } from '@/clusters/application/services/PredefinedClusterMatcher'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+
+interface Spec {
+  idPrefix: string
+  ciiu: string
+  municipio: string
+  estado?: string
+}
+
+function repeat(count: number, spec: Spec): Company[] {
+  return Array.from({ length: count }, (_, i) =>
+    Company.create({
+      id: `${spec.idPrefix}-${i}`,
+      razonSocial: 'X',
+      ciiu: spec.ciiu,
+      municipio: spec.municipio,
+      estado: spec.estado,
+    }),
+  )
+}
+
+async function seedTaxonomy(): Promise<InMemoryCiiuTaxonomyRepository> {
+  const repo = new InMemoryCiiuTaxonomyRepository()
+  await repo.saveAll([
+    CiiuActivity.create({
+      code: '4711',
+      titulo: 'Tiendas',
+      seccion: 'G',
+      division: '47',
+      grupo: '471',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio en establecimientos',
+    }),
+    CiiuActivity.create({
+      code: '4771',
+      titulo: 'Vestuario',
+      seccion: 'G',
+      division: '47',
+      grupo: '477',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio especializado',
+    }),
+  ])
+  return repo
+}
+
+describe('GenerateClusters', () => {
+  let companyRepo: InMemoryCompanyRepository
+  let clusterRepo: InMemoryClusterRepository
+  let membershipRepo: InMemoryClusterMembershipRepository
+  let mappingRepo: InMemoryClusterCiiuMappingRepository
+  let ciiuRepo: InMemoryCiiuTaxonomyRepository
+  let useCase: GenerateClusters
+
+  beforeEach(async () => {
+    companyRepo = new InMemoryCompanyRepository()
+    clusterRepo = new InMemoryClusterRepository()
+    membershipRepo = new InMemoryClusterMembershipRepository()
+    mappingRepo = new InMemoryClusterCiiuMappingRepository()
+    ciiuRepo = await seedTaxonomy()
+    useCase = new GenerateClusters(
+      companyRepo,
+      clusterRepo,
+      membershipRepo,
+      new PredefinedClusterMatcher(mappingRepo),
+      new HeuristicClusterer(ciiuRepo),
+    )
+
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'pred-1',
+        codigo: 'COMERCIO',
+        titulo: 'Comercio',
+        tipo: 'predefined',
+        memberCount: 0,
+      }),
+    ])
+    await mappingRepo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+  })
+
+  it('persists heuristic clusters and assigns memberships for both flows', async () => {
+    await companyRepo.saveMany([
+      ...repeat(6, {
+        idPrefix: 'c47',
+        ciiu: 'G4711',
+        municipio: 'SANTA MARTA',
+      }),
+      ...repeat(12, {
+        idPrefix: 'c477',
+        ciiu: 'G4771',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+
+    const stats = await useCase.execute()
+
+    expect(stats.predefinedClusters).toBe(1)
+    expect(stats.heuristicClusters).toBeGreaterThanOrEqual(1)
+
+    const allClusters = await clusterRepo.findAll()
+    expect(allClusters.some((c) => c.tipo === 'heuristic-division')).toBe(true)
+    expect(allClusters.some((c) => c.tipo === 'heuristic-grupo')).toBe(true)
+
+    const pred1Companies =
+      await membershipRepo.findCompanyIdsByCluster('pred-1')
+    expect(pred1Companies.length).toBe(6)
+
+    const totalMemberships = await membershipRepo.count()
+    expect(stats.totalMemberships).toBe(totalMemberships)
+  })
+
+  it('updates predefined cluster memberCount based on matched companies', async () => {
+    await companyRepo.saveMany(
+      repeat(6, { idPrefix: 'c47', ciiu: 'G4711', municipio: 'SANTA MARTA' }),
+    )
+
+    await useCase.execute()
+
+    const updated = await clusterRepo.findById('pred-1')
+    expect(updated!.memberCount).toBe(6)
+  })
+
+  it('only considers ACTIVO companies', async () => {
+    await companyRepo.saveMany([
+      ...repeat(5, { idPrefix: 'a', ciiu: 'G4711', municipio: 'SANTA MARTA' }),
+      ...repeat(2, {
+        idPrefix: 'inactive',
+        ciiu: 'G4711',
+        municipio: 'SANTA MARTA',
+        estado: 'CANCELADO',
+      }),
+    ])
+
+    const stats = await useCase.execute()
+
+    const pred1 = await membershipRepo.findCompanyIdsByCluster('pred-1')
+    expect(pred1).toHaveLength(5)
+    expect(stats.totalMemberships).toBeGreaterThanOrEqual(5)
+  })
+
+  it('wipes existing memberships before regenerating', async () => {
+    await membershipRepo.saveMany([{ clusterId: 'stale', companyId: 'old' }])
+    await companyRepo.saveMany(
+      repeat(5, { idPrefix: 'c', ciiu: 'G4711', municipio: 'SANTA MARTA' }),
+    )
+
+    await useCase.execute()
+
+    const staleResidue = await membershipRepo.findCompanyIdsByCluster('stale')
+    expect(staleResidue).toEqual([])
+  })
+
+  it('returns zeros when no companies are active', async () => {
+    const stats = await useCase.execute()
+    expect(stats.predefinedClusters).toBe(0)
+    expect(stats.heuristicClusters).toBe(0)
+    expect(stats.totalMemberships).toBe(0)
+  })
+})

--- a/src/brain/__tests__/clusters/GetCompanyClusters.test.ts
+++ b/src/brain/__tests__/clusters/GetCompanyClusters.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { GetCompanyClusters } from '@/clusters/application/use-cases/GetCompanyClusters'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+
+describe('GetCompanyClusters', () => {
+  let clusterRepo: InMemoryClusterRepository
+  let membershipRepo: InMemoryClusterMembershipRepository
+  let useCase: GetCompanyClusters
+
+  beforeEach(() => {
+    clusterRepo = new InMemoryClusterRepository()
+    membershipRepo = new InMemoryClusterMembershipRepository()
+    useCase = new GetCompanyClusters(membershipRepo, clusterRepo)
+  })
+
+  it('returns clusters the company belongs to', async () => {
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'pred-1',
+        codigo: 'C1',
+        titulo: 'C1',
+        tipo: 'predefined',
+      }),
+      Cluster.create({
+        id: 'pred-2',
+        codigo: 'C2',
+        titulo: 'C2',
+        tipo: 'predefined',
+      }),
+      Cluster.create({
+        id: 'pred-3',
+        codigo: 'C3',
+        titulo: 'C3',
+        tipo: 'predefined',
+      }),
+    ])
+    await membershipRepo.saveMany([
+      { clusterId: 'pred-1', companyId: 'c-1' },
+      { clusterId: 'pred-3', companyId: 'c-1' },
+      { clusterId: 'pred-2', companyId: 'c-2' },
+    ])
+
+    const { clusters } = await useCase.execute({ companyId: 'c-1' })
+
+    expect(clusters.map((c) => c.id).sort()).toEqual(['pred-1', 'pred-3'])
+  })
+
+  it('returns empty array when company has no memberships', async () => {
+    const { clusters } = await useCase.execute({ companyId: 'missing' })
+    expect(clusters).toEqual([])
+  })
+})

--- a/src/brain/__tests__/clusters/HeuristicClusterer.test.ts
+++ b/src/brain/__tests__/clusters/HeuristicClusterer.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { HeuristicClusterer } from '@/clusters/application/services/HeuristicClusterer'
+import { Company } from '@/companies/domain/entities/Company'
+
+interface RepeatSpec {
+  idPrefix: string
+  ciiu: string
+  municipio: string
+}
+
+function repeat(count: number, spec: RepeatSpec): Company[] {
+  return Array.from({ length: count }, (_, i) =>
+    Company.create({
+      id: `${spec.idPrefix}-${i}`,
+      razonSocial: 'X',
+      ciiu: spec.ciiu,
+      municipio: spec.municipio,
+    }),
+  )
+}
+
+async function seedTaxonomy(): Promise<InMemoryCiiuTaxonomyRepository> {
+  const repo = new InMemoryCiiuTaxonomyRepository()
+  await repo.saveAll([
+    CiiuActivity.create({
+      code: '4711',
+      titulo: 'Tiendas de víveres',
+      seccion: 'G',
+      division: '47',
+      grupo: '471',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio en establecimientos no especializados',
+    }),
+    CiiuActivity.create({
+      code: '4771',
+      titulo: 'Comercio de prendas de vestir',
+      seccion: 'G',
+      division: '47',
+      grupo: '477',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio especializado de productos',
+    }),
+    CiiuActivity.create({
+      code: '4761',
+      titulo: 'Comercio de libros',
+      seccion: 'G',
+      division: '47',
+      grupo: '476',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio cultural',
+    }),
+    CiiuActivity.create({
+      code: '4721',
+      titulo: 'Comercio de alimentos',
+      seccion: 'G',
+      division: '47',
+      grupo: '472',
+      tituloSeccion: 'Comercio',
+      tituloDivision: 'Comercio al por menor',
+      tituloGrupo: 'Comercio de alimentos',
+    }),
+    CiiuActivity.create({
+      code: '4921',
+      titulo: 'Transporte terrestre',
+      seccion: 'H',
+      division: '49',
+      grupo: '492',
+      tituloSeccion: 'Transporte',
+      tituloDivision: 'Transporte terrestre',
+      tituloGrupo: 'Transporte de pasajeros',
+    }),
+    CiiuActivity.create({
+      code: '5611',
+      titulo: 'Restaurantes',
+      seccion: 'I',
+      division: '56',
+      grupo: '561',
+      tituloSeccion: 'Alojamiento y comidas',
+      tituloDivision: 'Servicio de comidas',
+      tituloGrupo: 'Restaurantes',
+    }),
+  ])
+  return repo
+}
+
+describe('HeuristicClusterer', () => {
+  let ciiuRepo: InMemoryCiiuTaxonomyRepository
+  let clusterer: HeuristicClusterer
+
+  beforeEach(async () => {
+    ciiuRepo = await seedTaxonomy()
+    clusterer = new HeuristicClusterer(ciiuRepo)
+  })
+
+  it('PASE 1: groups by (ciiu_division, municipio) when group >= 5', async () => {
+    const companies = [
+      ...repeat(6, {
+        idPrefix: 'sm-47',
+        ciiu: 'G4711',
+        municipio: 'SANTA MARTA',
+      }),
+      ...repeat(3, {
+        idPrefix: 'sm-49',
+        ciiu: 'H4921',
+        municipio: 'SANTA MARTA',
+      }),
+      ...repeat(5, { idPrefix: 'cn-56', ciiu: 'I5611', municipio: 'CIENAGA' }),
+    ]
+    const result = await clusterer.cluster(companies)
+    const divClusters = result.filter(
+      (r) => r.cluster.tipo === 'heuristic-division',
+    )
+    expect(divClusters).toHaveLength(2)
+
+    const ids = divClusters.map((c) => c.cluster.id).sort()
+    expect(ids).toEqual(['div-47-SANTA_MARTA', 'div-56-CIENAGA'])
+
+    const sm47 = divClusters.find((c) => c.cluster.id === 'div-47-SANTA_MARTA')!
+    expect(sm47.cluster.titulo).toContain('Comercio al por menor')
+    expect(sm47.cluster.titulo).toContain('SANTA MARTA')
+    expect(sm47.cluster.memberCount).toBe(6)
+    expect(sm47.members).toHaveLength(6)
+  })
+
+  it('PASE 2: groups by (ciiu_grupo, municipio) when group >= 10', async () => {
+    const companies = [
+      ...repeat(12, {
+        idPrefix: 'sm-477',
+        ciiu: 'G4771',
+        municipio: 'SANTA MARTA',
+      }),
+      ...repeat(8, {
+        idPrefix: 'sm-476',
+        ciiu: 'G4761',
+        municipio: 'SANTA MARTA',
+      }),
+    ]
+    const result = await clusterer.cluster(companies)
+    const grupoClusters = result.filter(
+      (r) => r.cluster.tipo === 'heuristic-grupo',
+    )
+    expect(grupoClusters).toHaveLength(1)
+    expect(grupoClusters[0].cluster.id).toBe('grp-477-SANTA_MARTA')
+    expect(grupoClusters[0].cluster.titulo).toContain(
+      'Comercio especializado de productos',
+    )
+  })
+
+  it('CASCADA: empresa pertenece a cluster división Y a cluster grupo cuando ambos califican', async () => {
+    const companies = repeat(12, {
+      idPrefix: 'sm-477',
+      ciiu: 'G4771',
+      municipio: 'SANTA MARTA',
+    })
+    const result = await clusterer.cluster(companies)
+    expect(result).toHaveLength(2)
+
+    const div = result.find((r) => r.cluster.tipo === 'heuristic-division')!
+    const grp = result.find((r) => r.cluster.tipo === 'heuristic-grupo')!
+    expect(div.members).toHaveLength(12)
+    expect(grp.members).toHaveLength(12)
+    expect(grp.members.every((m) => div.members.includes(m))).toBe(true)
+  })
+
+  it('ORTOGONAL: división califica pero ningún grupo individual llega a 10 → solo cluster división', async () => {
+    const companies = [
+      ...repeat(6, {
+        idPrefix: 'sm-471',
+        ciiu: 'G4711',
+        municipio: 'SANTA MARTA',
+      }),
+      ...repeat(4, {
+        idPrefix: 'sm-472',
+        ciiu: 'G4721',
+        municipio: 'SANTA MARTA',
+      }),
+    ]
+    const result = await clusterer.cluster(companies)
+    expect(
+      result.filter((r) => r.cluster.tipo === 'heuristic-division'),
+    ).toHaveLength(1)
+    expect(
+      result.filter((r) => r.cluster.tipo === 'heuristic-grupo'),
+    ).toHaveLength(0)
+  })
+
+  it('division below threshold (<5) is excluded entirely', async () => {
+    const companies = repeat(4, {
+      idPrefix: 'sm-47',
+      ciiu: 'G4711',
+      municipio: 'SANTA MARTA',
+    })
+    const result = await clusterer.cluster(companies)
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array for empty input', async () => {
+    expect(await clusterer.cluster([])).toEqual([])
+  })
+
+  it('slugifies municipios with spaces and accents in cluster ids', async () => {
+    const companies = repeat(5, {
+      idPrefix: 'bog-47',
+      ciiu: 'G4711',
+      municipio: 'BOGOTÁ DC',
+    })
+    const result = await clusterer.cluster(companies)
+    expect(result).toHaveLength(1)
+    expect(result[0].cluster.id).toBe('div-47-BOGOTA_DC')
+    expect(result[0].cluster.codigo).toBe('47-BOGOTA_DC')
+    expect(result[0].cluster.municipio).toBe('BOGOTÁ DC')
+  })
+
+  it('falls back to a default title when CIIU taxonomy is missing the division', async () => {
+    const emptyRepo = new InMemoryCiiuTaxonomyRepository()
+    const c = new HeuristicClusterer(emptyRepo)
+    const companies = repeat(5, {
+      idPrefix: 'x-47',
+      ciiu: 'G4711',
+      municipio: 'SANTA MARTA',
+    })
+    const result = await c.cluster(companies)
+    expect(result[0].cluster.titulo).toContain('División 47')
+  })
+})

--- a/src/brain/__tests__/clusters/InMemoryClusterCiiuMappingRepository.test.ts
+++ b/src/brain/__tests__/clusters/InMemoryClusterCiiuMappingRepository.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+
+describe('InMemoryClusterCiiuMappingRepository', () => {
+  let repo: InMemoryClusterCiiuMappingRepository
+
+  beforeEach(() => {
+    repo = new InMemoryClusterCiiuMappingRepository()
+  })
+
+  it('saves mappings and exposes them via findAll', async () => {
+    await repo.saveMany([
+      { clusterId: 'pred-1', ciiuCode: '4711' },
+      { clusterId: 'pred-1', ciiuCode: '4712' },
+    ])
+    const all = await repo.findAll()
+    expect(all).toHaveLength(2)
+  })
+
+  it('dedupes (cluster, ciiu) pairs', async () => {
+    await repo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+    await repo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+    expect(await repo.count()).toBe(1)
+  })
+
+  it('getCiiuToClusterMap groups cluster ids by ciiu code', async () => {
+    await repo.saveMany([
+      { clusterId: 'pred-1', ciiuCode: '4711' },
+      { clusterId: 'pred-2', ciiuCode: '4711' },
+      { clusterId: 'pred-3', ciiuCode: '5611' },
+    ])
+    const map = await repo.getCiiuToClusterMap()
+    expect(map.get('4711')!.sort()).toEqual(['pred-1', 'pred-2'])
+    expect(map.get('5611')).toEqual(['pred-3'])
+    expect(map.get('9999')).toBeUndefined()
+  })
+
+  it('does nothing on empty saveMany', async () => {
+    await repo.saveMany([])
+    expect(await repo.count()).toBe(0)
+  })
+})

--- a/src/brain/__tests__/clusters/InMemoryClusterMembershipRepository.test.ts
+++ b/src/brain/__tests__/clusters/InMemoryClusterMembershipRepository.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+
+describe('InMemoryClusterMembershipRepository', () => {
+  let repo: InMemoryClusterMembershipRepository
+
+  beforeEach(() => {
+    repo = new InMemoryClusterMembershipRepository()
+  })
+
+  it('saves memberships and exposes them by company', async () => {
+    await repo.saveMany([
+      { clusterId: 'pred-1', companyId: 'c-1' },
+      { clusterId: 'pred-2', companyId: 'c-1' },
+      { clusterId: 'pred-1', companyId: 'c-2' },
+    ])
+    const clusters = await repo.findClusterIdsByCompany('c-1')
+    expect(clusters.sort()).toEqual(['pred-1', 'pred-2'])
+  })
+
+  it('exposes memberships by cluster', async () => {
+    await repo.saveMany([
+      { clusterId: 'pred-1', companyId: 'c-1' },
+      { clusterId: 'pred-1', companyId: 'c-2' },
+      { clusterId: 'pred-2', companyId: 'c-3' },
+    ])
+    const companies = await repo.findCompanyIdsByCluster('pred-1')
+    expect(companies.sort()).toEqual(['c-1', 'c-2'])
+  })
+
+  it('dedupes (cluster, company) pairs', async () => {
+    await repo.saveMany([{ clusterId: 'pred-1', companyId: 'c-1' }])
+    await repo.saveMany([{ clusterId: 'pred-1', companyId: 'c-1' }])
+    expect(await repo.count()).toBe(1)
+  })
+
+  it('deleteAll wipes the store', async () => {
+    await repo.saveMany([
+      { clusterId: 'pred-1', companyId: 'c-1' },
+      { clusterId: 'pred-2', companyId: 'c-2' },
+    ])
+    await repo.deleteAll()
+    expect(await repo.count()).toBe(0)
+    expect(await repo.findClusterIdsByCompany('c-1')).toEqual([])
+  })
+
+  it('returns empty arrays for unknown ids', async () => {
+    expect(await repo.findClusterIdsByCompany('missing')).toEqual([])
+    expect(await repo.findCompanyIdsByCluster('missing')).toEqual([])
+  })
+
+  it('does nothing on empty saveMany', async () => {
+    await repo.saveMany([])
+    expect(await repo.count()).toBe(0)
+  })
+})

--- a/src/brain/__tests__/clusters/InMemoryClusterRepository.test.ts
+++ b/src/brain/__tests__/clusters/InMemoryClusterRepository.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  Cluster,
+  type CreateClusterInput,
+} from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+
+function makeCluster(overrides: Partial<CreateClusterInput> = {}): Cluster {
+  return Cluster.create({
+    id: 'pred-1',
+    codigo: 'C1',
+    titulo: 'C1',
+    tipo: 'predefined',
+    memberCount: 0,
+    ...overrides,
+  })
+}
+
+describe('InMemoryClusterRepository', () => {
+  let repo: InMemoryClusterRepository
+
+  beforeEach(() => {
+    repo = new InMemoryClusterRepository()
+  })
+
+  it('saves and retrieves clusters via findAll', async () => {
+    await repo.saveMany([makeCluster({ id: '1' }), makeCluster({ id: '2' })])
+    const all = await repo.findAll()
+    expect(all.map((c) => c.id).sort()).toEqual(['1', '2'])
+  })
+
+  it('upserts by id', async () => {
+    await repo.saveMany([makeCluster({ id: '1', titulo: 'OLD' })])
+    await repo.saveMany([makeCluster({ id: '1', titulo: 'NEW' })])
+    const all = await repo.findAll()
+    expect(all).toHaveLength(1)
+    expect(all[0].titulo).toBe('NEW')
+  })
+
+  it('findById returns the cluster or null', async () => {
+    await repo.saveMany([makeCluster({ id: 'x' })])
+    expect((await repo.findById('x'))!.id).toBe('x')
+    expect(await repo.findById('missing')).toBeNull()
+  })
+
+  it('findManyByIds returns matching clusters in any order', async () => {
+    await repo.saveMany([
+      makeCluster({ id: 'a' }),
+      makeCluster({ id: 'b' }),
+      makeCluster({ id: 'c' }),
+    ])
+    const result = await repo.findManyByIds(['a', 'c'])
+    expect(result.map((c) => c.id).sort()).toEqual(['a', 'c'])
+  })
+
+  it('findManyByIds returns empty when ids is empty', async () => {
+    await repo.saveMany([makeCluster({ id: 'a' })])
+    expect(await repo.findManyByIds([])).toEqual([])
+  })
+
+  it('findByTipo filters by cluster type', async () => {
+    await repo.saveMany([
+      makeCluster({ id: 'pred-1', tipo: 'predefined' }),
+      makeCluster({
+        id: 'div-47-X',
+        codigo: '47-X',
+        titulo: 'div',
+        tipo: 'heuristic-division',
+        ciiuDivision: '47',
+        municipio: 'X',
+      }),
+    ])
+    const result = await repo.findByTipo('heuristic-division')
+    expect(result.map((c) => c.id)).toEqual(['div-47-X'])
+  })
+
+  it('updateDescripcion mutates only the descripcion', async () => {
+    await repo.saveMany([
+      makeCluster({ id: '1', titulo: 'T', descripcion: null }),
+    ])
+    await repo.updateDescripcion('1', 'new desc')
+    const c = await repo.findById('1')
+    expect(c!.descripcion).toBe('new desc')
+    expect(c!.titulo).toBe('T')
+  })
+
+  it('updateDescripcion is a no-op when cluster does not exist', async () => {
+    await repo.updateDescripcion('missing', 'foo')
+    expect(await repo.count()).toBe(0)
+  })
+
+  it('count returns total clusters', async () => {
+    expect(await repo.count()).toBe(0)
+    await repo.saveMany([makeCluster({ id: '1' }), makeCluster({ id: '2' })])
+    expect(await repo.count()).toBe(2)
+  })
+})

--- a/src/brain/__tests__/clusters/PredefinedClusterMatcher.test.ts
+++ b/src/brain/__tests__/clusters/PredefinedClusterMatcher.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PredefinedClusterMatcher } from '@/clusters/application/services/PredefinedClusterMatcher'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+import { Company } from '@/companies/domain/entities/Company'
+
+function makeCompany(id: string, ciiu: string): Company {
+  return Company.create({
+    id,
+    razonSocial: 'X',
+    ciiu,
+    municipio: 'SANTA MARTA',
+  })
+}
+
+describe('PredefinedClusterMatcher', () => {
+  let mappingRepo: InMemoryClusterCiiuMappingRepository
+  let matcher: PredefinedClusterMatcher
+
+  beforeEach(() => {
+    mappingRepo = new InMemoryClusterCiiuMappingRepository()
+    matcher = new PredefinedClusterMatcher(mappingRepo)
+  })
+
+  it('assigns companies to clusters whose CIIU matches', async () => {
+    await mappingRepo.saveMany([
+      { clusterId: 'pred-1', ciiuCode: '4711' },
+      { clusterId: 'pred-2', ciiuCode: '4711' },
+      { clusterId: 'pred-3', ciiuCode: '5611' },
+    ])
+    const companies = [
+      makeCompany('a', 'G4711'),
+      makeCompany('b', 'I5611'),
+      makeCompany('c', 'G4711'),
+    ]
+    const result = await matcher.match(companies)
+    const pred1 = result.get('pred-1')!
+    expect(pred1.map((c) => c.id).sort()).toEqual(['a', 'c'])
+    expect(
+      result
+        .get('pred-2')!
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(['a', 'c'])
+    expect(result.get('pred-3')!.map((c) => c.id)).toEqual(['b'])
+  })
+
+  it('a company in multiple predefined clusters appears in each', async () => {
+    await mappingRepo.saveMany([
+      { clusterId: 'pred-1', ciiuCode: '4711' },
+      { clusterId: 'pred-2', ciiuCode: '4711' },
+    ])
+    const companies = [makeCompany('a', 'G4711')]
+    const result = await matcher.match(companies)
+    expect(result.get('pred-1')).toEqual(companies)
+    expect(result.get('pred-2')).toEqual(companies)
+  })
+
+  it('skips companies whose CIIU has no mapping', async () => {
+    await mappingRepo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+    const companies = [makeCompany('a', 'G4711'), makeCompany('b', 'H4921')]
+    const result = await matcher.match(companies)
+    expect(result.get('pred-1')!.map((c) => c.id)).toEqual(['a'])
+    expect(result.size).toBe(1)
+  })
+
+  it('returns empty map when no mappings exist', async () => {
+    const result = await matcher.match([makeCompany('a', 'G4711')])
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty map for empty company list', async () => {
+    await mappingRepo.saveMany([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+    expect((await matcher.match([])).size).toBe(0)
+  })
+})

--- a/src/brain/__tests__/clusters/SupabaseClusterCiiuMappingRepository.test.ts
+++ b/src/brain/__tests__/clusters/SupabaseClusterCiiuMappingRepository.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SupabaseClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/SupabaseClusterCiiuMappingRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    upsert: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of ['from', 'select', 'upsert'] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+describe('SupabaseClusterCiiuMappingRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseClusterCiiuMappingRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseClusterCiiuMappingRepository(fake.db)
+  })
+
+  describe('saveMany', () => {
+    it('upserts mapped rows with composite onConflict', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.saveMany([
+        { clusterId: 'pred-1', ciiuCode: '4711' },
+        { clusterId: 'pred-1', ciiuCode: '4712' },
+      ])
+      expect(fake.spies.from).toHaveBeenCalledWith('cluster_ciiu_mapping')
+      const [rows, opts] = fake.spies.upsert.mock.calls[0]
+      expect(rows).toEqual([
+        { cluster_id: 'pred-1', ciiu_code: '4711' },
+        { cluster_id: 'pred-1', ciiu_code: '4712' },
+      ])
+      expect(opts).toEqual({ onConflict: 'cluster_id,ciiu_code' })
+    })
+
+    it('chunks payloads of more than 1000 rows', async () => {
+      fake.setNext({ data: null, error: null })
+      const rows = Array.from({ length: 1500 }, (_, i) => ({
+        clusterId: `c-${i}`,
+        ciiuCode: `${i}`,
+      }))
+      await repo.saveMany(rows)
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(2)
+      expect(fake.spies.upsert.mock.calls[0][0]).toHaveLength(1000)
+      expect(fake.spies.upsert.mock.calls[1][0]).toHaveLength(500)
+    })
+
+    it('does nothing for empty array', async () => {
+      await repo.saveMany([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('bad') })
+      await expect(
+        repo.saveMany([{ clusterId: 'a', ciiuCode: '1' }]),
+      ).rejects.toThrow(/bad/)
+    })
+  })
+
+  describe('findAll', () => {
+    it('returns mappings mapped from DB rows', async () => {
+      fake.setNext({
+        data: [{ cluster_id: 'pred-1', ciiu_code: '4711' }],
+        error: null,
+      })
+      const result = await repo.findAll()
+      expect(result).toEqual([{ clusterId: 'pred-1', ciiuCode: '4711' }])
+    })
+
+    it('returns [] when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findAll()).toEqual([])
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findAll()).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('getCiiuToClusterMap', () => {
+    it('groups cluster ids by ciiu code', async () => {
+      fake.setNext({
+        data: [
+          { cluster_id: 'pred-1', ciiu_code: '4711' },
+          { cluster_id: 'pred-2', ciiu_code: '4711' },
+          { cluster_id: 'pred-3', ciiu_code: '5611' },
+        ],
+        error: null,
+      })
+      const map = await repo.getCiiuToClusterMap()
+      expect(map.get('4711')!.sort()).toEqual(['pred-1', 'pred-2'])
+      expect(map.get('5611')).toEqual(['pred-3'])
+    })
+  })
+
+  describe('count', () => {
+    it('returns the count from head request', async () => {
+      fake.setNext({ data: null, error: null, count: 8 })
+      expect(await repo.count()).toBe(8)
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.count()).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/clusters/SupabaseClusterMembershipRepository.test.ts
+++ b/src/brain/__tests__/clusters/SupabaseClusterMembershipRepository.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SupabaseClusterMembershipRepository } from '@/clusters/infrastructure/repositories/SupabaseClusterMembershipRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    neq: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of [
+    'from',
+    'select',
+    'eq',
+    'neq',
+    'upsert',
+    'delete',
+  ] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+describe('SupabaseClusterMembershipRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseClusterMembershipRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseClusterMembershipRepository(fake.db)
+  })
+
+  describe('saveMany', () => {
+    it('upserts mapped rows with composite onConflict', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.saveMany([
+        { clusterId: 'pred-1', companyId: 'c-1' },
+        { clusterId: 'pred-2', companyId: 'c-1' },
+      ])
+      expect(fake.spies.from).toHaveBeenCalledWith('cluster_members')
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(1)
+      const [rows, opts] = fake.spies.upsert.mock.calls[0]
+      expect(rows).toEqual([
+        { cluster_id: 'pred-1', company_id: 'c-1' },
+        { cluster_id: 'pred-2', company_id: 'c-1' },
+      ])
+      expect(opts).toEqual({ onConflict: 'cluster_id,company_id' })
+    })
+
+    it('chunks payloads of more than 1000 rows', async () => {
+      fake.setNext({ data: null, error: null })
+      const rows = Array.from({ length: 2300 }, (_, i) => ({
+        clusterId: `c-${i}`,
+        companyId: `co-${i}`,
+      }))
+      await repo.saveMany(rows)
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(3)
+      expect(fake.spies.upsert.mock.calls[0][0]).toHaveLength(1000)
+      expect(fake.spies.upsert.mock.calls[2][0]).toHaveLength(300)
+    })
+
+    it('does nothing for empty array', async () => {
+      await repo.saveMany([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('bad') })
+      await expect(
+        repo.saveMany([{ clusterId: 'a', companyId: 'b' }]),
+      ).rejects.toThrow(/bad/)
+    })
+  })
+
+  describe('findClusterIdsByCompany', () => {
+    it('returns the cluster_id column filtered by company_id', async () => {
+      fake.setNext({
+        data: [{ cluster_id: 'pred-1' }, { cluster_id: 'pred-2' }],
+        error: null,
+      })
+      const result = await repo.findClusterIdsByCompany('c-1')
+      expect(result).toEqual(['pred-1', 'pred-2'])
+      expect(fake.spies.select).toHaveBeenCalledWith('cluster_id')
+      expect(fake.spies.eq).toHaveBeenCalledWith('company_id', 'c-1')
+    })
+
+    it('returns [] when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findClusterIdsByCompany('c-1')).toEqual([])
+    })
+  })
+
+  describe('findCompanyIdsByCluster', () => {
+    it('returns the company_id column filtered by cluster_id', async () => {
+      fake.setNext({ data: [{ company_id: 'c-1' }], error: null })
+      const result = await repo.findCompanyIdsByCluster('pred-1')
+      expect(result).toEqual(['c-1'])
+      expect(fake.spies.select).toHaveBeenCalledWith('company_id')
+      expect(fake.spies.eq).toHaveBeenCalledWith('cluster_id', 'pred-1')
+    })
+  })
+
+  describe('deleteAll', () => {
+    it('issues a delete unbounded by neq trick', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.deleteAll()
+      expect(fake.spies.delete).toHaveBeenCalledTimes(1)
+      expect(fake.spies.neq).toHaveBeenCalledWith('cluster_id', '')
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('forbidden') })
+      await expect(repo.deleteAll()).rejects.toThrow(/forbidden/)
+    })
+  })
+
+  describe('count', () => {
+    it('returns the count from head request', async () => {
+      fake.setNext({ data: null, error: null, count: 7 })
+      expect(await repo.count()).toBe(7)
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.count()).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/clusters/SupabaseClusterRepository.test.ts
+++ b/src/brain/__tests__/clusters/SupabaseClusterRepository.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { SupabaseClusterRepository } from '@/clusters/infrastructure/repositories/SupabaseClusterRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+    maybeSingle: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of [
+    'from',
+    'select',
+    'eq',
+    'in',
+    'update',
+    'upsert',
+  ] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  id: 'pred-7',
+  codigo: 'LOGISTICA',
+  titulo: 'Logística',
+  descripcion: 'desc',
+  tipo: 'predefined',
+  ciiu_division: null,
+  ciiu_grupo: null,
+  municipio: null,
+  macro_sector: null,
+  member_count: 12,
+}
+
+describe('SupabaseClusterRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseClusterRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseClusterRepository(fake.db)
+  })
+
+  describe('findAll', () => {
+    it('returns Cluster entities mapped from rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findAll()
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBeInstanceOf(Cluster)
+      expect(result[0].id).toBe('pred-7')
+      expect(fake.spies.from).toHaveBeenCalledWith('clusters')
+    })
+
+    it('returns empty array when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findAll()).toEqual([])
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findAll()).rejects.toThrow(/boom/)
+    })
+
+    it('throws when row tipo is unknown', async () => {
+      fake.setNext({ data: [{ ...validRow, tipo: 'wat' }], error: null })
+      await expect(repo.findAll()).rejects.toThrow(/Unknown cluster tipo/)
+    })
+  })
+
+  describe('findById', () => {
+    it('returns a Cluster when row exists', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const c = await repo.findById('pred-7')
+      expect(c).not.toBeNull()
+      expect(c!.id).toBe('pred-7')
+      expect(fake.spies.eq).toHaveBeenCalledWith('id', 'pred-7')
+    })
+
+    it('returns null when no row', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findById('missing')).toBeNull()
+    })
+  })
+
+  describe('findManyByIds', () => {
+    it('queries with .in("id", ids) and maps rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findManyByIds(['pred-7', 'pred-8'])
+      expect(result).toHaveLength(1)
+      expect(fake.spies.in).toHaveBeenCalledWith('id', ['pred-7', 'pred-8'])
+    })
+
+    it('returns empty array without querying when ids is empty', async () => {
+      const result = await repo.findManyByIds([])
+      expect(result).toEqual([])
+      expect(fake.spies.from).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('findByTipo', () => {
+    it('queries by tipo and maps rows', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findByTipo('predefined')
+      expect(result).toHaveLength(1)
+      expect(fake.spies.eq).toHaveBeenCalledWith('tipo', 'predefined')
+    })
+  })
+
+  describe('saveMany', () => {
+    it('upserts mapped rows with onConflict on id', async () => {
+      fake.setNext({ data: null, error: null })
+      const c = Cluster.create({
+        id: 'pred-7',
+        codigo: 'LOGISTICA',
+        titulo: 'Logística',
+        descripcion: 'desc',
+        tipo: 'predefined',
+        memberCount: 12,
+      })
+      await repo.saveMany([c])
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(1)
+      const [rows, opts] = fake.spies.upsert.mock.calls[0]
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toEqual({
+        id: 'pred-7',
+        codigo: 'LOGISTICA',
+        titulo: 'Logística',
+        descripcion: 'desc',
+        tipo: 'predefined',
+        ciiu_division: null,
+        ciiu_grupo: null,
+        municipio: null,
+        macro_sector: null,
+        member_count: 12,
+      })
+      expect(opts).toEqual({ onConflict: 'id' })
+    })
+
+    it('chunks payloads of more than 500 rows', async () => {
+      fake.setNext({ data: null, error: null })
+      const clusters = Array.from({ length: 1100 }, (_, i) =>
+        Cluster.create({
+          id: `pred-${i}`,
+          codigo: `c${i}`,
+          titulo: `t${i}`,
+          tipo: 'predefined',
+          memberCount: 0,
+        }),
+      )
+      await repo.saveMany(clusters)
+      expect(fake.spies.upsert).toHaveBeenCalledTimes(3)
+      expect(fake.spies.upsert.mock.calls[0][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[1][0]).toHaveLength(500)
+      expect(fake.spies.upsert.mock.calls[2][0]).toHaveLength(100)
+    })
+
+    it('does nothing for empty array', async () => {
+      await repo.saveMany([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('insert failed') })
+      const c = Cluster.create({
+        id: '1',
+        codigo: '1',
+        titulo: '1',
+        tipo: 'predefined',
+      })
+      await expect(repo.saveMany([c])).rejects.toThrow(/insert failed/)
+    })
+  })
+
+  describe('updateDescripcion', () => {
+    it('issues an UPDATE with the new descripcion filtered by id', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.updateDescripcion('pred-7', 'new desc')
+      expect(fake.spies.update).toHaveBeenCalledWith({
+        descripcion: 'new desc',
+      })
+      expect(fake.spies.eq).toHaveBeenCalledWith('id', 'pred-7')
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('update failed') })
+      await expect(repo.updateDescripcion('pred-7', 'x')).rejects.toThrow(
+        /update failed/,
+      )
+    })
+  })
+
+  describe('count', () => {
+    it('returns the count from the head request', async () => {
+      fake.setNext({ data: null, error: null, count: 42 })
+      const total = await repo.count()
+      expect(total).toBe(42)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.count()).toBe(0)
+    })
+  })
+})

--- a/src/brain/src/app.module.ts
+++ b/src/brain/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
 import { SharedModule } from './shared/shared.module'
 import { CiiuTaxonomyModule } from './ciiu-taxonomy/ciiu-taxonomy.module'
+import { ClustersModule } from './clusters/clusters.module'
 import { CompaniesModule } from './companies/companies.module'
 import { HealthController } from './shared/infrastructure/health/health.controller'
 
@@ -11,6 +12,7 @@ import { HealthController } from './shared/infrastructure/health/health.controll
     SharedModule,
     CiiuTaxonomyModule,
     CompaniesModule,
+    ClustersModule,
   ],
   controllers: [HealthController],
 })

--- a/src/brain/src/clusters/application/services/HeuristicClusterer.ts
+++ b/src/brain/src/clusters/application/services/HeuristicClusterer.ts
@@ -1,0 +1,138 @@
+import { Inject, Injectable } from '@nestjs/common'
+import {
+  CIIU_TAXONOMY_REPOSITORY,
+  type CiiuTaxonomyRepository,
+} from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import type { Company } from '@/companies/domain/entities/Company'
+
+export interface HeuristicClusterResult {
+  cluster: Cluster
+  members: Company[]
+}
+
+@Injectable()
+export class HeuristicClusterer {
+  private static readonly MIN_DIVISION_SIZE = 5
+  private static readonly MIN_GRUPO_SIZE = 10
+
+  constructor(
+    @Inject(CIIU_TAXONOMY_REPOSITORY)
+    private readonly ciiuRepo: CiiuTaxonomyRepository,
+  ) {}
+
+  async cluster(companies: Company[]): Promise<HeuristicClusterResult[]> {
+    if (companies.length === 0) return []
+    const out: HeuristicClusterResult[] = []
+
+    const divGroups = groupBy(
+      companies,
+      (c) => `${c.ciiuDivision}|${c.municipio}`,
+    )
+    const eligibleDivisions = new Set<string>()
+    for (const [key, members] of divGroups) {
+      if (members.length >= HeuristicClusterer.MIN_DIVISION_SIZE) {
+        eligibleDivisions.add(key.split('|')[0])
+      }
+    }
+    const divisionTitles = await this.fetchDivisionTitles(eligibleDivisions)
+
+    for (const [key, members] of divGroups) {
+      if (members.length < HeuristicClusterer.MIN_DIVISION_SIZE) continue
+      const [div, mun] = key.split('|')
+      const titulo = divisionTitles.get(div) ?? `División ${div}`
+      out.push({
+        cluster: Cluster.create({
+          id: `div-${div}-${slug(mun)}`,
+          codigo: `${div}-${slug(mun)}`,
+          titulo: `${titulo} en ${mun}`,
+          descripcion: `Empresas con CIIU división ${div} ubicadas en ${mun}`,
+          tipo: 'heuristic-division',
+          ciiuDivision: div,
+          municipio: mun,
+          memberCount: members.length,
+        }),
+        members,
+      })
+    }
+
+    const grpGroups = groupBy(
+      companies,
+      (c) => `${c.ciiuGrupo}|${c.ciiuDivision}|${c.municipio}`,
+    )
+    const eligibleGrupos = new Set<string>()
+    for (const [key, members] of grpGroups) {
+      if (members.length >= HeuristicClusterer.MIN_GRUPO_SIZE) {
+        eligibleGrupos.add(key.split('|')[0])
+      }
+    }
+    const grupoTitles = await this.fetchGrupoTitles(eligibleGrupos)
+
+    for (const [key, members] of grpGroups) {
+      if (members.length < HeuristicClusterer.MIN_GRUPO_SIZE) continue
+      const [grp, div, mun] = key.split('|')
+      const titulo = grupoTitles.get(grp) ?? `Grupo ${grp}`
+      out.push({
+        cluster: Cluster.create({
+          id: `grp-${grp}-${slug(mun)}`,
+          codigo: `${grp}-${slug(mun)}`,
+          titulo: `${titulo} en ${mun}`,
+          descripcion: `Empresas con CIIU grupo ${grp} ubicadas en ${mun}`,
+          tipo: 'heuristic-grupo',
+          ciiuDivision: div,
+          ciiuGrupo: grp,
+          municipio: mun,
+          memberCount: members.length,
+        }),
+        members,
+      })
+    }
+
+    return out
+  }
+
+  private async fetchDivisionTitles(
+    divisions: Set<string>,
+  ): Promise<Map<string, string>> {
+    const result = new Map<string, string>()
+    const batches = await Promise.all(
+      Array.from(divisions).map((d) => this.ciiuRepo.findByDivision(d)),
+    )
+    for (const acts of batches) {
+      if (acts.length > 0) result.set(acts[0].division, acts[0].tituloDivision)
+    }
+    return result
+  }
+
+  private async fetchGrupoTitles(
+    grupos: Set<string>,
+  ): Promise<Map<string, string>> {
+    const result = new Map<string, string>()
+    const batches = await Promise.all(
+      Array.from(grupos).map((g) => this.ciiuRepo.findByGrupo(g)),
+    )
+    for (const acts of batches) {
+      if (acts.length > 0) result.set(acts[0].grupo, acts[0].tituloGrupo)
+    }
+    return result
+  }
+}
+
+function groupBy<T>(items: T[], keyFn: (t: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyFn(item)
+    const arr = map.get(key) ?? []
+    arr.push(item)
+    map.set(key, arr)
+  }
+  return map
+}
+
+function slug(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/\s+/g, '_')
+    .toUpperCase()
+}

--- a/src/brain/src/clusters/application/services/PredefinedClusterMatcher.ts
+++ b/src/brain/src/clusters/application/services/PredefinedClusterMatcher.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common'
+import {
+  CLUSTER_CIIU_MAPPING_REPOSITORY,
+  type ClusterCiiuMappingRepository,
+} from '@/clusters/domain/repositories/ClusterCiiuMappingRepository'
+import type { Company } from '@/companies/domain/entities/Company'
+
+@Injectable()
+export class PredefinedClusterMatcher {
+  constructor(
+    @Inject(CLUSTER_CIIU_MAPPING_REPOSITORY)
+    private readonly mappingRepo: ClusterCiiuMappingRepository,
+  ) {}
+
+  async match(companies: Company[]): Promise<Map<string, Company[]>> {
+    const result = new Map<string, Company[]>()
+    if (companies.length === 0) return result
+
+    const ciiuToClusterIds = await this.mappingRepo.getCiiuToClusterMap()
+    if (ciiuToClusterIds.size === 0) return result
+
+    for (const c of companies) {
+      const clusterIds = ciiuToClusterIds.get(c.ciiu) ?? []
+      for (const cid of clusterIds) {
+        const arr = result.get(cid) ?? []
+        arr.push(c)
+        result.set(cid, arr)
+      }
+    }
+    return result
+  }
+}

--- a/src/brain/src/clusters/application/use-cases/ExplainCluster.ts
+++ b/src/brain/src/clusters/application/use-cases/ExplainCluster.ts
@@ -1,0 +1,113 @@
+import { Inject, Injectable } from '@nestjs/common'
+import {
+  CLUSTER_MEMBERSHIP_REPOSITORY,
+  type ClusterMembershipRepository,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import {
+  CLUSTER_REPOSITORY,
+  type ClusterRepository,
+} from '@/clusters/domain/repositories/ClusterRepository'
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import {
+  COMPANY_REPOSITORY,
+  type CompanyRepository,
+} from '@/companies/domain/repositories/CompanyRepository'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import { GEMINI_PORT } from '@/shared/shared.module'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface ExplainClusterInput {
+  clusterId: string
+}
+
+export interface ExplainClusterOutput {
+  description: string
+}
+
+const SAMPLE_SIZE = 3
+
+@Injectable()
+export class ExplainCluster implements UseCase<
+  ExplainClusterInput,
+  ExplainClusterOutput
+> {
+  constructor(
+    @Inject(CLUSTER_REPOSITORY)
+    private readonly clusterRepo: ClusterRepository,
+    @Inject(CLUSTER_MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: ClusterMembershipRepository,
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    @Inject(GEMINI_PORT)
+    private readonly gemini: GeminiPort,
+  ) {}
+
+  async execute({
+    clusterId,
+  }: ExplainClusterInput): Promise<ExplainClusterOutput> {
+    const cluster = await this.clusterRepo.findById(clusterId)
+    if (!cluster) {
+      throw new Error(`Cluster '${clusterId}' not found`)
+    }
+    if (cluster.descripcion) {
+      return { description: cluster.descripcion }
+    }
+
+    const examples = await this.collectExamples(clusterId)
+    const prompt = buildPrompt(cluster, examples)
+    const description = (await this.gemini.generateText(prompt)).trim()
+
+    await this.clusterRepo.updateDescripcion(clusterId, description)
+    return { description }
+  }
+
+  private async collectExamples(clusterId: string): Promise<string[]> {
+    const companyIds =
+      await this.membershipRepo.findCompanyIdsByCluster(clusterId)
+    const sample = pickRandom(companyIds, SAMPLE_SIZE)
+    const companies = await Promise.all(
+      sample.map((id) => this.companyRepo.findById(id)),
+    )
+    return companies
+      .filter((c): c is NonNullable<typeof c> => c !== null)
+      .map((c) => c.razonSocial)
+  }
+}
+
+function buildPrompt(cluster: Cluster, examples: string[]): string {
+  const lines = [
+    'Sos un consultor empresarial. Te paso un cluster de empresas y necesito que generes',
+    'una descripción de 2-3 frases explicando qué tienen en común y qué oportunidades de',
+    'negocio podrían surgir entre ellas.',
+    '',
+    `Cluster: ${cluster.titulo}`,
+    `Tipo: ${cluster.tipo}`,
+  ]
+  if (cluster.ciiuDivision) {
+    lines.push(`División CIIU: ${cluster.ciiuDivision}`)
+  }
+  if (cluster.ciiuGrupo) {
+    lines.push(`Grupo CIIU: ${cluster.ciiuGrupo}`)
+  }
+  if (cluster.municipio) {
+    lines.push(`Municipio: ${cluster.municipio}`)
+  }
+  lines.push(`Cantidad de empresas: ${cluster.memberCount}`)
+  if (examples.length > 0) {
+    lines.push(`Ejemplos: ${examples.join(', ')}`)
+  }
+  lines.push('', 'Responde en español, tono profesional pero cercano.')
+  return lines.join('\n')
+}
+
+function pickRandom<T>(items: T[], n: number): T[] {
+  if (items.length <= n) return [...items]
+  const copy = [...items]
+  const out: T[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = Math.floor(Math.random() * copy.length)
+    out.push(copy[idx])
+    copy.splice(idx, 1)
+  }
+  return out
+}

--- a/src/brain/src/clusters/application/use-cases/GenerateClusters.ts
+++ b/src/brain/src/clusters/application/use-cases/GenerateClusters.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { HeuristicClusterer } from '@/clusters/application/services/HeuristicClusterer'
+import { PredefinedClusterMatcher } from '@/clusters/application/services/PredefinedClusterMatcher'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import {
+  CLUSTER_MEMBERSHIP_REPOSITORY,
+  type ClusterMembershipRepository,
+  type Membership,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import {
+  CLUSTER_REPOSITORY,
+  type ClusterRepository,
+} from '@/clusters/domain/repositories/ClusterRepository'
+import {
+  COMPANY_REPOSITORY,
+  type CompanyRepository,
+} from '@/companies/domain/repositories/CompanyRepository'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GenerateClustersResult {
+  predefinedClusters: number
+  heuristicClusters: number
+  totalMemberships: number
+}
+
+@Injectable()
+export class GenerateClusters implements UseCase<void, GenerateClustersResult> {
+  constructor(
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    @Inject(CLUSTER_REPOSITORY)
+    private readonly clusterRepo: ClusterRepository,
+    @Inject(CLUSTER_MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: ClusterMembershipRepository,
+    private readonly predefinedMatcher: PredefinedClusterMatcher,
+    private readonly heuristicClusterer: HeuristicClusterer,
+  ) {}
+
+  async execute(): Promise<GenerateClustersResult> {
+    const companies = (await this.companyRepo.findAll()).filter(
+      (c) => c.estado === 'ACTIVO',
+    )
+
+    const predefinedAssignments = await this.predefinedMatcher.match(companies)
+    const heuristicResults = await this.heuristicClusterer.cluster(companies)
+
+    await this.membershipRepo.deleteAll()
+
+    await this.persistPredefinedUpdates(predefinedAssignments)
+    await this.persistHeuristicClusters(heuristicResults)
+
+    const memberships: Membership[] = []
+    for (const [clusterId, list] of predefinedAssignments) {
+      for (const c of list) {
+        memberships.push({ clusterId, companyId: c.id })
+      }
+    }
+    for (const { cluster, members } of heuristicResults) {
+      for (const c of members) {
+        memberships.push({ clusterId: cluster.id, companyId: c.id })
+      }
+    }
+    await this.membershipRepo.saveMany(memberships)
+
+    return {
+      predefinedClusters: predefinedAssignments.size,
+      heuristicClusters: heuristicResults.length,
+      totalMemberships: memberships.length,
+    }
+  }
+
+  private async persistPredefinedUpdates(
+    assignments: Map<string, Company[]>,
+  ): Promise<void> {
+    const ids = Array.from(assignments.keys())
+    if (ids.length === 0) return
+    const existing = await this.clusterRepo.findManyByIds(ids)
+    const updated = existing.map((c) =>
+      Cluster.create({
+        id: c.id,
+        codigo: c.codigo,
+        titulo: c.titulo,
+        descripcion: c.descripcion,
+        tipo: c.tipo,
+        ciiuDivision: c.ciiuDivision,
+        ciiuGrupo: c.ciiuGrupo,
+        municipio: c.municipio,
+        macroSector: c.macroSector,
+        memberCount: assignments.get(c.id)!.length,
+      }),
+    )
+    await this.clusterRepo.saveMany(updated)
+  }
+
+  private async persistHeuristicClusters(
+    results: { cluster: Cluster; members: Company[] }[],
+  ): Promise<void> {
+    if (results.length === 0) return
+    await this.clusterRepo.saveMany(results.map((r) => r.cluster))
+  }
+}

--- a/src/brain/src/clusters/application/use-cases/GetCompanyClusters.ts
+++ b/src/brain/src/clusters/application/use-cases/GetCompanyClusters.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import {
+  CLUSTER_MEMBERSHIP_REPOSITORY,
+  type ClusterMembershipRepository,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import {
+  CLUSTER_REPOSITORY,
+  type ClusterRepository,
+} from '@/clusters/domain/repositories/ClusterRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GetCompanyClustersInput {
+  companyId: string
+}
+
+export interface GetCompanyClustersOutput {
+  clusters: Cluster[]
+}
+
+@Injectable()
+export class GetCompanyClusters implements UseCase<
+  GetCompanyClustersInput,
+  GetCompanyClustersOutput
+> {
+  constructor(
+    @Inject(CLUSTER_MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: ClusterMembershipRepository,
+    @Inject(CLUSTER_REPOSITORY)
+    private readonly clusterRepo: ClusterRepository,
+  ) {}
+
+  async execute({
+    companyId,
+  }: GetCompanyClustersInput): Promise<GetCompanyClustersOutput> {
+    const ids = await this.membershipRepo.findClusterIdsByCompany(companyId)
+    if (ids.length === 0) return { clusters: [] }
+    const clusters = await this.clusterRepo.findManyByIds(ids)
+    return { clusters }
+  }
+}

--- a/src/brain/src/clusters/clusters.module.ts
+++ b/src/brain/src/clusters/clusters.module.ts
@@ -1,0 +1,49 @@
+import { Module } from '@nestjs/common'
+import { CompaniesModule } from '@/companies/companies.module'
+import { ExplainCluster } from './application/use-cases/ExplainCluster'
+import { GenerateClusters } from './application/use-cases/GenerateClusters'
+import { GetCompanyClusters } from './application/use-cases/GetCompanyClusters'
+import { HeuristicClusterer } from './application/services/HeuristicClusterer'
+import { PredefinedClusterMatcher } from './application/services/PredefinedClusterMatcher'
+import { CLUSTER_CIIU_MAPPING_REPOSITORY } from './domain/repositories/ClusterCiiuMappingRepository'
+import { CLUSTER_MEMBERSHIP_REPOSITORY } from './domain/repositories/ClusterMembershipRepository'
+import { CLUSTER_REPOSITORY } from './domain/repositories/ClusterRepository'
+import { ClustersController } from './infrastructure/http/clusters.controller'
+import { CompanyClustersController } from './infrastructure/http/company-clusters.controller'
+import { SupabaseClusterCiiuMappingRepository } from './infrastructure/repositories/SupabaseClusterCiiuMappingRepository'
+import { SupabaseClusterMembershipRepository } from './infrastructure/repositories/SupabaseClusterMembershipRepository'
+import { SupabaseClusterRepository } from './infrastructure/repositories/SupabaseClusterRepository'
+import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
+
+@Module({
+  imports: [CiiuTaxonomyModule, CompaniesModule],
+  controllers: [ClustersController, CompanyClustersController],
+  providers: [
+    {
+      provide: CLUSTER_REPOSITORY,
+      useClass: SupabaseClusterRepository,
+    },
+    {
+      provide: CLUSTER_MEMBERSHIP_REPOSITORY,
+      useClass: SupabaseClusterMembershipRepository,
+    },
+    {
+      provide: CLUSTER_CIIU_MAPPING_REPOSITORY,
+      useClass: SupabaseClusterCiiuMappingRepository,
+    },
+    HeuristicClusterer,
+    PredefinedClusterMatcher,
+    GenerateClusters,
+    GetCompanyClusters,
+    ExplainCluster,
+  ],
+  exports: [
+    CLUSTER_REPOSITORY,
+    CLUSTER_MEMBERSHIP_REPOSITORY,
+    CLUSTER_CIIU_MAPPING_REPOSITORY,
+    GenerateClusters,
+    GetCompanyClusters,
+    ExplainCluster,
+  ],
+})
+export class ClustersModule {}

--- a/src/brain/src/clusters/domain/entities/Cluster.ts
+++ b/src/brain/src/clusters/domain/entities/Cluster.ts
@@ -1,0 +1,133 @@
+import { Entity } from '@/shared/domain/Entity'
+import type { ClusterType } from '@/clusters/domain/value-objects/ClusterType'
+
+interface ClusterProps {
+  codigo: string
+  titulo: string
+  descripcion: string | null
+  tipo: ClusterType
+  ciiuDivision: string | null
+  ciiuGrupo: string | null
+  municipio: string | null
+  macroSector: string | null
+  memberCount: number
+}
+
+export interface CreateClusterInput {
+  id: string
+  codigo: string
+  titulo: string
+  descripcion?: string | null
+  tipo: ClusterType
+  ciiuDivision?: string | null
+  ciiuGrupo?: string | null
+  municipio?: string | null
+  macroSector?: string | null
+  memberCount?: number
+}
+
+export class Cluster extends Entity<string> {
+  private readonly props: ClusterProps
+
+  private constructor(id: string, props: ClusterProps) {
+    super(id)
+    this.props = Object.freeze(props)
+  }
+
+  static create(data: CreateClusterInput): Cluster {
+    const id = data.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('Cluster.id cannot be empty')
+    }
+    const codigo = data.codigo?.trim() ?? ''
+    if (codigo.length === 0) {
+      throw new Error('Cluster.codigo cannot be empty')
+    }
+    const titulo = data.titulo?.trim() ?? ''
+    if (titulo.length === 0) {
+      throw new Error('Cluster.titulo cannot be empty')
+    }
+
+    const memberCount = data.memberCount ?? 0
+    if (memberCount < 0) {
+      throw new Error(`Cluster.memberCount must be >= 0, got ${memberCount}`)
+    }
+
+    const ciiuDivision = data.ciiuDivision ?? null
+    const ciiuGrupo = data.ciiuGrupo ?? null
+    const municipio = data.municipio ?? null
+
+    if (data.tipo === 'heuristic-division') {
+      if (!ciiuDivision) {
+        throw new Error(
+          "Cluster of type 'heuristic-division' requires ciiuDivision",
+        )
+      }
+    }
+
+    if (data.tipo === 'heuristic-grupo') {
+      if (!ciiuDivision) {
+        throw new Error(
+          "Cluster of type 'heuristic-grupo' requires ciiuDivision",
+        )
+      }
+      if (!ciiuGrupo) {
+        throw new Error("Cluster of type 'heuristic-grupo' requires ciiuGrupo")
+      }
+      if (!municipio) {
+        throw new Error("Cluster of type 'heuristic-grupo' requires municipio")
+      }
+      if (!ciiuGrupo.startsWith(ciiuDivision)) {
+        throw new Error(
+          `Cluster.ciiuGrupo '${ciiuGrupo}' must start with ciiuDivision '${ciiuDivision}'`,
+        )
+      }
+    }
+
+    if (data.tipo === 'heuristic-municipio' && !municipio) {
+      throw new Error(
+        "Cluster of type 'heuristic-municipio' requires municipio",
+      )
+    }
+
+    return new Cluster(id, {
+      codigo,
+      titulo,
+      descripcion: data.descripcion ?? null,
+      tipo: data.tipo,
+      ciiuDivision,
+      ciiuGrupo,
+      municipio,
+      macroSector: data.macroSector ?? null,
+      memberCount,
+    })
+  }
+
+  get codigo(): string {
+    return this.props.codigo
+  }
+  get titulo(): string {
+    return this.props.titulo
+  }
+  get descripcion(): string | null {
+    return this.props.descripcion
+  }
+  get tipo(): ClusterType {
+    return this.props.tipo
+  }
+  get ciiuDivision(): string | null {
+    return this.props.ciiuDivision
+  }
+  get ciiuGrupo(): string | null {
+    return this.props.ciiuGrupo
+  }
+  get municipio(): string | null {
+    return this.props.municipio
+  }
+  get macroSector(): string | null {
+    return this.props.macroSector
+  }
+  get memberCount(): number {
+    return this.props.memberCount
+  }
+}

--- a/src/brain/src/clusters/domain/repositories/ClusterCiiuMappingRepository.ts
+++ b/src/brain/src/clusters/domain/repositories/ClusterCiiuMappingRepository.ts
@@ -1,0 +1,19 @@
+export const CLUSTER_CIIU_MAPPING_REPOSITORY = Symbol(
+  'CLUSTER_CIIU_MAPPING_REPOSITORY',
+)
+
+export interface ClusterCiiuMapping {
+  clusterId: string
+  ciiuCode: string
+}
+
+export interface ClusterCiiuMappingRepository {
+  saveMany(mappings: ClusterCiiuMapping[]): Promise<void>
+  findAll(): Promise<ClusterCiiuMapping[]>
+  /**
+   * Returns a map from CIIU code → list of cluster IDs that include it.
+   * Used by PredefinedClusterMatcher to assign companies to predefined clusters.
+   */
+  getCiiuToClusterMap(): Promise<Map<string, string[]>>
+  count(): Promise<number>
+}

--- a/src/brain/src/clusters/domain/repositories/ClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/domain/repositories/ClusterMembershipRepository.ts
@@ -1,0 +1,16 @@
+export const CLUSTER_MEMBERSHIP_REPOSITORY = Symbol(
+  'CLUSTER_MEMBERSHIP_REPOSITORY',
+)
+
+export interface Membership {
+  clusterId: string
+  companyId: string
+}
+
+export interface ClusterMembershipRepository {
+  saveMany(memberships: Membership[]): Promise<void>
+  findClusterIdsByCompany(companyId: string): Promise<string[]>
+  findCompanyIdsByCluster(clusterId: string): Promise<string[]>
+  deleteAll(): Promise<void>
+  count(): Promise<number>
+}

--- a/src/brain/src/clusters/domain/repositories/ClusterRepository.ts
+++ b/src/brain/src/clusters/domain/repositories/ClusterRepository.ts
@@ -1,0 +1,14 @@
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import type { ClusterType } from '@/clusters/domain/value-objects/ClusterType'
+
+export const CLUSTER_REPOSITORY = Symbol('CLUSTER_REPOSITORY')
+
+export interface ClusterRepository {
+  findAll(): Promise<Cluster[]>
+  findById(id: string): Promise<Cluster | null>
+  findManyByIds(ids: string[]): Promise<Cluster[]>
+  findByTipo(tipo: ClusterType): Promise<Cluster[]>
+  saveMany(clusters: Cluster[]): Promise<void>
+  updateDescripcion(id: string, descripcion: string): Promise<void>
+  count(): Promise<number>
+}

--- a/src/brain/src/clusters/domain/value-objects/ClusterType.ts
+++ b/src/brain/src/clusters/domain/value-objects/ClusterType.ts
@@ -1,0 +1,12 @@
+export const CLUSTER_TYPES = [
+  'predefined',
+  'heuristic-division',
+  'heuristic-grupo',
+  'heuristic-municipio',
+] as const
+
+export type ClusterType = (typeof CLUSTER_TYPES)[number]
+
+export function isClusterType(value: string): value is ClusterType {
+  return (CLUSTER_TYPES as readonly string[]).includes(value)
+}

--- a/src/brain/src/clusters/infrastructure/http/clusters.controller.ts
+++ b/src/brain/src/clusters/infrastructure/http/clusters.controller.ts
@@ -9,7 +9,7 @@ import {
 import { Inject } from '@nestjs/common'
 import type { Cluster } from '@/clusters/domain/entities/Cluster'
 
-interface ClusterDto {
+export interface ClusterDto {
   id: string
   codigo: string
   titulo: string

--- a/src/brain/src/clusters/infrastructure/http/clusters.controller.ts
+++ b/src/brain/src/clusters/infrastructure/http/clusters.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, NotFoundException, Param, Post } from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import { ExplainCluster } from '@/clusters/application/use-cases/ExplainCluster'
+import { GenerateClusters } from '@/clusters/application/use-cases/GenerateClusters'
+import {
+  CLUSTER_REPOSITORY,
+  type ClusterRepository,
+} from '@/clusters/domain/repositories/ClusterRepository'
+import { Inject } from '@nestjs/common'
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+
+interface ClusterDto {
+  id: string
+  codigo: string
+  titulo: string
+  descripcion: string | null
+  tipo: string
+  ciiuDivision: string | null
+  ciiuGrupo: string | null
+  municipio: string | null
+  memberCount: number
+}
+
+@ApiTags('clusters')
+@Controller('clusters')
+export class ClustersController {
+  constructor(
+    private readonly generateClusters: GenerateClusters,
+    private readonly explainCluster: ExplainCluster,
+    @Inject(CLUSTER_REPOSITORY)
+    private readonly clusterRepo: ClusterRepository,
+  ) {}
+
+  @Post('generate')
+  @ApiOperation({ summary: 'Regenerate predefined and heuristic clusters' })
+  async generate(): Promise<{
+    predefinedClusters: number
+    heuristicClusters: number
+    totalMemberships: number
+  }> {
+    return this.generateClusters.execute()
+  }
+
+  @Get(':id/explain')
+  @ApiOperation({ summary: 'Get a human-readable description of a cluster' })
+  async explain(@Param('id') id: string): Promise<{ description: string }> {
+    const exists = await this.clusterRepo.findById(id)
+    if (!exists) throw new NotFoundException(`Cluster ${id} not found`)
+    return this.explainCluster.execute({ clusterId: id })
+  }
+}
+
+export function toClusterDto(c: Cluster): ClusterDto {
+  return {
+    id: c.id,
+    codigo: c.codigo,
+    titulo: c.titulo,
+    descripcion: c.descripcion,
+    tipo: c.tipo,
+    ciiuDivision: c.ciiuDivision,
+    ciiuGrupo: c.ciiuGrupo,
+    municipio: c.municipio,
+    memberCount: c.memberCount,
+  }
+}

--- a/src/brain/src/clusters/infrastructure/http/company-clusters.controller.ts
+++ b/src/brain/src/clusters/infrastructure/http/company-clusters.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Param } from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import { GetCompanyClusters } from '@/clusters/application/use-cases/GetCompanyClusters'
+import { toClusterDto } from '@/clusters/infrastructure/http/clusters.controller'
+
+@ApiTags('clusters')
+@Controller('companies')
+export class CompanyClustersController {
+  constructor(private readonly getCompanyClusters: GetCompanyClusters) {}
+
+  @Get(':id/clusters')
+  @ApiOperation({ summary: 'List clusters that contain a given company' })
+  async list(@Param('id') id: string) {
+    const { clusters } = await this.getCompanyClusters.execute({
+      companyId: id,
+    })
+    return clusters.map(toClusterDto)
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common'
+import type {
+  ClusterCiiuMapping,
+  ClusterCiiuMappingRepository,
+} from '@/clusters/domain/repositories/ClusterCiiuMappingRepository'
+
+@Injectable()
+export class InMemoryClusterCiiuMappingRepository implements ClusterCiiuMappingRepository {
+  private readonly store = new Set<string>()
+
+  private key(m: ClusterCiiuMapping): string {
+    return `${m.clusterId}::${m.ciiuCode}`
+  }
+
+  private parse(key: string): ClusterCiiuMapping {
+    const [clusterId, ciiuCode] = key.split('::')
+    return { clusterId, ciiuCode }
+  }
+
+  async saveMany(mappings: ClusterCiiuMapping[]): Promise<void> {
+    for (const m of mappings) {
+      this.store.add(this.key(m))
+    }
+  }
+
+  async findAll(): Promise<ClusterCiiuMapping[]> {
+    return Array.from(this.store).map((k) => this.parse(k))
+  }
+
+  async getCiiuToClusterMap(): Promise<Map<string, string[]>> {
+    const map = new Map<string, string[]>()
+    for (const key of this.store) {
+      const m = this.parse(key)
+      const arr = map.get(m.ciiuCode) ?? []
+      arr.push(m.clusterId)
+      map.set(m.ciiuCode, arr)
+    }
+    return map
+  }
+
+  async count(): Promise<number> {
+    return this.store.size
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common'
+import type {
+  ClusterMembershipRepository,
+  Membership,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+
+@Injectable()
+export class InMemoryClusterMembershipRepository implements ClusterMembershipRepository {
+  private readonly store = new Set<string>()
+
+  private key(m: Membership): string {
+    return `${m.clusterId}::${m.companyId}`
+  }
+
+  private parse(key: string): Membership {
+    const [clusterId, companyId] = key.split('::')
+    return { clusterId, companyId }
+  }
+
+  async saveMany(memberships: Membership[]): Promise<void> {
+    for (const m of memberships) {
+      this.store.add(this.key(m))
+    }
+  }
+
+  async findClusterIdsByCompany(companyId: string): Promise<string[]> {
+    const result: string[] = []
+    for (const key of this.store) {
+      const m = this.parse(key)
+      if (m.companyId === companyId) result.push(m.clusterId)
+    }
+    return result
+  }
+
+  async findCompanyIdsByCluster(clusterId: string): Promise<string[]> {
+    const result: string[] = []
+    for (const key of this.store) {
+      const m = this.parse(key)
+      if (m.clusterId === clusterId) result.push(m.companyId)
+    }
+    return result
+  }
+
+  async deleteAll(): Promise<void> {
+    this.store.clear()
+  }
+
+  async count(): Promise<number> {
+    return this.store.size
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterRepository.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import type { ClusterRepository } from '@/clusters/domain/repositories/ClusterRepository'
+import type { ClusterType } from '@/clusters/domain/value-objects/ClusterType'
+
+@Injectable()
+export class InMemoryClusterRepository implements ClusterRepository {
+  private readonly store = new Map<string, Cluster>()
+
+  async findAll(): Promise<Cluster[]> {
+    return Array.from(this.store.values())
+  }
+
+  async findById(id: string): Promise<Cluster | null> {
+    return this.store.get(id) ?? null
+  }
+
+  async findManyByIds(ids: string[]): Promise<Cluster[]> {
+    const set = new Set(ids)
+    return Array.from(this.store.values()).filter((c) => set.has(c.id))
+  }
+
+  async findByTipo(tipo: ClusterType): Promise<Cluster[]> {
+    return Array.from(this.store.values()).filter((c) => c.tipo === tipo)
+  }
+
+  async saveMany(clusters: Cluster[]): Promise<void> {
+    for (const c of clusters) {
+      this.store.set(c.id, c)
+    }
+  }
+
+  async updateDescripcion(id: string, descripcion: string): Promise<void> {
+    const existing = this.store.get(id)
+    if (!existing) return
+    const updated = Cluster.create({
+      id: existing.id,
+      codigo: existing.codigo,
+      titulo: existing.titulo,
+      descripcion,
+      tipo: existing.tipo,
+      ciiuDivision: existing.ciiuDivision,
+      ciiuGrupo: existing.ciiuGrupo,
+      municipio: existing.municipio,
+      macroSector: existing.macroSector,
+      memberCount: existing.memberCount,
+    })
+    this.store.set(id, updated)
+  }
+
+  async count(): Promise<number> {
+    return this.store.size
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterCiiuMappingRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterCiiuMappingRepository.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type {
+  ClusterCiiuMapping,
+  ClusterCiiuMappingRepository,
+} from '@/clusters/domain/repositories/ClusterCiiuMappingRepository'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'cluster_ciiu_mapping'
+const CHUNK_SIZE = 1000
+
+interface MappingRow {
+  cluster_id: string
+  ciiu_code: string
+}
+
+@Injectable()
+export class SupabaseClusterCiiuMappingRepository implements ClusterCiiuMappingRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async saveMany(mappings: ClusterCiiuMapping[]): Promise<void> {
+    if (mappings.length === 0) return
+    const rows: MappingRow[] = mappings.map((m) => ({
+      cluster_id: m.clusterId,
+      ciiu_code: m.ciiuCode,
+    }))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'cluster_id,ciiu_code' })
+      if (error) throw error
+    }
+  }
+
+  async findAll(): Promise<ClusterCiiuMapping[]> {
+    const { data, error } = await this.db.from(TABLE).select('*')
+    if (error) throw error
+    return ((data ?? []) as MappingRow[]).map((r) => ({
+      clusterId: r.cluster_id,
+      ciiuCode: r.ciiu_code,
+    }))
+  }
+
+  async getCiiuToClusterMap(): Promise<Map<string, string[]>> {
+    const all = await this.findAll()
+    const map = new Map<string, string[]>()
+    for (const m of all) {
+      const arr = map.get(m.ciiuCode) ?? []
+      arr.push(m.clusterId)
+      map.set(m.ciiuCode, arr)
+    }
+    return map
+  }
+
+  async count(): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+    if (error) throw error
+    return count ?? 0
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterMembershipRepository.ts
@@ -1,0 +1,68 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type {
+  ClusterMembershipRepository,
+  Membership,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'cluster_members'
+const CHUNK_SIZE = 1000
+
+interface MembershipRow {
+  cluster_id: string
+  company_id: string
+}
+
+@Injectable()
+export class SupabaseClusterMembershipRepository implements ClusterMembershipRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async saveMany(memberships: Membership[]): Promise<void> {
+    if (memberships.length === 0) return
+    const rows: MembershipRow[] = memberships.map((m) => ({
+      cluster_id: m.clusterId,
+      company_id: m.companyId,
+    }))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'cluster_id,company_id' })
+      if (error) throw error
+    }
+  }
+
+  async findClusterIdsByCompany(companyId: string): Promise<string[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('cluster_id')
+      .eq('company_id', companyId)
+    if (error) throw error
+    return ((data ?? []) as { cluster_id: string }[]).map((r) => r.cluster_id)
+  }
+
+  async findCompanyIdsByCluster(clusterId: string): Promise<string[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('company_id')
+      .eq('cluster_id', clusterId)
+    if (error) throw error
+    return ((data ?? []) as { company_id: string }[]).map((r) => r.company_id)
+  }
+
+  async deleteAll(): Promise<void> {
+    const { error } = await this.db.from(TABLE).delete().neq('cluster_id', '')
+    if (error) throw error
+  }
+
+  async count(): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+    if (error) throw error
+    return count ?? 0
+  }
+}

--- a/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterRepository.ts
@@ -1,0 +1,129 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import type { ClusterRepository } from '@/clusters/domain/repositories/ClusterRepository'
+import {
+  CLUSTER_TYPES,
+  type ClusterType,
+} from '@/clusters/domain/value-objects/ClusterType'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'clusters'
+const CHUNK_SIZE = 500
+
+interface ClusterRow {
+  id: string
+  codigo: string
+  titulo: string
+  descripcion: string | null
+  tipo: string
+  ciiu_division: string | null
+  ciiu_grupo: string | null
+  municipio: string | null
+  macro_sector: string | null
+  member_count: number
+}
+
+@Injectable()
+export class SupabaseClusterRepository implements ClusterRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async findAll(): Promise<Cluster[]> {
+    const { data, error } = await this.db.from(TABLE).select('*')
+    if (error) throw error
+    return ((data ?? []) as ClusterRow[]).map((r) => this.toEntity(r))
+  }
+
+  async findById(id: string): Promise<Cluster | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('id', id)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as ClusterRow) : null
+  }
+
+  async findManyByIds(ids: string[]): Promise<Cluster[]> {
+    if (ids.length === 0) return []
+    const { data, error } = await this.db.from(TABLE).select('*').in('id', ids)
+    if (error) throw error
+    return ((data ?? []) as ClusterRow[]).map((r) => this.toEntity(r))
+  }
+
+  async findByTipo(tipo: ClusterType): Promise<Cluster[]> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('tipo', tipo)
+    if (error) throw error
+    return ((data ?? []) as ClusterRow[]).map((r) => this.toEntity(r))
+  }
+
+  async saveMany(clusters: Cluster[]): Promise<void> {
+    if (clusters.length === 0) return
+    const rows = clusters.map((c) => this.toRow(c))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'id' })
+      if (error) throw error
+    }
+  }
+
+  async updateDescripcion(id: string, descripcion: string): Promise<void> {
+    const { error } = await this.db
+      .from(TABLE)
+      .update({ descripcion })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  async count(): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+    if (error) throw error
+    return count ?? 0
+  }
+
+  private toEntity(row: ClusterRow): Cluster {
+    if (!isClusterType(row.tipo)) {
+      throw new Error(`Unknown cluster tipo from DB: ${row.tipo}`)
+    }
+    return Cluster.create({
+      id: row.id,
+      codigo: row.codigo,
+      titulo: row.titulo,
+      descripcion: row.descripcion,
+      tipo: row.tipo,
+      ciiuDivision: row.ciiu_division,
+      ciiuGrupo: row.ciiu_grupo,
+      municipio: row.municipio,
+      macroSector: row.macro_sector,
+      memberCount: row.member_count,
+    })
+  }
+
+  private toRow(c: Cluster): ClusterRow {
+    return {
+      id: c.id,
+      codigo: c.codigo,
+      titulo: c.titulo,
+      descripcion: c.descripcion,
+      tipo: c.tipo,
+      ciiu_division: c.ciiuDivision,
+      ciiu_grupo: c.ciiuGrupo,
+      municipio: c.municipio,
+      macro_sector: c.macroSector,
+      member_count: c.memberCount,
+    }
+  }
+}
+
+function isClusterType(s: string): s is ClusterType {
+  return (CLUSTER_TYPES as readonly string[]).includes(s)
+}


### PR DESCRIPTION
## Summary

Phase 4 of the brain clustering engine — implements the **Clusters bounded context**: predefined cluster matching by CIIU code, dynamic heuristic clustering with a 2-level cascade (división ≥5, grupo ≥10), per-company cluster lookup, and AI-cached cluster explanations via Gemini.

- 9 commits, hexagonal layout (`domain/application/infrastructure`), TDD throughout.
- 107 new tests, full brain suite at **226/226** ✅
- 3 new HTTP endpoints wired into `AppModule`.

## What changed

**Domain**
- `Cluster` entity + `ClusterType` value object with per-tipo invariants (heuristic-grupo requires ciiuDivision/ciiuGrupo/municipio AND grupo must start with division digits).
- 3 ports: `ClusterRepository`, `ClusterMembershipRepository`, `ClusterCiiuMappingRepository` — each with a `Symbol` token.

**Application**
- `HeuristicClusterer` — 2-pass cascade (división then grupo), Unicode-aware municipio slug.
- `PredefinedClusterMatcher` — assigns companies to seeded predefined clusters via `cluster_ciiu_mapping`.
- `GenerateClusters` use case — orchestrates both matchers, filters `estado='ACTIVO'`, wipes memberships before regen, refreshes predefined `memberCount`.
- `GetCompanyClusters` + `ExplainCluster` use cases. `ExplainCluster` short-circuits on cached `descripcion` and persists fresh Gemini output via `updateDescripcion`.

**Infrastructure**
- `Supabase*` and `InMemory*` adapters for the 3 repositories.
- `ClustersController` (`POST /clusters/generate`, `GET /clusters/:id/explain`) and `CompanyClustersController` (`GET /companies/:id/clusters`).
- `ClustersModule` wired into `AppModule`.

## Endpoints

| Method | Path | Use case |
|--------|------|----------|
| POST | `/clusters/generate` | `GenerateClusters` |
| GET | `/clusters/:id/explain` | `ExplainCluster` (cached or Gemini) |
| GET | `/companies/:id/clusters` | `GetCompanyClusters` |

## Test plan

- [x] `bun --filter brain test:run` — 226/226 passing
- [x] `bun --filter brain typecheck` clean
- [ ] Smoke test `POST /clusters/generate` against staging Supabase once env is set
- [ ] Smoke test `GET /clusters/:id/explain` with both cached and uncached clusters
- [ ] Verify `cluster_members` row count matches the returned `totalMemberships`

## Notes

- Predefined clusters are NEVER created by the engine — they are seeded externally; only their `memberCount` is refreshed.
- `deleteAll()` on memberships before regen is intentional: full re-cluster, no stale rows.
- `ClusterMembershipRepository.deleteAll()` uses Supabase `.neq('cluster_id', '')` to delete unbounded.
- Phase 5 (Recommendations) and Phase 4 are independent — this PR unblocks both.

Plan reference: `docs/2026-04-25-brain-clustering-engine-implementation.md` lines 2017–2449.