### PR TITLE
feat(brain): phase 5 recommendations context

### DIFF
--- a/src/brain/__tests__/recommendations/AiMatchCacheEntry.test.ts
+++ b/src/brain/__tests__/recommendations/AiMatchCacheEntry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AiMatchCacheEntry,
+  type CreateAiMatchCacheEntryInput,
+} from '@/recommendations/domain/entities/AiMatchCacheEntry'
+
+const validInput = (
+  overrides: Partial<CreateAiMatchCacheEntryInput> = {},
+): CreateAiMatchCacheEntryInput => ({
+  ciiuOrigen: '0122',
+  ciiuDestino: '4631',
+  hasMatch: true,
+  relationType: 'cliente',
+  confidence: 0.85,
+  reason: 'Banano hacia mayoristas',
+  ...overrides,
+})
+
+describe('AiMatchCacheEntry', () => {
+  it('creates a positive match entry with all fields', () => {
+    const entry = AiMatchCacheEntry.create(validInput())
+
+    expect(entry.ciiuOrigen).toBe('0122')
+    expect(entry.ciiuDestino).toBe('4631')
+    expect(entry.hasMatch).toBe(true)
+    expect(entry.relationType).toBe('cliente')
+    expect(entry.confidence).toBe(0.85)
+    expect(entry.reason).toBe('Banano hacia mayoristas')
+    expect(entry.cachedAt).toBeInstanceOf(Date)
+  })
+
+  it('creates a negative match entry without relationType', () => {
+    const entry = AiMatchCacheEntry.create(
+      validInput({
+        hasMatch: false,
+        relationType: null,
+        confidence: null,
+        reason: null,
+      }),
+    )
+
+    expect(entry.hasMatch).toBe(false)
+    expect(entry.relationType).toBeNull()
+    expect(entry.confidence).toBeNull()
+    expect(entry.reason).toBeNull()
+  })
+
+  it('uses provided cachedAt when given', () => {
+    const at = new Date('2026-04-25T12:00:00Z')
+    const entry = AiMatchCacheEntry.create(validInput({ cachedAt: at }))
+    expect(entry.cachedAt).toEqual(at)
+  })
+
+  it('rejects empty ciiuOrigen and ciiuDestino', () => {
+    expect(() =>
+      AiMatchCacheEntry.create(validInput({ ciiuOrigen: '' })),
+    ).toThrow('AiMatchCacheEntry.ciiuOrigen cannot be empty')
+    expect(() =>
+      AiMatchCacheEntry.create(validInput({ ciiuDestino: '   ' })),
+    ).toThrow('AiMatchCacheEntry.ciiuDestino cannot be empty')
+  })
+
+  it('rejects positive matches without a relationType', () => {
+    expect(() =>
+      AiMatchCacheEntry.create(
+        validInput({ hasMatch: true, relationType: null }),
+      ),
+    ).toThrow('AiMatchCacheEntry with hasMatch=true requires a relationType')
+  })
+
+  it('rejects confidence outside 0..1', () => {
+    expect(() =>
+      AiMatchCacheEntry.create(validInput({ confidence: -0.1 })),
+    ).toThrow('AiMatchCacheEntry.confidence must be between 0 and 1')
+    expect(() =>
+      AiMatchCacheEntry.create(validInput({ confidence: 1.2 })),
+    ).toThrow('AiMatchCacheEntry.confidence must be between 0 and 1')
+  })
+
+  it('exposes a stable composite key', () => {
+    const entry = AiMatchCacheEntry.create(validInput())
+    expect(entry.key).toBe('0122->4631')
+  })
+})

--- a/src/brain/__tests__/recommendations/AiMatchEngine.test.ts
+++ b/src/brain/__tests__/recommendations/AiMatchEngine.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+const mayorista = CiiuActivity.create({
+  code: '4631',
+  titulo: 'Mayorista alimentos',
+  seccion: 'G',
+  division: '46',
+  grupo: '463',
+  tituloSeccion: 'Comercio',
+  tituloDivision: 'Mayorista',
+  tituloGrupo: 'Alimentos',
+})
+
+const restaurante = CiiuActivity.create({
+  code: '5611',
+  titulo: 'Restaurantes',
+  seccion: 'I',
+  division: '56',
+  grupo: '561',
+  tituloSeccion: 'Alojamiento',
+  tituloDivision: 'Comidas',
+  tituloGrupo: 'Restaurantes',
+})
+
+describe('AiMatchEngine', () => {
+  it('short-circuits to referente when ciiuOrigen === ciiuDestino without calling Gemini', async () => {
+    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository()
+    const spy = vi.spyOn(gemini, 'inferStructured')
+
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+    const result = await engine.evaluate('5611', '5611')
+
+    expect(result.hasMatch).toBe(true)
+    expect(result.relationType).toBe('referente')
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8)
+    expect(spy).not.toHaveBeenCalled()
+    expect(await cache.size()).toBe(1)
+  })
+
+  it('caches the result on second call with the same pair', async () => {
+    const gemini = new StubGeminiAdapter('', {
+      has_match: true,
+      relation_type: 'cliente',
+      confidence: 0.85,
+      reason: 'mayorista vende a restaurante',
+    })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+      mayorista,
+      restaurante,
+    ])
+    const spy = vi.spyOn(gemini, 'inferStructured')
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    const r1 = await engine.evaluate('4631', '5611')
+    expect(r1.hasMatch).toBe(true)
+    expect(r1.relationType).toBe('cliente')
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    const r2 = await engine.evaluate('4631', '5611')
+    expect(r2.relationType).toBe('cliente')
+    expect(r2.confidence).toBe(0.85)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns no-match when CIIU origen is missing in DIAN taxonomy', async () => {
+    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository()
+    const spy = vi.spyOn(gemini, 'inferStructured')
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    const result = await engine.evaluate('9999', '8888')
+    expect(result.hasMatch).toBe(false)
+    expect(result.confidence).toBe(0)
+    expect(result.relationType).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+    expect(await cache.size()).toBe(1)
+  })
+
+  it('returns no-match when only one CIIU is missing', async () => {
+    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([mayorista])
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    const result = await engine.evaluate('4631', '8888')
+    expect(result.hasMatch).toBe(false)
+  })
+
+  it('includes applicable rules in the prompt as guidance', async () => {
+    let capturedPrompt = ''
+    const gemini = new StubGeminiAdapter('', {
+      has_match: true,
+      relation_type: 'cliente',
+      confidence: 0.9,
+      reason: 'x',
+    })
+    const original = gemini.inferStructured.bind(gemini)
+    gemini.inferStructured = async (prompt, validate) => {
+      capturedPrompt = prompt
+      return original(prompt, validate)
+    }
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+      mayorista,
+      restaurante,
+    ])
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    await engine.evaluate('4631', '5611')
+    expect(capturedPrompt).toContain(
+      'Mayorista de alimentos abastece restaurantes',
+    )
+    expect(capturedPrompt).toContain('CIIU 4631')
+    expect(capturedPrompt).toContain('CIIU 5611')
+  })
+
+  it('falls back to "no rules apply" message when no rules match the pair', async () => {
+    let capturedPrompt = ''
+    const gemini = new StubGeminiAdapter('', {
+      has_match: false,
+      relation_type: null,
+      confidence: 0,
+      reason: 'no relation',
+    })
+    gemini.inferStructured = async (prompt, validate) => {
+      capturedPrompt = prompt
+      return validate({
+        has_match: false,
+        relation_type: null,
+        confidence: 0,
+        reason: 'no relation',
+      })
+    }
+    const educacion = CiiuActivity.create({
+      code: '8512',
+      titulo: 'Educación primaria',
+      seccion: 'P',
+      division: '85',
+      grupo: '851',
+      tituloSeccion: 'Educación',
+      tituloDivision: 'Educación',
+      tituloGrupo: 'Educación primaria',
+    })
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([mayorista, educacion])
+    const engine = new AiMatchEngine(
+      gemini,
+      new InMemoryAiMatchCacheRepository(),
+      ciiuRepo,
+    )
+
+    await engine.evaluate('4631', '8512')
+    expect(capturedPrompt).toContain('ninguna regla')
+  })
+
+  it('clamps confidence into 0..1 range', async () => {
+    const gemini = new StubGeminiAdapter('', {
+      has_match: true,
+      relation_type: 'cliente',
+      confidence: 1.5,
+      reason: 'r',
+    })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+      mayorista,
+      restaurante,
+    ])
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    const result = await engine.evaluate('4631', '5611')
+    expect(result.confidence).toBe(1)
+  })
+
+  it('treats invalid relation_type from Gemini as null', async () => {
+    const gemini = new StubGeminiAdapter('', {
+      has_match: true,
+      relation_type: 'enemigo',
+      confidence: 0.7,
+      reason: 'r',
+    })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+      mayorista,
+      restaurante,
+    ])
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    const result = await engine.evaluate('4631', '5611')
+    expect(result.relationType).toBeNull()
+  })
+
+  it('persists the cache entry after Gemini call', async () => {
+    const gemini = new StubGeminiAdapter('', {
+      has_match: true,
+      relation_type: 'cliente',
+      confidence: 0.85,
+      reason: 'r',
+    })
+    const cache = new InMemoryAiMatchCacheRepository()
+    const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+      mayorista,
+      restaurante,
+    ])
+    const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+
+    await engine.evaluate('4631', '5611')
+    const entry = await cache.get('4631', '5611')
+    expect(entry).not.toBeNull()
+    expect(entry!.hasMatch).toBe(true)
+    expect(entry!.relationType).toBe('cliente')
+  })
+})

--- a/src/brain/__tests__/recommendations/AllianceMatcher.test.ts
+++ b/src/brain/__tests__/recommendations/AllianceMatcher.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c1',
+    razonSocial: 'Acme',
+    ciiu: 'I5511',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+describe('AllianceMatcher', () => {
+  const matcher = new AllianceMatcher()
+
+  it('pairs companies that share an ecosystem with relationType aliado from ecosystem source', () => {
+    const hotel = company({ id: 'hotel', ciiu: 'I5511' })
+    const transporte = company({ id: 'tr', ciiu: 'H4921' })
+    const result = matcher.match([hotel, transporte])
+
+    const hotelRecs = result.get('hotel') ?? []
+    expect(hotelRecs.length).toBeGreaterThan(0)
+    expect(hotelRecs[0].relationType).toBe('aliado')
+    expect(hotelRecs[0].source).toBe('ecosystem')
+    expect(hotelRecs[0].targetCompanyId).toBe('tr')
+  })
+
+  it('does not pair companies of the same ciiu (would be referente, not aliado)', () => {
+    const hotel1 = company({ id: 'h1', ciiu: 'I5511' })
+    const hotel2 = company({ id: 'h2', ciiu: 'I5511' })
+    const result = matcher.match([hotel1, hotel2])
+
+    expect(result.get('h1') ?? []).toEqual([])
+  })
+
+  it('boosts score when companies share municipio', () => {
+    const hotel = company({
+      id: 'hotel',
+      ciiu: 'I5511',
+      municipio: 'SANTA MARTA',
+    })
+    const trSm = company({
+      id: 'trSm',
+      ciiu: 'H4921',
+      municipio: 'SANTA MARTA',
+    })
+    const trBog = company({ id: 'trBog', ciiu: 'H4921', municipio: 'BOGOTA' })
+
+    const result = matcher.match([hotel, trSm, trBog])
+    const recs = result.get('hotel') ?? []
+    const sm = recs.find((r) => r.targetCompanyId === 'trSm')!
+    const bog = recs.find((r) => r.targetCompanyId === 'trBog')!
+    expect(sm.score).toBeGreaterThan(bog.score)
+  })
+
+  it('attaches an ecosistema_compartido reason carrying the ecosystem id', () => {
+    const hotel = company({ id: 'hotel', ciiu: 'I5511' })
+    const transporte = company({ id: 'tr', ciiu: 'H4921' })
+    const result = matcher.match([hotel, transporte])
+
+    const reasons = result.get('hotel')![0].reasons.toJson()
+    expect(reasons[0].feature).toBe('ecosistema_compartido')
+    expect(reasons[0].value).toBe('turismo')
+  })
+
+  it('emits both directions of the alliance', () => {
+    const hotel = company({ id: 'hotel', ciiu: 'I5511' })
+    const transporte = company({ id: 'tr', ciiu: 'H4921' })
+    const result = matcher.match([hotel, transporte])
+
+    const hotelTargets = (result.get('hotel') ?? []).map(
+      (r) => r.targetCompanyId,
+    )
+    const trTargets = (result.get('tr') ?? []).map((r) => r.targetCompanyId)
+    expect(hotelTargets).toContain('tr')
+    expect(trTargets).toContain('hotel')
+  })
+
+  it('returns no recommendations when no two companies share an ecosystem', () => {
+    const a = company({ id: 'a', ciiu: 'P8512' })
+    const b = company({ id: 'b', ciiu: 'A0122' })
+    const result = matcher.match([a, b])
+    expect(result.get('a') ?? []).toEqual([])
+    expect(result.get('b') ?? []).toEqual([])
+  })
+
+  it('produces unique recommendation ids', () => {
+    const hotel = company({ id: 'hotel', ciiu: 'I5511' })
+    const tr = company({ id: 'tr', ciiu: 'H4921' })
+    const rest = company({ id: 'rest', ciiu: 'I5611' })
+    const result = matcher.match([hotel, tr, rest])
+    const ids = (result.get('hotel') ?? []).map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/src/brain/__tests__/recommendations/CandidateSelector.test.ts
+++ b/src/brain/__tests__/recommendations/CandidateSelector.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import {
+  CandidateSelector,
+  canonicalPair,
+} from '@/recommendations/application/services/CandidateSelector'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c1',
+    razonSocial: 'Acme',
+    ciiu: 'G4631',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+describe('canonicalPair', () => {
+  it('orders ciius alphabetically to produce a symmetric key', () => {
+    expect(canonicalPair('5611', '4631')).toBe('4631|5611')
+    expect(canonicalPair('4631', '5611')).toBe('4631|5611')
+  })
+
+  it('returns same key when ciius are equal', () => {
+    expect(canonicalPair('5611', '5611')).toBe('5611|5611')
+  })
+})
+
+describe('CandidateSelector.selectCiiuPairs', () => {
+  const selector = new CandidateSelector()
+
+  it('produces auto-pairs for each distinct ciiu (referente)', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'G4631' }),
+      company({ id: 'c2', ciiu: 'I5611' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+
+    expect(pairs.has('4631|4631')).toBe(true)
+    expect(pairs.has('5611|5611')).toBe(true)
+  })
+
+  it('pairs ciius from the same division', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'I5611' }),
+      company({ id: 'c2', ciiu: 'I5630' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+
+    expect(pairs.has(canonicalPair('5611', '5630'))).toBe(true)
+  })
+
+  it('pairs ciius linked through a value chain rule', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'A0122' }),
+      company({ id: 'c2', ciiu: 'G4631' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+    expect(pairs.has(canonicalPair('0122', '4631'))).toBe(true)
+  })
+
+  it('pairs ciius via wildcard rule (target = *)', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'M6910' }),
+      company({ id: 'c2', ciiu: 'P8512' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+    expect(pairs.has(canonicalPair('6910', '8512'))).toBe(true)
+  })
+
+  it('pairs ciius that share an ecosystem', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'I5511' }),
+      company({ id: 'c2', ciiu: 'L6810' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+    expect(pairs.has(canonicalPair('5511', '6810'))).toBe(true)
+  })
+
+  it('does not pair unrelated ciius from different divisions, no rules, no ecosystems', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'A0122' }),
+      company({ id: 'c2', ciiu: 'P8551' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+    expect(pairs.has(canonicalPair('0122', '8551'))).toBe(false)
+  })
+
+  it('deduplicates when many companies share the same ciiu', () => {
+    const companies = [
+      company({ id: 'c1', ciiu: 'G4631' }),
+      company({ id: 'c2', ciiu: 'G4631' }),
+      company({ id: 'c3', ciiu: 'G4631' }),
+    ]
+    const pairs = selector.selectCiiuPairs(companies)
+    expect(pairs.size).toBe(1)
+    expect(pairs.has('4631|4631')).toBe(true)
+  })
+})
+
+describe('CandidateSelector.selectTargetCompanies', () => {
+  const selector = new CandidateSelector()
+  const source = company({
+    id: 'src',
+    ciiu: 'G4631',
+    municipio: 'SANTA MARTA',
+  })
+
+  it('excludes the source company itself', () => {
+    const cache = new Map([[canonicalPair('4631', '4631'), { hasMatch: true }]])
+    const result = selector.selectTargetCompanies(source, [source], cache)
+    expect(result).toEqual([])
+  })
+
+  it('keeps only companies with hasMatch=true in the cache', () => {
+    const t1 = company({ id: 't1', ciiu: 'I5611', municipio: 'SANTA MARTA' })
+    const t2 = company({ id: 't2', ciiu: 'P8551', municipio: 'BOGOTÁ' })
+    const cache = new Map<string, { hasMatch: boolean }>([
+      [canonicalPair('4631', '5611'), { hasMatch: true }],
+      [canonicalPair('4631', '8551'), { hasMatch: false }],
+    ])
+    const result = selector.selectTargetCompanies(
+      source,
+      [source, t1, t2],
+      cache,
+    )
+    expect(result.map((c) => c.id)).toEqual(['t1'])
+  })
+
+  it('sorts by proximity score (same municipio + same ciiuDivision gain priority)', () => {
+    const near = company({
+      id: 'near',
+      ciiu: 'G4719',
+      municipio: 'SANTA MARTA',
+    })
+    const far = company({
+      id: 'far',
+      ciiu: 'G4719',
+      municipio: 'CARTAGENA',
+    })
+    const cache = new Map<string, { hasMatch: boolean }>([
+      [canonicalPair('4631', '4719'), { hasMatch: true }],
+    ])
+    const result = selector.selectTargetCompanies(
+      source,
+      [source, far, near],
+      cache,
+    )
+    expect(result.map((c) => c.id)).toEqual(['near', 'far'])
+  })
+
+  it('respects the topN parameter', () => {
+    const targets = Array.from({ length: 5 }, (_, i) =>
+      company({ id: `t${i}`, ciiu: 'I5611', municipio: 'SANTA MARTA' }),
+    )
+    const cache = new Map<string, { hasMatch: boolean }>([
+      [canonicalPair('4631', '5611'), { hasMatch: true }],
+    ])
+    const result = selector.selectTargetCompanies(
+      source,
+      [source, ...targets],
+      cache,
+      2,
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it('uses the default topN of 30 when not specified', () => {
+    const targets = Array.from({ length: 50 }, (_, i) =>
+      company({ id: `t${i}`, ciiu: 'I5611', municipio: 'SANTA MARTA' }),
+    )
+    const cache = new Map<string, { hasMatch: boolean }>([
+      [canonicalPair('4631', '5611'), { hasMatch: true }],
+    ])
+    const result = selector.selectTargetCompanies(
+      source,
+      [source, ...targets],
+      cache,
+    )
+    expect(result).toHaveLength(30)
+  })
+
+  it('treats absent cache entries as no-match', () => {
+    const t1 = company({ id: 't1', ciiu: 'I5611' })
+    const cache = new Map<string, { hasMatch: boolean }>()
+    const result = selector.selectTargetCompanies(source, [source, t1], cache)
+    expect(result).toEqual([])
+  })
+})

--- a/src/brain/__tests__/recommendations/CiiuPairEvaluator.test.ts
+++ b/src/brain/__tests__/recommendations/CiiuPairEvaluator.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
+import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+const ciius = [
+  ['4631', 'Mayorista', 'G', '46', '463'],
+  ['5611', 'Restaurantes', 'I', '56', '561'],
+  ['0122', 'Banano', 'A', '01', '012'],
+  ['4720', 'Minorista', 'G', '47', '472'],
+] as const
+
+const ciiuRepo = (() => {
+  const repo = new InMemoryCiiuTaxonomyRepository(
+    ciius.map(([code, titulo, seccion, division, grupo]) =>
+      CiiuActivity.create({
+        code,
+        titulo,
+        seccion,
+        division,
+        grupo,
+        tituloSeccion: 'x',
+        tituloDivision: 'x',
+        tituloGrupo: 'x',
+      }),
+    ),
+  )
+  return repo
+})()
+
+function newSetup() {
+  const cache = new InMemoryAiMatchCacheRepository()
+  const gemini = new StubGeminiAdapter('', {
+    has_match: true,
+    relation_type: 'cliente',
+    confidence: 0.8,
+    reason: 'r',
+  })
+  const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
+  const evaluator = new CiiuPairEvaluator(engine, cache)
+  return { cache, gemini, engine, evaluator }
+}
+
+describe('CiiuPairEvaluator.evaluateAll', () => {
+  it('evaluates every pair when cache is empty', async () => {
+    const { evaluator, gemini } = newSetup()
+    const spy = vi.spyOn(gemini, 'inferStructured')
+
+    const stats = await evaluator.evaluateAll(
+      new Set(['4631|5611', '0122|4631']),
+    )
+
+    expect(stats.total).toBe(2)
+    expect(stats.evaluated).toBe(2)
+    expect(stats.cached).toBe(0)
+    expect(stats.errors).toBe(0)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips pairs that are already cached', async () => {
+    const { cache, evaluator, gemini } = newSetup()
+    await cache.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '4631',
+        ciiuDestino: '5611',
+        hasMatch: true,
+        relationType: 'cliente',
+        confidence: 0.9,
+      }),
+    )
+    const spy = vi.spyOn(gemini, 'inferStructured')
+
+    const stats = await evaluator.evaluateAll(
+      new Set(['4631|5611', '0122|4631']),
+    )
+
+    expect(stats.cached).toBe(1)
+    expect(stats.evaluated).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports errors without aborting other pairs', async () => {
+    const { evaluator, engine } = newSetup()
+    const original = engine.evaluate.bind(engine)
+    vi.spyOn(engine, 'evaluate').mockImplementation(async (a, b) => {
+      if (a === '0122' && b === '4631') throw new Error('boom')
+      return original(a, b)
+    })
+
+    const stats = await evaluator.evaluateAll(
+      new Set(['4631|5611', '0122|4631']),
+    )
+
+    expect(stats.errors).toBe(1)
+    expect(stats.evaluated).toBe(1)
+  })
+
+  it('invokes onProgress for every completed pair', async () => {
+    const { evaluator } = newSetup()
+    const calls: Array<[number, number]> = []
+
+    await evaluator.evaluateAll(new Set(['4631|5611', '0122|4631']), {
+      onProgress: (done, total) => calls.push([done, total]),
+    })
+
+    expect(calls).toHaveLength(2)
+    expect(calls[calls.length - 1]).toEqual([2, 2])
+  })
+
+  it('returns zero counts when given an empty set', async () => {
+    const { evaluator } = newSetup()
+    const stats = await evaluator.evaluateAll(new Set())
+    expect(stats).toEqual({ total: 0, cached: 0, evaluated: 0, errors: 0 })
+  })
+
+  it('respects concurrency by limiting in-flight workers', async () => {
+    const { evaluator, engine } = newSetup()
+    let inFlight = 0
+    let peak = 0
+    vi.spyOn(engine, 'evaluate').mockImplementation(async () => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((r) => setTimeout(r, 5))
+      inFlight--
+      return {
+        hasMatch: true,
+        relationType: 'cliente',
+        confidence: 0.8,
+        reason: 'r',
+      }
+    })
+
+    const pairs = new Set([
+      '4631|5611',
+      '0122|4631',
+      '4631|4720',
+      '0122|5611',
+      '4720|5611',
+      '0122|4720',
+    ])
+    await evaluator.evaluateAll(pairs, { concurrency: 2 })
+
+    expect(peak).toBeLessThanOrEqual(2)
+  })
+})

--- a/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
+++ b/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { ExplainRecommendation } from '@/recommendations/application/use-cases/ExplainRecommendation'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c',
+    razonSocial: 'Acme',
+    ciiu: 'I5611',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+const recommendation = (
+  overrides: Partial<{
+    id: string
+    sourceCompanyId: string
+    targetCompanyId: string
+    explanation: string | null
+  }> = {},
+): Recommendation =>
+  Recommendation.create({
+    id: overrides.id ?? 'rec-1',
+    sourceCompanyId: overrides.sourceCompanyId ?? 'src',
+    targetCompanyId: overrides.targetCompanyId ?? 'tgt',
+    relationType: 'cliente',
+    score: 0.85,
+    reasons: Reasons.from([
+      {
+        feature: 'cadena_valor_directa',
+        weight: 0.85,
+        description: 'Banano hacia mayoristas',
+      },
+    ]),
+    source: 'rule',
+    explanation: overrides.explanation ?? null,
+  })
+
+describe('ExplainRecommendation', () => {
+  let recRepo: InMemoryRecommendationRepository
+  let companyRepo: InMemoryCompanyRepository
+  let gemini: StubGeminiAdapter
+  let useCase: ExplainRecommendation
+
+  beforeEach(async () => {
+    recRepo = new InMemoryRecommendationRepository()
+    companyRepo = new InMemoryCompanyRepository()
+    gemini = new StubGeminiAdapter('Generated explanation from Gemini')
+    useCase = new ExplainRecommendation(recRepo, companyRepo, gemini)
+
+    await companyRepo.saveMany([
+      company({ id: 'src', razonSocial: 'Banano SA', ciiu: 'A0122' }),
+      company({ id: 'tgt', razonSocial: 'Mayorista SA', ciiu: 'G4631' }),
+    ])
+    await recRepo.saveAll([recommendation()])
+  })
+
+  it('returns the cached explanation without calling Gemini', async () => {
+    await recRepo.updateExplanation('rec-1', 'cached explanation')
+    const spy = vi.spyOn(gemini, 'generateText')
+
+    const result = await useCase.execute({ recommendationId: 'rec-1' })
+    expect(result.explanation).toBe('cached explanation')
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('calls Gemini and persists the explanation when missing', async () => {
+    const spy = vi.spyOn(gemini, 'generateText')
+    const result = await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(result.explanation).toBe('Generated explanation from Gemini')
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    const persisted = await recRepo.findById('rec-1')
+    expect(persisted!.explanation).toBe('Generated explanation from Gemini')
+  })
+
+  it('builds the prompt with both companies and the relation type', async () => {
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured).toContain('Banano SA')
+    expect(captured).toContain('Mayorista SA')
+    expect(captured).toContain('CIIU 0122')
+    expect(captured).toContain('CIIU 4631')
+    expect(captured).toContain('cliente')
+  })
+
+  it('throws when the recommendation does not exist', async () => {
+    await expect(
+      useCase.execute({ recommendationId: 'missing' }),
+    ).rejects.toThrow(/Recommendation not found/)
+  })
+
+  it('throws when source or target company is missing', async () => {
+    await recRepo.saveAll([
+      recommendation({
+        id: 'orphan',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'ghost',
+      }),
+    ])
+    await expect(
+      useCase.execute({ recommendationId: 'orphan' }),
+    ).rejects.toThrow(/Companies not found/)
+  })
+})

--- a/src/brain/__tests__/recommendations/FeatureVectorBuilder.test.ts
+++ b/src/brain/__tests__/recommendations/FeatureVectorBuilder.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c1',
+    razonSocial: 'Acme',
+    ciiu: 'G4631',
+    municipio: 'SANTA MARTA',
+    personal: 10,
+    ingresoOperacion: 1_000_000,
+    activosTotales: 1_000_000,
+    fechaMatricula: new Date('2020-01-01'),
+    ...overrides,
+  })
+
+describe('FeatureVectorBuilder.build', () => {
+  const builder = new FeatureVectorBuilder()
+
+  it('extracts ciiu fields, municipio, etapa ordinal, and log-normalized magnitudes', () => {
+    const c = company()
+    const v = builder.build(c)
+
+    expect(v.ciiuClase).toBe('4631')
+    expect(v.ciiuDivision).toBe('46')
+    expect(v.ciiuSeccion).toBe('G')
+    expect(v.municipio).toBe('SANTA MARTA')
+    expect(v.etapaOrdinal).toBeGreaterThanOrEqual(1)
+    expect(v.etapaOrdinal).toBeLessThanOrEqual(4)
+    expect(v.personalLog).toBeGreaterThanOrEqual(0)
+    expect(v.personalLog).toBeLessThanOrEqual(1)
+    expect(v.ingresoLog).toBeGreaterThanOrEqual(0)
+    expect(v.ingresoLog).toBeLessThanOrEqual(1)
+  })
+
+  it('clamps personal/ingreso below or above the normalization range', () => {
+    const small = builder.build(company({ personal: 0, ingresoOperacion: 0 }))
+    expect(small.personalLog).toBe(0)
+    expect(small.ingresoLog).toBe(0)
+
+    const huge = builder.build(
+      company({ personal: 1_000_000, ingresoOperacion: 1e15 }),
+    )
+    expect(huge.personalLog).toBe(1)
+    expect(huge.ingresoLog).toBe(1)
+  })
+
+  it('maps each canonical etapa to a distinct ordinal in 1..4', () => {
+    const ordinals = new Set<number>()
+    for (const fechaMatricula of [
+      new Date('2025-06-01'),
+      new Date('2022-01-01'),
+      new Date('2017-01-01'),
+      new Date('2005-01-01'),
+    ]) {
+      ordinals.add(
+        builder.build(
+          company({
+            fechaMatricula,
+            personal: 5,
+            ingresoOperacion: 100_000,
+          }),
+        ).etapaOrdinal,
+      )
+    }
+    expect(ordinals.size).toBeGreaterThan(1)
+    for (const o of ordinals) {
+      expect([1, 2, 3, 4]).toContain(o)
+    }
+  })
+})
+
+describe('FeatureVectorBuilder.proximity', () => {
+  const builder = new FeatureVectorBuilder()
+
+  it('returns ~1 for identical vectors', () => {
+    const v = builder.build(company())
+    expect(builder.proximity(v, v)).toBeCloseTo(1, 5)
+  })
+
+  it('weighs same municipio more than same etapa', () => {
+    const a = builder.build(company({ id: 'a' }))
+    const sameMunicipio = builder.build(
+      company({
+        id: 'b',
+        municipio: 'SANTA MARTA',
+        fechaMatricula: new Date('2005-01-01'),
+        personal: 200,
+        ingresoOperacion: 500_000_000,
+      }),
+    )
+    const sameEtapa = builder.build(
+      company({
+        id: 'c',
+        municipio: 'CARTAGENA',
+        fechaMatricula:
+          a.etapaOrdinal === 2
+            ? new Date('2020-01-01')
+            : new Date('2022-01-01'),
+        personal: 200,
+        ingresoOperacion: 500_000_000,
+      }),
+    )
+    expect(builder.proximity(a, sameMunicipio)).toBeGreaterThan(
+      builder.proximity(a, sameEtapa),
+    )
+  })
+
+  it('caps at 1', () => {
+    const a = builder.build(company({ id: 'a' }))
+    const b = builder.build(company({ id: 'b' }))
+    expect(builder.proximity(a, b)).toBeLessThanOrEqual(1)
+  })
+
+  it('drops to lower scores when municipio and etapa differ and magnitudes are far apart', () => {
+    const a = builder.build(
+      company({ id: 'a', personal: 1, ingresoOperacion: 100 }),
+    )
+    const b = builder.build(
+      company({
+        id: 'b',
+        municipio: 'CARTAGENA',
+        fechaMatricula: new Date('2005-01-01'),
+        personal: 5000,
+        ingresoOperacion: 1e13,
+      }),
+    )
+    expect(builder.proximity(a, b)).toBeLessThan(0.5)
+  })
+})

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { CandidateSelector } from '@/recommendations/application/services/CandidateSelector'
+import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c',
+    razonSocial: 'Acme',
+    ciiu: 'I5611',
+    municipio: 'SANTA MARTA',
+    personal: 5,
+    ingresoOperacion: 50_000_000,
+    fechaMatricula: new Date('2022-01-01'),
+    ...overrides,
+  })
+
+const ciius = [
+  ['0122', 'A', '01', '012', 'Banano'],
+  ['4631', 'G', '46', '463', 'Mayorista'],
+  ['5611', 'I', '56', '561', 'Restaurante'],
+  ['4921', 'H', '49', '492', 'Transporte turistico'],
+  ['5511', 'I', '55', '551', 'Hoteles'],
+  ['1071', 'C', '10', '107', 'Panaderia'],
+] as const
+
+function makeCiiuRepo() {
+  return new InMemoryCiiuTaxonomyRepository(
+    ciius.map(([code, seccion, division, grupo, titulo]) =>
+      CiiuActivity.create({
+        code,
+        titulo,
+        seccion,
+        division,
+        grupo,
+        tituloSeccion: 'x',
+        tituloDivision: 'x',
+        tituloGrupo: 'x',
+      }),
+    ),
+  )
+}
+
+function makeSetup({
+  matchResponse,
+}: {
+  matchResponse?: Record<string, unknown>
+} = {}) {
+  const companyRepo = new InMemoryCompanyRepository()
+  const recRepo = new InMemoryRecommendationRepository()
+  const cache = new InMemoryAiMatchCacheRepository()
+  const ciiuRepo = makeCiiuRepo()
+  const gemini = new StubGeminiAdapter(
+    '',
+    matchResponse ?? {
+      has_match: true,
+      relation_type: 'cliente',
+      confidence: 0.85,
+      reason: 'mayorista vende a restaurante',
+    },
+  )
+  const aiEngine = new AiMatchEngine(gemini, cache, ciiuRepo)
+  const evaluator = new CiiuPairEvaluator(aiEngine, cache)
+  const selector = new CandidateSelector()
+  const featureBuilder = new FeatureVectorBuilder()
+  const peer = new PeerMatcher(featureBuilder)
+  const valueChain = new ValueChainMatcher()
+  const alliance = new AllianceMatcher()
+  const useCase = new GenerateRecommendations(
+    companyRepo,
+    recRepo,
+    cache,
+    selector,
+    evaluator,
+    featureBuilder,
+    peer,
+    valueChain,
+    alliance,
+  )
+  return {
+    useCase,
+    companyRepo,
+    recRepo,
+    cache,
+    aiEngine,
+    gemini,
+    evaluator,
+  }
+}
+
+describe('GenerateRecommendations', () => {
+  describe('fallback mode (enableAi=false)', () => {
+    let setup: ReturnType<typeof makeSetup>
+
+    beforeEach(async () => {
+      setup = makeSetup()
+      await setup.companyRepo.saveMany([
+        company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'banano', ciiu: 'A0122', municipio: 'CIENAGA' }),
+        company({ id: 'mayor', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'hotel', ciiu: 'I5511', municipio: 'SANTA MARTA' }),
+        company({ id: 'transp', ciiu: 'H4921', municipio: 'SANTA MARTA' }),
+      ])
+    })
+
+    it('runs hardcoded matchers without calling Gemini', async () => {
+      const spy = vi.spyOn(setup.gemini, 'inferStructured')
+      const result = await setup.useCase.execute({ enableAi: false })
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(result.totalRecommendations).toBeGreaterThan(0)
+    })
+
+    it('persists recommendations via the repository', async () => {
+      await setup.useCase.execute({ enableAi: false })
+
+      const persisted = await setup.recRepo.findBySource('p1')
+      expect(persisted.length).toBeGreaterThan(0)
+      expect(persisted.every((r) => r.sourceCompanyId === 'p1')).toBe(true)
+    })
+
+    it('produces recommendations from cosine, rule, and ecosystem sources', async () => {
+      await setup.useCase.execute({ enableAi: false })
+
+      const allSources = new Set<string>()
+      for (const id of ['p1', 'banano', 'hotel']) {
+        const recs = await setup.recRepo.findBySource(id)
+        for (const r of recs) allSources.add(r.source)
+      }
+      expect(allSources.has('cosine')).toBe(true)
+      expect(allSources.has('rule')).toBe(true)
+      expect(allSources.has('ecosystem')).toBe(true)
+    })
+
+    it('clears existing recommendations before saving the new batch', async () => {
+      await setup.useCase.execute({ enableAi: false })
+      const before = await setup.recRepo.findBySource('p1')
+      await setup.useCase.execute({ enableAi: false })
+      const after = await setup.recRepo.findBySource('p1')
+
+      expect(before.length).toBe(after.length)
+      for (const beforeRec of before) {
+        expect(after.some((a) => a.id === beforeRec.id)).toBe(false)
+      }
+    })
+
+    it('skips inactive companies', async () => {
+      await setup.companyRepo.saveMany([
+        company({
+          id: 'inactivo',
+          ciiu: 'C1071',
+          municipio: 'SANTA MARTA',
+          estado: 'CANCELADO',
+        }),
+      ])
+
+      await setup.useCase.execute({ enableAi: false })
+      expect(await setup.recRepo.countBySource('inactivo')).toBe(0)
+    })
+  })
+
+  describe('limit and dedupe', () => {
+    it('caps each company to at most 20 total recommendations', async () => {
+      const setup = makeSetup()
+      const companies: Company[] = [
+        company({ id: 'src', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+      ]
+      for (let i = 0; i < 40; i++) {
+        companies.push(
+          company({ id: `t${i}`, ciiu: 'I5611', municipio: 'SANTA MARTA' }),
+        )
+      }
+      await setup.companyRepo.saveMany(companies)
+
+      await setup.useCase.execute({ enableAi: false })
+      expect(await setup.recRepo.countBySource('src')).toBeLessThanOrEqual(20)
+    })
+
+    it('caps each (relationType) to at most 5 recommendations per company', async () => {
+      const setup = makeSetup()
+      const companies: Company[] = [
+        company({ id: 'banano', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+      ]
+      for (let i = 0; i < 12; i++) {
+        companies.push(
+          company({
+            id: `m${i}`,
+            ciiu: 'G4631',
+            municipio: 'SANTA MARTA',
+          }),
+        )
+      }
+      await setup.companyRepo.saveMany(companies)
+
+      await setup.useCase.execute({ enableAi: false })
+      const clientes = await setup.recRepo.findBySourceAndType(
+        'banano',
+        'cliente',
+      )
+      expect(clientes.length).toBeLessThanOrEqual(5)
+    })
+  })
+
+  describe('AI-first mode', () => {
+    it('marks recommendations with source=ai-inferred when enableAi is true', async () => {
+      const setup = makeSetup({
+        matchResponse: {
+          has_match: true,
+          relation_type: 'cliente',
+          confidence: 0.85,
+          reason: 'r',
+        },
+      })
+      await setup.companyRepo.saveMany([
+        company({ id: 'mayor', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'rest', ciiu: 'I5611', municipio: 'SANTA MARTA' }),
+      ])
+
+      await setup.useCase.execute({ enableAi: true })
+      const recs = await setup.recRepo.findBySource('mayor')
+
+      expect(recs.length).toBeGreaterThan(0)
+      expect(recs.every((r) => r.source === 'ai-inferred')).toBe(true)
+    })
+
+    it('falls back to hardcoded matchers when AI orchestration throws', async () => {
+      const setup = makeSetup()
+      vi.spyOn(setup.evaluator, 'evaluateAll').mockRejectedValue(
+        new Error('rate limited'),
+      )
+      await setup.companyRepo.saveMany([
+        company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+      ])
+
+      await setup.useCase.execute({ enableAi: true })
+      const recs = await setup.recRepo.findBySource('p1')
+      expect(recs.length).toBeGreaterThan(0)
+      expect(recs.every((r) => r.source !== 'ai-inferred')).toBe(true)
+    })
+  })
+
+  it('returns stats describing the persisted batch', async () => {
+    const setup = makeSetup()
+    await setup.companyRepo.saveMany([
+      company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+      company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+    ])
+
+    const result = await setup.useCase.execute({ enableAi: false })
+
+    expect(result.totalRecommendations).toBeGreaterThanOrEqual(0)
+    expect(result.companiesWithRecs).toBeGreaterThanOrEqual(0)
+    expect(result.byRelationType).toBeDefined()
+  })
+})

--- a/src/brain/__tests__/recommendations/GetCompanyRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GetCompanyRecommendations.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { GetCompanyRecommendations } from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c',
+    razonSocial: 'Acme',
+    ciiu: 'I5611',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+const rec = (
+  id: string,
+  overrides: Partial<{
+    score: number
+    relationType: 'referente' | 'cliente' | 'proveedor' | 'aliado'
+    targetCompanyId: string
+    sourceCompanyId: string
+    explanation: string | null
+  }> = {},
+): Recommendation =>
+  Recommendation.create({
+    id,
+    sourceCompanyId: overrides.sourceCompanyId ?? 'src',
+    targetCompanyId: overrides.targetCompanyId ?? 'tgt-1',
+    relationType: overrides.relationType ?? 'cliente',
+    score: overrides.score ?? 0.7,
+    reasons: Reasons.empty(),
+    source: 'rule',
+    explanation: overrides.explanation ?? null,
+  })
+
+describe('GetCompanyRecommendations', () => {
+  let recRepo: InMemoryRecommendationRepository
+  let companyRepo: InMemoryCompanyRepository
+  let useCase: GetCompanyRecommendations
+
+  beforeEach(async () => {
+    recRepo = new InMemoryRecommendationRepository()
+    companyRepo = new InMemoryCompanyRepository()
+    useCase = new GetCompanyRecommendations(recRepo, companyRepo)
+
+    await companyRepo.saveMany([
+      company({ id: 'src', ciiu: 'G4631' }),
+      company({ id: 'tgt-1', razonSocial: 'Restaurante 1', ciiu: 'I5611' }),
+      company({ id: 'tgt-2', razonSocial: 'Restaurante 2', ciiu: 'I5630' }),
+    ])
+    await recRepo.saveAll([
+      rec('r1', {
+        targetCompanyId: 'tgt-1',
+        relationType: 'cliente',
+        score: 0.9,
+      }),
+      rec('r2', {
+        targetCompanyId: 'tgt-2',
+        relationType: 'cliente',
+        score: 0.7,
+      }),
+      rec('r3', {
+        targetCompanyId: 'tgt-1',
+        relationType: 'aliado',
+        score: 0.5,
+      }),
+    ])
+  })
+
+  it('returns recommendations sorted by score desc with hydrated target companies', async () => {
+    const result = await useCase.execute({ companyId: 'src' })
+
+    expect(result.recommendations.map((r) => r.id)).toEqual(['r1', 'r2', 'r3'])
+    const r1 = result.recommendations[0]
+    expect(r1.targetCompany?.id).toBe('tgt-1')
+    expect(r1.targetCompany?.razonSocial).toBe('Restaurante 1')
+    expect(r1.targetCompany?.ciiu).toBe('5611')
+  })
+
+  it('filters by relationType when provided', async () => {
+    const result = await useCase.execute({
+      companyId: 'src',
+      type: 'aliado',
+    })
+
+    expect(result.recommendations.map((r) => r.id)).toEqual(['r3'])
+  })
+
+  it('respects the limit parameter', async () => {
+    const result = await useCase.execute({ companyId: 'src', limit: 1 })
+    expect(result.recommendations).toHaveLength(1)
+  })
+
+  it('uses the default limit of 10 when not provided', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => `extra-${i}`)
+    await companyRepo.saveMany(
+      many.map((id) => company({ id, razonSocial: id, ciiu: 'I5611' })),
+    )
+    await recRepo.saveAll(
+      many.map((id, i) =>
+        rec(`rec-${i}`, {
+          targetCompanyId: id,
+          relationType: 'cliente',
+          score: 0.1 + i * 0.01,
+        }),
+      ),
+    )
+    const result = await useCase.execute({ companyId: 'src' })
+    expect(result.recommendations).toHaveLength(10)
+  })
+
+  it('returns null targetCompany when the target company is missing', async () => {
+    await recRepo.saveAll([
+      rec('orphan', { targetCompanyId: 'ghost', relationType: 'cliente' }),
+    ])
+    const result = await useCase.execute({ companyId: 'src' })
+    const orphan = result.recommendations.find((r) => r.id === 'orphan')
+    expect(orphan).toBeDefined()
+    expect(orphan!.targetCompany).toBeNull()
+  })
+
+  it('exposes the explanation field for hydrated recs', async () => {
+    await recRepo.updateExplanation('r1', 'enriched explanation')
+    const result = await useCase.execute({ companyId: 'src' })
+    const r1 = result.recommendations.find((r) => r.id === 'r1')
+    expect(r1!.explanation).toBe('enriched explanation')
+  })
+
+  it('returns empty when company has no recommendations', async () => {
+    const result = await useCase.execute({ companyId: 'unknown' })
+    expect(result.recommendations).toEqual([])
+  })
+})

--- a/src/brain/__tests__/recommendations/InMemoryAiMatchCacheRepository.test.ts
+++ b/src/brain/__tests__/recommendations/InMemoryAiMatchCacheRepository.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+
+describe('InMemoryAiMatchCacheRepository', () => {
+  let repo: InMemoryAiMatchCacheRepository
+
+  beforeEach(() => {
+    repo = new InMemoryAiMatchCacheRepository()
+  })
+
+  it('returns null when entry is missing', async () => {
+    expect(await repo.get('0122', '4631')).toBeNull()
+  })
+
+  it('puts and gets entries by composite key', async () => {
+    const entry = AiMatchCacheEntry.create({
+      ciiuOrigen: '0122',
+      ciiuDestino: '4631',
+      hasMatch: true,
+      relationType: 'cliente',
+      confidence: 0.9,
+    })
+    await repo.put(entry)
+
+    const got = await repo.get('0122', '4631')
+    expect(got).not.toBeNull()
+    expect(got!.confidence).toBe(0.9)
+  })
+
+  it('treats different directions as different entries', async () => {
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: true,
+        relationType: 'cliente',
+      }),
+    )
+    expect(await repo.get('4631', '0122')).toBeNull()
+  })
+
+  it('overwrites entries with the same composite key', async () => {
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: false,
+      }),
+    )
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: true,
+        relationType: 'cliente',
+        confidence: 0.7,
+      }),
+    )
+
+    const got = await repo.get('0122', '4631')
+    expect(got!.hasMatch).toBe(true)
+    expect(got!.confidence).toBe(0.7)
+    expect(await repo.size()).toBe(1)
+  })
+
+  it('size returns the total number of entries', async () => {
+    expect(await repo.size()).toBe(0)
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: false,
+      }),
+    )
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0123',
+        ciiuDestino: '4631',
+        hasMatch: false,
+      }),
+    )
+    expect(await repo.size()).toBe(2)
+  })
+})

--- a/src/brain/__tests__/recommendations/InMemoryAiMatchCacheRepository.test.ts
+++ b/src/brain/__tests__/recommendations/InMemoryAiMatchCacheRepository.test.ts
@@ -64,6 +64,33 @@ describe('InMemoryAiMatchCacheRepository', () => {
     expect(await repo.size()).toBe(1)
   })
 
+  it('findAll returns every entry in the store', async () => {
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: true,
+        relationType: 'cliente',
+        confidence: 0.8,
+      }),
+    )
+    await repo.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '4631',
+        ciiuDestino: '5611',
+        hasMatch: false,
+      }),
+    )
+
+    const all = await repo.findAll()
+    expect(all).toHaveLength(2)
+    expect(all.map((e) => e.key).sort()).toEqual(['0122->4631', '4631->5611'])
+  })
+
+  it('findAll returns an empty array when nothing was stored', async () => {
+    expect(await repo.findAll()).toEqual([])
+  })
+
   it('size returns the total number of entries', async () => {
     expect(await repo.size()).toBe(0)
     await repo.put(

--- a/src/brain/__tests__/recommendations/InMemoryRecommendationRepository.test.ts
+++ b/src/brain/__tests__/recommendations/InMemoryRecommendationRepository.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  Recommendation,
+  type CreateRecommendationInput,
+} from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+
+const makeRec = (
+  overrides: Partial<CreateRecommendationInput> = {},
+): Recommendation =>
+  Recommendation.create({
+    id: 'rec-1',
+    sourceCompanyId: 'a',
+    targetCompanyId: 'b',
+    relationType: 'cliente',
+    score: 0.5,
+    reasons: Reasons.empty(),
+    source: 'rule',
+    ...overrides,
+  })
+
+describe('InMemoryRecommendationRepository', () => {
+  let repo: InMemoryRecommendationRepository
+
+  beforeEach(() => {
+    repo = new InMemoryRecommendationRepository()
+  })
+
+  it('saveAll persists every recommendation', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1' }),
+      makeRec({ id: 'r2', targetCompanyId: 'c' }),
+    ])
+
+    expect(await repo.findById('r1')).not.toBeNull()
+    expect(await repo.findById('r2')).not.toBeNull()
+  })
+
+  it('saveAll upserts by id', async () => {
+    await repo.saveAll([makeRec({ id: 'r1', score: 0.1 })])
+    await repo.saveAll([makeRec({ id: 'r1', score: 0.9 })])
+
+    const fetched = await repo.findById('r1')
+    expect(fetched!.score).toBe(0.9)
+    expect(await repo.countBySource('a')).toBe(1)
+  })
+
+  it('findById returns null for unknown id', async () => {
+    expect(await repo.findById('missing')).toBeNull()
+  })
+
+  it('findBySource returns all recs sourced from a company sorted by score desc', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1', sourceCompanyId: 'a', score: 0.4 }),
+      makeRec({
+        id: 'r2',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'c',
+        score: 0.9,
+      }),
+      makeRec({
+        id: 'r3',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'd',
+        score: 0.7,
+      }),
+      makeRec({ id: 'r4', sourceCompanyId: 'other', targetCompanyId: 'b' }),
+    ])
+
+    const result = await repo.findBySource('a')
+    expect(result.map((r) => r.id)).toEqual(['r2', 'r3', 'r1'])
+  })
+
+  it('findBySource respects the limit parameter', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1', score: 0.9 }),
+      makeRec({ id: 'r2', targetCompanyId: 'c', score: 0.7 }),
+      makeRec({ id: 'r3', targetCompanyId: 'd', score: 0.5 }),
+    ])
+
+    expect(await repo.findBySource('a', 2)).toHaveLength(2)
+  })
+
+  it('findBySourceAndType filters by relation type', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1', relationType: 'cliente', score: 0.9 }),
+      makeRec({
+        id: 'r2',
+        relationType: 'proveedor',
+        targetCompanyId: 'c',
+        score: 0.8,
+      }),
+      makeRec({
+        id: 'r3',
+        relationType: 'cliente',
+        targetCompanyId: 'd',
+        score: 0.6,
+      }),
+    ])
+
+    const clientes = await repo.findBySourceAndType('a', 'cliente')
+    expect(clientes.map((r) => r.id)).toEqual(['r1', 'r3'])
+  })
+
+  it('findBySourceAndType respects the limit', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1', relationType: 'cliente', score: 0.9 }),
+      makeRec({
+        id: 'r2',
+        relationType: 'cliente',
+        targetCompanyId: 'c',
+        score: 0.8,
+      }),
+      makeRec({
+        id: 'r3',
+        relationType: 'cliente',
+        targetCompanyId: 'd',
+        score: 0.7,
+      }),
+    ])
+
+    expect(await repo.findBySourceAndType('a', 'cliente', 2)).toHaveLength(2)
+  })
+
+  it('updateExplanation mutates only the explanation and stamps cached_at', async () => {
+    await repo.saveAll([makeRec({ id: 'r1' })])
+    await repo.updateExplanation('r1', 'porque sí')
+
+    const fetched = await repo.findById('r1')
+    expect(fetched!.explanation).toBe('porque sí')
+    expect(fetched!.explanationCachedAt).toBeInstanceOf(Date)
+  })
+
+  it('updateExplanation is a no-op for unknown id', async () => {
+    await expect(
+      repo.updateExplanation('missing', 'x'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('countBySource counts only the matching source', async () => {
+    await repo.saveAll([
+      makeRec({ id: 'r1', sourceCompanyId: 'a' }),
+      makeRec({ id: 'r2', sourceCompanyId: 'a', targetCompanyId: 'c' }),
+      makeRec({ id: 'r3', sourceCompanyId: 'other', targetCompanyId: 'b' }),
+    ])
+
+    expect(await repo.countBySource('a')).toBe(2)
+    expect(await repo.countBySource('other')).toBe(1)
+    expect(await repo.countBySource('nope')).toBe(0)
+  })
+
+  it('deleteAll empties the store', async () => {
+    await repo.saveAll([makeRec({ id: 'r1' })])
+    await repo.deleteAll()
+
+    expect(await repo.findById('r1')).toBeNull()
+    expect(await repo.countBySource('a')).toBe(0)
+  })
+})

--- a/src/brain/__tests__/recommendations/PeerMatcher.test.ts
+++ b/src/brain/__tests__/recommendations/PeerMatcher.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c1',
+    razonSocial: 'Acme',
+    ciiu: 'C1071',
+    municipio: 'SANTA MARTA',
+    personal: 5,
+    ingresoOperacion: 50_000_000,
+    fechaMatricula: new Date('2022-01-01'),
+    ...overrides,
+  })
+
+describe('PeerMatcher', () => {
+  const matcher = new PeerMatcher(new FeatureVectorBuilder())
+
+  it('recommends peers from the same ciiu division', () => {
+    const sm1 = company({ id: 'sm1', municipio: 'SANTA MARTA', ciiu: 'C1071' })
+    const sm2 = company({ id: 'sm2', municipio: 'SANTA MARTA', ciiu: 'C1071' })
+    const sm3 = company({ id: 'sm3', municipio: 'SANTA MARTA', ciiu: 'C1071' })
+    const cienaga1 = company({
+      id: 'ci1',
+      municipio: 'CIENAGA',
+      ciiu: 'C1071',
+    })
+    const cienaga2 = company({
+      id: 'ci2',
+      municipio: 'CIENAGA',
+      ciiu: 'C1071',
+    })
+    const hotel = company({
+      id: 'hotel',
+      municipio: 'SANTA MARTA',
+      ciiu: 'I5511',
+    })
+
+    const result = matcher.match([sm1, sm2, sm3, cienaga1, cienaga2, hotel])
+
+    const sm1Recs = result.get('sm1') ?? []
+    expect(sm1Recs.length).toBeGreaterThan(0)
+    const targetIds = sm1Recs.map((r) => r.targetCompanyId)
+    expect(targetIds).toContain('sm2')
+    expect(targetIds).toContain('sm3')
+    expect(targetIds).not.toContain('hotel')
+  })
+
+  it('marks every recommendation as referente from cosine source', () => {
+    const a = company({ id: 'a', ciiu: 'C1071' })
+    const b = company({ id: 'b', ciiu: 'C1071' })
+    const result = matcher.match([a, b])
+
+    const aRecs = result.get('a')!
+    expect(aRecs[0].relationType).toBe('referente')
+    expect(aRecs[0].source).toBe('cosine')
+  })
+
+  it('orders peers by proximity (same municipio first)', () => {
+    const src = company({
+      id: 'src',
+      municipio: 'SANTA MARTA',
+      ciiu: 'C1071',
+    })
+    const near = company({
+      id: 'near',
+      municipio: 'SANTA MARTA',
+      ciiu: 'C1071',
+    })
+    const far = company({ id: 'far', municipio: 'CIENAGA', ciiu: 'C1071' })
+
+    const result = matcher.match([src, near, far])
+    const ids = result.get('src')!.map((r) => r.targetCompanyId)
+    expect(ids[0]).toBe('near')
+    expect(ids[1]).toBe('far')
+  })
+
+  it('attaches structured reasons reflecting shared ciiu and municipio', () => {
+    const a = company({ id: 'a', ciiu: 'C1071', municipio: 'SANTA MARTA' })
+    const b = company({ id: 'b', ciiu: 'C1071', municipio: 'SANTA MARTA' })
+
+    const result = matcher.match([a, b])
+    const reasons = result.get('a')![0].reasons.toJson()
+    const features = reasons.map((r) => r.feature)
+    expect(features).toContain('mismo_ciiu_clase')
+    expect(features).toContain('mismo_municipio')
+  })
+
+  it('returns empty for a company with no peers in its division', () => {
+    const lonely = company({ id: 'lonely', ciiu: 'I5511' })
+    const a = company({ id: 'a', ciiu: 'C1071' })
+    const result = matcher.match([lonely, a])
+    expect(result.get('lonely') ?? []).toEqual([])
+  })
+
+  it('respects topN per company', () => {
+    const peers = Array.from({ length: 8 }, (_, i) =>
+      company({ id: `p${i}`, ciiu: 'C1071' }),
+    )
+    const result = matcher.match(peers, { topN: 3 })
+    expect(result.get('p0')!.length).toBe(3)
+  })
+
+  it('produces scores in 0..1', () => {
+    const a = company({ id: 'a', ciiu: 'C1071' })
+    const b = company({ id: 'b', ciiu: 'C1071' })
+    const result = matcher.match([a, b])
+    for (const rec of result.get('a')!) {
+      expect(rec.score).toBeGreaterThan(0)
+      expect(rec.score).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/src/brain/__tests__/recommendations/Reason.test.ts
+++ b/src/brain/__tests__/recommendations/Reason.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type Reason,
+  Reasons,
+} from '@/recommendations/domain/value-objects/Reason'
+
+const sample = (overrides: Partial<Reason> = {}): Reason => ({
+  feature: 'mismo_ciiu_clase',
+  weight: 0.4,
+  description: 'Mismo CIIU clase',
+  ...overrides,
+})
+
+describe('Reasons', () => {
+  it('starts empty with zero total weight and empty json', () => {
+    const reasons = Reasons.empty()
+
+    expect(reasons.totalWeight()).toBe(0)
+    expect(reasons.toJson()).toEqual([])
+  })
+
+  it('builds from a list and exposes a defensive copy via toJson', () => {
+    const items = [
+      sample({ feature: 'mismo_municipio', weight: 0.3 }),
+      sample({ feature: 'misma_etapa', weight: 0.2 }),
+    ]
+    const reasons = Reasons.from(items)
+
+    const json = reasons.toJson()
+    expect(json).toEqual(items)
+    expect(json).not.toBe(items)
+
+    json.push(sample())
+    expect(reasons.toJson()).toHaveLength(2)
+  })
+
+  it('add() returns a new instance without mutating the original', () => {
+    const original = Reasons.from([sample({ weight: 0.5 })])
+    const next = original.add(
+      sample({ feature: 'mismo_municipio', weight: 0.3 }),
+    )
+
+    expect(original.toJson()).toHaveLength(1)
+    expect(next.toJson()).toHaveLength(2)
+    expect(next).not.toBe(original)
+  })
+
+  it('totalWeight sums the weight of all reasons', () => {
+    const reasons = Reasons.from([
+      sample({ weight: 0.4 }),
+      sample({ feature: 'mismo_municipio', weight: 0.3 }),
+      sample({ feature: 'misma_etapa', weight: 0.25 }),
+    ])
+
+    expect(reasons.totalWeight()).toBeCloseTo(0.95, 5)
+  })
+
+  it('preserves reason metadata (value field) through toJson', () => {
+    const reasons = Reasons.from([
+      sample({
+        feature: 'mismo_municipio',
+        weight: 0.3,
+        value: 'SANTA MARTA',
+        description: 'Misma ciudad',
+      }),
+    ])
+
+    expect(reasons.toJson()[0]).toEqual({
+      feature: 'mismo_municipio',
+      weight: 0.3,
+      value: 'SANTA MARTA',
+      description: 'Misma ciudad',
+    })
+  })
+
+  it('does not share state when constructed via from()', () => {
+    const items = [sample({ weight: 0.4 })]
+    const reasons = Reasons.from(items)
+
+    items.push(sample({ feature: 'misma_etapa', weight: 0.9 }))
+
+    expect(reasons.toJson()).toHaveLength(1)
+    expect(reasons.totalWeight()).toBe(0.4)
+  })
+})

--- a/src/brain/__tests__/recommendations/Recommendation.test.ts
+++ b/src/brain/__tests__/recommendations/Recommendation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Recommendation,
+  type CreateRecommendationInput,
+  type RecommendationSource,
+} from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+const validInput = (
+  overrides: Partial<CreateRecommendationInput> = {},
+): CreateRecommendationInput => ({
+  id: 'rec-1',
+  sourceCompanyId: 'company-a',
+  targetCompanyId: 'company-b',
+  relationType: 'cliente',
+  score: 0.8,
+  reasons: Reasons.from([
+    {
+      feature: 'mismo_ciiu_clase',
+      weight: 0.4,
+      description: 'mismo ciiu',
+    },
+  ]),
+  source: 'ai-inferred',
+  ...overrides,
+})
+
+describe('Recommendation', () => {
+  it('creates a recommendation with all required fields', () => {
+    const rec = Recommendation.create(validInput())
+
+    expect(rec.id).toBe('rec-1')
+    expect(rec.sourceCompanyId).toBe('company-a')
+    expect(rec.targetCompanyId).toBe('company-b')
+    expect(rec.relationType).toBe('cliente')
+    expect(rec.score).toBe(0.8)
+    expect(rec.source).toBe<RecommendationSource>('ai-inferred')
+    expect(rec.explanation).toBeNull()
+    expect(rec.explanationCachedAt).toBeNull()
+    expect(rec.reasons.toJson()).toHaveLength(1)
+  })
+
+  it('accepts optional explanation fields', () => {
+    const cachedAt = new Date('2026-04-26T00:00:00Z')
+    const rec = Recommendation.create(
+      validInput({ explanation: 'porque sí', explanationCachedAt: cachedAt }),
+    )
+
+    expect(rec.explanation).toBe('porque sí')
+    expect(rec.explanationCachedAt).toEqual(cachedAt)
+  })
+
+  it('rejects empty id', () => {
+    expect(() => Recommendation.create(validInput({ id: '' }))).toThrow(
+      'Recommendation.id cannot be empty',
+    )
+    expect(() => Recommendation.create(validInput({ id: '   ' }))).toThrow(
+      'Recommendation.id cannot be empty',
+    )
+  })
+
+  it('rejects empty source/target company ids', () => {
+    expect(() =>
+      Recommendation.create(validInput({ sourceCompanyId: '' })),
+    ).toThrow('Recommendation.sourceCompanyId cannot be empty')
+    expect(() =>
+      Recommendation.create(validInput({ targetCompanyId: '' })),
+    ).toThrow('Recommendation.targetCompanyId cannot be empty')
+  })
+
+  it('rejects self-recommendations', () => {
+    expect(() =>
+      Recommendation.create(
+        validInput({ sourceCompanyId: 'same', targetCompanyId: 'same' }),
+      ),
+    ).toThrow('Cannot recommend a company to itself')
+  })
+
+  it('rejects scores outside 0..1', () => {
+    expect(() => Recommendation.create(validInput({ score: -0.01 }))).toThrow(
+      'Recommendation.score must be between 0 and 1',
+    )
+    expect(() => Recommendation.create(validInput({ score: 1.5 }))).toThrow(
+      'Recommendation.score must be between 0 and 1',
+    )
+  })
+
+  it('accepts boundary scores 0 and 1', () => {
+    expect(() => Recommendation.create(validInput({ score: 0 }))).not.toThrow()
+    expect(() => Recommendation.create(validInput({ score: 1 }))).not.toThrow()
+  })
+
+  it('accepts every recommendation source', () => {
+    const sources: RecommendationSource[] = [
+      'rule',
+      'cosine',
+      'ecosystem',
+      'ai-inferred',
+    ]
+    for (const source of sources) {
+      const rec = Recommendation.create(validInput({ source }))
+      expect(rec.source).toBe(source)
+    }
+  })
+
+  it('accepts every relation type', () => {
+    for (const relationType of [
+      'referente',
+      'cliente',
+      'proveedor',
+      'aliado',
+    ] as const) {
+      const rec = Recommendation.create(validInput({ relationType }))
+      expect(rec.relationType).toBe(relationType)
+    }
+  })
+
+  it('exposes reasons as a Reasons collection', () => {
+    const reasons = Reasons.from([
+      { feature: 'mismo_municipio', weight: 0.3, description: 'misma ciudad' },
+      { feature: 'misma_etapa', weight: 0.2, description: 'misma etapa' },
+    ])
+    const rec = Recommendation.create(validInput({ reasons }))
+
+    expect(rec.reasons.toJson()).toHaveLength(2)
+    expect(rec.reasons.totalWeight()).toBeCloseTo(0.5, 5)
+  })
+
+  it('returns true for equals when ids match', () => {
+    const a = Recommendation.create(validInput({ id: 'rec-x' }))
+    const b = Recommendation.create(
+      validInput({ id: 'rec-x', sourceCompanyId: 'other' }),
+    )
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('returns false for equals when ids differ', () => {
+    const a = Recommendation.create(validInput({ id: 'rec-1' }))
+    const b = Recommendation.create(validInput({ id: 'rec-2' }))
+    expect(a.equals(b)).toBe(false)
+  })
+
+  it('withExplanation returns a new instance with explanation populated', () => {
+    const rec = Recommendation.create(validInput())
+    const at = new Date('2026-04-26T01:00:00Z')
+    const enriched = rec.withExplanation('detalle largo', at)
+
+    expect(enriched).not.toBe(rec)
+    expect(enriched.explanation).toBe('detalle largo')
+    expect(enriched.explanationCachedAt).toEqual(at)
+    expect(rec.explanation).toBeNull()
+    expect(enriched.id).toBe(rec.id)
+  })
+})

--- a/src/brain/__tests__/recommendations/RecommendationsController.test.ts
+++ b/src/brain/__tests__/recommendations/RecommendationsController.test.ts
@@ -1,0 +1,258 @@
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { CandidateSelector } from '@/recommendations/application/services/CandidateSelector'
+import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { ExplainRecommendation } from '@/recommendations/application/use-cases/ExplainRecommendation'
+import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
+import { GetCompanyRecommendations } from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { CompanyRecommendationsController } from '@/recommendations/infrastructure/http/company-recommendations.controller'
+import { RecommendationsController } from '@/recommendations/infrastructure/http/recommendations.controller'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+
+function makeWiring() {
+  const companyRepo = new InMemoryCompanyRepository()
+  const recRepo = new InMemoryRecommendationRepository()
+  const cache = new InMemoryAiMatchCacheRepository()
+  const ciiuRepo = new InMemoryCiiuTaxonomyRepository([
+    CiiuActivity.create({
+      code: '4631',
+      titulo: 'Mayorista alimentos',
+      seccion: 'G',
+      division: '46',
+      grupo: '463',
+      tituloSeccion: 'x',
+      tituloDivision: 'x',
+      tituloGrupo: 'x',
+    }),
+    CiiuActivity.create({
+      code: '5611',
+      titulo: 'Restaurantes',
+      seccion: 'I',
+      division: '56',
+      grupo: '561',
+      tituloSeccion: 'x',
+      tituloDivision: 'x',
+      tituloGrupo: 'x',
+    }),
+  ])
+  const gemini = new StubGeminiAdapter('explanation from gemini')
+  const aiEngine = new AiMatchEngine(gemini, cache, ciiuRepo)
+  const evaluator = new CiiuPairEvaluator(aiEngine, cache)
+  const featureBuilder = new FeatureVectorBuilder()
+  const selector = new CandidateSelector()
+  const peer = new PeerMatcher(featureBuilder)
+  const valueChain = new ValueChainMatcher()
+  const alliance = new AllianceMatcher()
+  const generate = new GenerateRecommendations(
+    companyRepo,
+    recRepo,
+    cache,
+    selector,
+    evaluator,
+    featureBuilder,
+    peer,
+    valueChain,
+    alliance,
+  )
+  const explain = new ExplainRecommendation(recRepo, companyRepo, gemini)
+  const get = new GetCompanyRecommendations(recRepo, companyRepo)
+  return {
+    companyRepo,
+    recRepo,
+    gemini,
+    controller: new RecommendationsController(generate, explain),
+    companyController: new CompanyRecommendationsController(get),
+  }
+}
+
+describe('RecommendationsController', () => {
+  it('POST /generate runs the use case and returns stats', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'c1',
+        razonSocial: 'A',
+        ciiu: 'C1071',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'c2',
+        razonSocial: 'B',
+        ciiu: 'C1071',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+
+    const result = await setup.controller.generate({ enableAi: false })
+    expect(result.totalRecommendations).toBeGreaterThanOrEqual(0)
+    expect(result.byRelationType).toBeDefined()
+  })
+
+  it('POST /:id/explain returns the cached explanation without hitting gemini', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'src',
+        razonSocial: 'Banano SA',
+        ciiu: 'A0122',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'tgt',
+        razonSocial: 'Mayorista SA',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+    await setup.recRepo.saveAll([
+      Recommendation.create({
+        id: 'rec-1',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'tgt',
+        relationType: 'cliente',
+        score: 0.85,
+        reasons: Reasons.empty(),
+        source: 'rule',
+        explanation: 'cached',
+      }),
+    ])
+    const spy = vi.spyOn(setup.gemini, 'generateText')
+
+    const result = await setup.controller.explain('rec-1')
+    expect(result.explanation).toBe('cached')
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('POST /:id/explain throws NotFoundException when recommendation is unknown', async () => {
+    const setup = makeWiring()
+    await expect(setup.controller.explain('missing')).rejects.toBeInstanceOf(
+      NotFoundException,
+    )
+  })
+})
+
+describe('CompanyRecommendationsController', () => {
+  it('GET /:id/recommendations returns the use case result', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'src',
+        razonSocial: 'Acme',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'tgt',
+        razonSocial: 'Restaurante',
+        ciiu: 'I5611',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+    await setup.recRepo.saveAll([
+      Recommendation.create({
+        id: 'r1',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'tgt',
+        relationType: 'cliente',
+        score: 0.8,
+        reasons: Reasons.empty(),
+        source: 'rule',
+      }),
+    ])
+
+    const result = await setup.companyController.list('src')
+    expect(result.recommendations).toHaveLength(1)
+    expect(result.recommendations[0].id).toBe('r1')
+    expect(result.recommendations[0].targetCompany?.razonSocial).toBe(
+      'Restaurante',
+    )
+  })
+
+  it('parses the type query param and ignores unknown values', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'src',
+        razonSocial: 'Acme',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'tgt',
+        razonSocial: 'Restaurante',
+        ciiu: 'I5611',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+    await setup.recRepo.saveAll([
+      Recommendation.create({
+        id: 'r1',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'tgt',
+        relationType: 'cliente',
+        score: 0.8,
+        reasons: Reasons.empty(),
+        source: 'rule',
+      }),
+    ])
+
+    const filtered = await setup.companyController.list('src', 'cliente')
+    expect(filtered.recommendations).toHaveLength(1)
+
+    const ignored = await setup.companyController.list('src', 'invalid-type')
+    expect(ignored.recommendations).toHaveLength(1)
+  })
+
+  it('parses the limit query param and clamps invalid values', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'src',
+        razonSocial: 'Acme',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+    for (let i = 0; i < 4; i++) {
+      const id = `t${i}`
+      await setup.companyRepo.saveMany([
+        Company.create({
+          id,
+          razonSocial: id,
+          ciiu: 'I5611',
+          municipio: 'SANTA MARTA',
+        }),
+      ])
+      await setup.recRepo.saveAll([
+        Recommendation.create({
+          id: `r${i}`,
+          sourceCompanyId: 'src',
+          targetCompanyId: id,
+          relationType: 'cliente',
+          score: 0.5 + i * 0.1,
+          reasons: Reasons.empty(),
+          source: 'rule',
+        }),
+      ])
+    }
+
+    const limited = await setup.companyController.list('src', undefined, '2')
+    expect(limited.recommendations).toHaveLength(2)
+
+    const invalid = await setup.companyController.list('src', undefined, 'oops')
+    expect(invalid.recommendations.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/brain/__tests__/recommendations/RelationType.test.ts
+++ b/src/brain/__tests__/recommendations/RelationType.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RELATION_TYPES,
+  type RelationType,
+  inverseRelation,
+  isRelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+
+describe('RelationType', () => {
+  describe('RELATION_TYPES', () => {
+    it('lists the four canonical relation types', () => {
+      expect(RELATION_TYPES).toEqual([
+        'referente',
+        'cliente',
+        'proveedor',
+        'aliado',
+      ])
+    })
+  })
+
+  describe('isRelationType', () => {
+    it.each(RELATION_TYPES)('accepts %s', (value) => {
+      expect(isRelationType(value)).toBe(true)
+    })
+
+    it('rejects unknown values', () => {
+      expect(isRelationType('competidor')).toBe(false)
+      expect(isRelationType('')).toBe(false)
+      expect(isRelationType('REFERENTE')).toBe(false)
+    })
+  })
+
+  describe('inverseRelation', () => {
+    it('swaps cliente <-> proveedor', () => {
+      expect(inverseRelation('cliente')).toBe<RelationType>('proveedor')
+      expect(inverseRelation('proveedor')).toBe<RelationType>('cliente')
+    })
+
+    it('keeps referente symmetric', () => {
+      expect(inverseRelation('referente')).toBe<RelationType>('referente')
+    })
+
+    it('keeps aliado symmetric', () => {
+      expect(inverseRelation('aliado')).toBe<RelationType>('aliado')
+    })
+
+    it('is its own inverse for every relation', () => {
+      for (const t of RELATION_TYPES) {
+        expect(inverseRelation(inverseRelation(t))).toBe(t)
+      }
+    })
+  })
+})

--- a/src/brain/__tests__/recommendations/SupabaseAiMatchCacheRepository.test.ts
+++ b/src/brain/__tests__/recommendations/SupabaseAiMatchCacheRepository.test.ts
@@ -125,6 +125,26 @@ describe('SupabaseAiMatchCacheRepository', () => {
     })
   })
 
+  describe('findAll', () => {
+    it('returns mapped entries for every row', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const all = await repo.findAll()
+      expect(all).toHaveLength(1)
+      expect(all[0]).toBeInstanceOf(AiMatchCacheEntry)
+      expect(all[0].ciiuOrigen).toBe('0122')
+    })
+
+    it('returns empty array when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findAll()).toEqual([])
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findAll()).rejects.toThrow(/boom/)
+    })
+  })
+
   describe('size', () => {
     it('returns total count via count: exact head: true', async () => {
       fake.setNext({ data: null, error: null, count: 42 })

--- a/src/brain/__tests__/recommendations/SupabaseAiMatchCacheRepository.test.ts
+++ b/src/brain/__tests__/recommendations/SupabaseAiMatchCacheRepository.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { SupabaseAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/SupabaseAiMatchCacheRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    upsert: vi.fn(),
+    maybeSingle: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of ['from', 'select', 'eq', 'upsert'] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  ciiu_origen: '0122',
+  ciiu_destino: '4631',
+  has_match: true,
+  relation_type: 'cliente',
+  confidence: 0.85,
+  reason: 'Banano hacia mayoristas',
+  cached_at: '2026-04-25T12:00:00Z',
+}
+
+describe('SupabaseAiMatchCacheRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseAiMatchCacheRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseAiMatchCacheRepository(fake.db)
+  })
+
+  describe('get', () => {
+    it('returns mapped entry when found', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const entry = await repo.get('0122', '4631')
+
+      expect(fake.spies.from).toHaveBeenCalledWith('ai_match_cache')
+      expect(fake.spies.eq).toHaveBeenCalledWith('ciiu_origen', '0122')
+      expect(fake.spies.eq).toHaveBeenCalledWith('ciiu_destino', '4631')
+      expect(entry).not.toBeNull()
+      expect(entry).toBeInstanceOf(AiMatchCacheEntry)
+      expect(entry!.relationType).toBe('cliente')
+      expect(entry!.confidence).toBe(0.85)
+    })
+
+    it('returns null when no row', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.get('0122', '4631')).toBeNull()
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.get('0122', '4631')).rejects.toThrow(/boom/)
+    })
+
+    it('throws when relation_type from DB is unknown', async () => {
+      fake.setNext({
+        data: { ...validRow, relation_type: 'wat' },
+        error: null,
+      })
+      await expect(repo.get('0122', '4631')).rejects.toThrow(
+        /Unknown ai_match_cache relation_type/,
+      )
+    })
+  })
+
+  describe('put', () => {
+    it('upserts the entry as a row using composite key', async () => {
+      fake.setNext({ data: null, error: null })
+      const entry = AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: true,
+        relationType: 'cliente',
+        confidence: 0.85,
+        reason: 'r',
+      })
+
+      await repo.put(entry)
+
+      expect(fake.spies.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ciiu_origen: '0122',
+          ciiu_destino: '4631',
+          has_match: true,
+          relation_type: 'cliente',
+          confidence: 0.85,
+        }),
+        { onConflict: 'ciiu_origen,ciiu_destino' },
+      )
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      const entry = AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '4631',
+        hasMatch: false,
+      })
+      await expect(repo.put(entry)).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('size', () => {
+    it('returns total count via count: exact head: true', async () => {
+      fake.setNext({ data: null, error: null, count: 42 })
+      expect(await repo.size()).toBe(42)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.size()).toBe(0)
+    })
+
+    it('throws on supabase error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.size()).rejects.toThrow(/boom/)
+    })
+  })
+})

--- a/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
+++ b/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { SupabaseRecommendationRepository } from '@/recommendations/infrastructure/repositories/SupabaseRecommendationRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    neq: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of [
+    'from',
+    'select',
+    'eq',
+    'in',
+    'update',
+    'upsert',
+    'delete',
+    'neq',
+    'order',
+    'limit',
+  ] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  id: 'rec-1',
+  source_company_id: 'a',
+  target_company_id: 'b',
+  relation_type: 'cliente',
+  score: 0.8,
+  reasons: [
+    { feature: 'mismo_ciiu_clase', weight: 0.4, description: 'mismo ciiu' },
+  ],
+  source: 'ai-inferred',
+  explanation: null,
+  explanation_cached_at: null,
+}
+
+describe('SupabaseRecommendationRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseRecommendationRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseRecommendationRepository(fake.db)
+  })
+
+  describe('saveAll', () => {
+    it('upserts every recommendation row', async () => {
+      const rec = Recommendation.create({
+        id: 'rec-1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.8,
+        reasons: Reasons.from([
+          {
+            feature: 'mismo_ciiu_clase',
+            weight: 0.4,
+            description: 'mismo ciiu',
+          },
+        ]),
+        source: 'ai-inferred',
+      })
+
+      fake.setNext({ data: null, error: null })
+      await repo.saveAll([rec])
+
+      expect(fake.spies.from).toHaveBeenCalledWith('recommendations')
+      expect(fake.spies.upsert).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'rec-1',
+            source_company_id: 'a',
+            target_company_id: 'b',
+            relation_type: 'cliente',
+            score: 0.8,
+            source: 'ai-inferred',
+          }),
+        ]),
+        { onConflict: 'id' },
+      )
+    })
+
+    it('is a no-op when array is empty', async () => {
+      await repo.saveAll([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      const rec = Recommendation.create({
+        id: 'rec-1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.8,
+        reasons: Reasons.empty(),
+        source: 'rule',
+      })
+      await expect(repo.saveAll([rec])).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('findById', () => {
+    it('returns mapped entity when row exists', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const rec = await repo.findById('rec-1')
+      expect(rec).toBeInstanceOf(Recommendation)
+      expect(rec!.id).toBe('rec-1')
+      expect(rec!.relationType).toBe('cliente')
+      expect(rec!.reasons.toJson()).toHaveLength(1)
+    })
+
+    it('returns null when row missing', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findById('x')).toBeNull()
+    })
+  })
+
+  describe('findBySource', () => {
+    it('orders by score desc and applies limit when provided', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      await repo.findBySource('a', 5)
+
+      expect(fake.spies.eq).toHaveBeenCalledWith('source_company_id', 'a')
+      expect(fake.spies.order).toHaveBeenCalledWith('score', {
+        ascending: false,
+      })
+      expect(fake.spies.limit).toHaveBeenCalledWith(5)
+    })
+
+    it('does not call limit when omitted', async () => {
+      fake.setNext({ data: [], error: null })
+      await repo.findBySource('a')
+      expect(fake.spies.limit).not.toHaveBeenCalled()
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findBySource('a')).rejects.toThrow(/boom/)
+    })
+
+    it('throws when row source is unknown', async () => {
+      fake.setNext({
+        data: [{ ...validRow, source: 'wat' }],
+        error: null,
+      })
+      await expect(repo.findBySource('a')).rejects.toThrow(
+        /Unknown recommendation source/,
+      )
+    })
+
+    it('throws when row relation_type is unknown', async () => {
+      fake.setNext({
+        data: [{ ...validRow, relation_type: 'wat' }],
+        error: null,
+      })
+      await expect(repo.findBySource('a')).rejects.toThrow(
+        /Unknown recommendation relation_type/,
+      )
+    })
+  })
+
+  describe('findBySourceAndType', () => {
+    it('filters by source and type with ordering', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      await repo.findBySourceAndType('a', 'cliente', 3)
+
+      expect(fake.spies.eq).toHaveBeenCalledWith('source_company_id', 'a')
+      expect(fake.spies.eq).toHaveBeenCalledWith('relation_type', 'cliente')
+      expect(fake.spies.order).toHaveBeenCalledWith('score', {
+        ascending: false,
+      })
+      expect(fake.spies.limit).toHaveBeenCalledWith(3)
+    })
+  })
+
+  describe('updateExplanation', () => {
+    it('updates explanation and stamps explanation_cached_at', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.updateExplanation('rec-1', 'porque sí')
+
+      expect(fake.spies.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explanation: 'porque sí',
+          explanation_cached_at: expect.any(String),
+        }),
+      )
+      expect(fake.spies.eq).toHaveBeenCalledWith('id', 'rec-1')
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.updateExplanation('rec-1', 'x')).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('countBySource', () => {
+    it('uses count: exact head: true and filters by source', async () => {
+      fake.setNext({ data: null, error: null, count: 12 })
+      const n = await repo.countBySource('a')
+      expect(n).toBe(12)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+      expect(fake.spies.eq).toHaveBeenCalledWith('source_company_id', 'a')
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.countBySource('a')).toBe(0)
+    })
+  })
+
+  describe('deleteAll', () => {
+    it('issues a delete with neq trick to remove all rows', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.deleteAll()
+      expect(fake.spies.delete).toHaveBeenCalled()
+      expect(fake.spies.neq).toHaveBeenCalledWith('id', '')
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.deleteAll()).rejects.toThrow(/boom/)
+    })
+  })
+})

--- a/src/brain/__tests__/recommendations/ValueChainMatcher.test.ts
+++ b/src/brain/__tests__/recommendations/ValueChainMatcher.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c1',
+    razonSocial: 'Acme',
+    ciiu: 'G4631',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+describe('ValueChainMatcher', () => {
+  const matcher = new ValueChainMatcher()
+
+  it('produces cliente from origin and proveedor from target for matching pairs', () => {
+    const banano = company({ id: 'banano', ciiu: 'A0122' })
+    const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+    const result = matcher.match([banano, mayor])
+
+    const bananoRecs = result.get('banano') ?? []
+    const mayorRecs = result.get('mayor') ?? []
+
+    expect(bananoRecs).toHaveLength(1)
+    expect(bananoRecs[0].relationType).toBe('cliente')
+    expect(bananoRecs[0].targetCompanyId).toBe('mayor')
+    expect(bananoRecs[0].source).toBe('rule')
+
+    expect(mayorRecs).toHaveLength(1)
+    expect(mayorRecs[0].relationType).toBe('proveedor')
+    expect(mayorRecs[0].targetCompanyId).toBe('banano')
+  })
+
+  it('boosts the score when source and target are in the same municipio', () => {
+    const banano = company({
+      id: 'banano',
+      ciiu: 'A0122',
+      municipio: 'SANTA MARTA',
+    })
+    const mayorSM = company({
+      id: 'mayorSM',
+      ciiu: 'G4631',
+      municipio: 'SANTA MARTA',
+    })
+    const mayorBog = company({
+      id: 'mayorBog',
+      ciiu: 'G4631',
+      municipio: 'BOGOTA',
+    })
+    const result = matcher.match([banano, mayorSM, mayorBog])
+    const recs = result.get('banano') ?? []
+    const sameMunicipio = recs.find((r) => r.targetCompanyId === 'mayorSM')!
+    const otherMunicipio = recs.find((r) => r.targetCompanyId === 'mayorBog')!
+    expect(sameMunicipio.score).toBeGreaterThan(otherMunicipio.score)
+  })
+
+  it('expands wildcard rule (target=*) to every other ciiu', () => {
+    const legal = company({ id: 'legal', ciiu: 'M6910' })
+    const a = company({ id: 'a', ciiu: 'P8512' })
+    const b = company({ id: 'b', ciiu: 'A0121' })
+    const result = matcher.match([legal, a, b])
+    const legalRecs = result.get('legal') ?? []
+    const targets = legalRecs.map((r) => r.targetCompanyId)
+    expect(targets).toContain('a')
+    expect(targets).toContain('b')
+  })
+
+  it('does not generate a recommendation between a company and itself', () => {
+    const c1 = company({ id: 'c1', ciiu: 'G4631' })
+    const c2 = company({ id: 'c2', ciiu: 'G4631' })
+    const result = matcher.match([c1, c2])
+
+    const c1Recs = result.get('c1') ?? []
+    expect(c1Recs.every((r) => r.targetCompanyId !== 'c1')).toBe(true)
+  })
+
+  it('attaches structured reasons with cadena_valor_directa for cliente and inversa for proveedor', () => {
+    const banano = company({ id: 'banano', ciiu: 'A0122' })
+    const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+    const result = matcher.match([banano, mayor])
+
+    const bananoRec = result.get('banano')![0]
+    const mayorRec = result.get('mayor')![0]
+    expect(bananoRec.reasons.toJson()[0].feature).toBe('cadena_valor_directa')
+    expect(mayorRec.reasons.toJson()[0].feature).toBe('cadena_valor_inversa')
+  })
+
+  it('returns no recommendations when no rule applies', () => {
+    const a = company({ id: 'a', ciiu: 'P8512' })
+    const b = company({ id: 'b', ciiu: 'P8551' })
+    const result = matcher.match([a, b])
+    expect(result.get('a') ?? []).toEqual([])
+    expect(result.get('b') ?? []).toEqual([])
+  })
+
+  it('produces unique recommendation ids', () => {
+    const banano = company({ id: 'banano', ciiu: 'A0122' })
+    const mayor1 = company({ id: 'm1', ciiu: 'G4631' })
+    const mayor2 = company({ id: 'm2', ciiu: 'G4631' })
+    const result = matcher.match([banano, mayor1, mayor2])
+    const recs = result.get('banano') ?? []
+    const ids = recs.map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/src/brain/__tests__/recommendations/ValueChainRules.test.ts
+++ b/src/brain/__tests__/recommendations/ValueChainRules.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ECOSYSTEMS,
+  VALUE_CHAIN_RULES,
+  findRulesForPair,
+  findEcosystemsContaining,
+  type Ecosystem,
+  type ValueChainRule,
+} from '@/recommendations/application/services/ValueChainRules'
+
+describe('VALUE_CHAIN_RULES', () => {
+  it('exposes 24 rules', () => {
+    expect(VALUE_CHAIN_RULES).toHaveLength(24)
+  })
+
+  it('every rule has a 4-digit ciiuOrigen', () => {
+    for (const rule of VALUE_CHAIN_RULES) {
+      expect(rule.ciiuOrigen).toMatch(/^\d{4}$/)
+    }
+  })
+
+  it('every rule has a 4-digit ciiuDestino or wildcard *', () => {
+    for (const rule of VALUE_CHAIN_RULES) {
+      expect(rule.ciiuDestino === '*' || /^\d{4}$/.test(rule.ciiuDestino)).toBe(
+        true,
+      )
+    }
+  })
+
+  it('every rule has a weight in (0, 1]', () => {
+    for (const rule of VALUE_CHAIN_RULES) {
+      expect(rule.weight).toBeGreaterThan(0)
+      expect(rule.weight).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('every rule has a non-empty description', () => {
+    for (const rule of VALUE_CHAIN_RULES) {
+      expect(rule.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('ECOSYSTEMS', () => {
+  it('exposes 6 ecosystems', () => {
+    expect(ECOSYSTEMS).toHaveLength(6)
+  })
+
+  it('every ecosystem has unique id', () => {
+    const ids = ECOSYSTEMS.map((e) => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every ecosystem groups at least 3 CIIUs', () => {
+    for (const eco of ECOSYSTEMS) {
+      expect(eco.ciiuCodes.length).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('every ecosystem CIIU is 4-digit', () => {
+    for (const eco of ECOSYSTEMS) {
+      for (const code of eco.ciiuCodes) {
+        expect(code).toMatch(/^\d{4}$/)
+      }
+    }
+  })
+
+  it('exposes the canonical 6 ecosystem ids', () => {
+    expect(ECOSYSTEMS.map((e) => e.id).sort()).toEqual([
+      'agro-exportador',
+      'construccion',
+      'educacion',
+      'salud',
+      'servicios-profesionales',
+      'turismo',
+    ])
+  })
+})
+
+describe('findRulesForPair', () => {
+  const fakeRules: ValueChainRule[] = [
+    {
+      ciiuOrigen: '0122',
+      ciiuDestino: '4631',
+      weight: 0.85,
+      description: 'Banano hacia mayoristas',
+    },
+    {
+      ciiuOrigen: '6910',
+      ciiuDestino: '*',
+      weight: 0.4,
+      description: 'Legal universal',
+    },
+    {
+      ciiuOrigen: '4923',
+      ciiuDestino: '4290',
+      weight: 0.85,
+      description: 'Transporte para construcción',
+    },
+  ]
+
+  it('matches a direct ciiu-ciiu pair', () => {
+    const result = findRulesForPair('0122', '4631', fakeRules)
+    expect(result).toHaveLength(1)
+    expect(result[0].description).toMatch(/Banano/)
+  })
+
+  it('matches wildcard destino * for any target', () => {
+    const result = findRulesForPair('6910', '4631', fakeRules)
+    expect(result.map((r) => r.description)).toEqual(['Legal universal'])
+  })
+
+  it('returns empty when no rule applies', () => {
+    expect(findRulesForPair('9999', '0000', fakeRules)).toEqual([])
+  })
+
+  it('falls back to the registry when rules omitted', () => {
+    const result = findRulesForPair('0122', '4631')
+    expect(result.length).toBeGreaterThan(0)
+  })
+})
+
+describe('findEcosystemsContaining', () => {
+  const fakeEcos: Ecosystem[] = [
+    {
+      id: 'a',
+      name: 'A',
+      ciiuCodes: ['0001', '0002'],
+      description: 'a',
+    },
+    {
+      id: 'b',
+      name: 'B',
+      ciiuCodes: ['0001', '0003'],
+      description: 'b',
+    },
+    {
+      id: 'c',
+      name: 'C',
+      ciiuCodes: ['0004'],
+      description: 'c',
+    },
+  ]
+
+  it('returns ecosystems that include the CIIU', () => {
+    const result = findEcosystemsContaining('0001', fakeEcos)
+    expect(result.map((e) => e.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('returns empty when no ecosystem contains the CIIU', () => {
+    expect(findEcosystemsContaining('9999', fakeEcos)).toEqual([])
+  })
+
+  it('falls back to the registry when ecosystems omitted', () => {
+    const result = findEcosystemsContaining('5511')
+    expect(result.length).toBeGreaterThan(0)
+    expect(result.some((e) => e.id === 'turismo')).toBe(true)
+  })
+})

--- a/src/brain/src/app.module.ts
+++ b/src/brain/src/app.module.ts
@@ -4,6 +4,7 @@ import { SharedModule } from './shared/shared.module'
 import { CiiuTaxonomyModule } from './ciiu-taxonomy/ciiu-taxonomy.module'
 import { ClustersModule } from './clusters/clusters.module'
 import { CompaniesModule } from './companies/companies.module'
+import { RecommendationsModule } from './recommendations/recommendations.module'
 import { HealthController } from './shared/infrastructure/health/health.controller'
 
 @Module({
@@ -13,6 +14,7 @@ import { HealthController } from './shared/infrastructure/health/health.controll
     CiiuTaxonomyModule,
     CompaniesModule,
     ClustersModule,
+    RecommendationsModule,
   ],
   controllers: [HealthController],
 })

--- a/src/brain/src/recommendations/application/services/AiMatchEngine.ts
+++ b/src/brain/src/recommendations/application/services/AiMatchEngine.ts
@@ -1,0 +1,198 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { CIIU_TAXONOMY_REPOSITORY } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import type { CiiuTaxonomyRepository } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { AI_MATCH_CACHE_REPOSITORY } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import {
+  isRelationType,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+import {
+  ECOSYSTEMS,
+  VALUE_CHAIN_RULES,
+} from '@/recommendations/application/services/ValueChainRules'
+import { GEMINI_PORT } from '@/shared/shared.module'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+
+export interface InferredMatch {
+  hasMatch: boolean
+  relationType: RelationType | null
+  confidence: number
+  reason: string
+}
+
+const SAME_CIIU_CONFIDENCE = 0.85
+const SAME_CIIU_REASON =
+  'Misma actividad económica — referentes mutuos del mismo sector'
+
+@Injectable()
+export class AiMatchEngine {
+  constructor(
+    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+    @Inject(AI_MATCH_CACHE_REPOSITORY)
+    private readonly cache: AiMatchCacheRepository,
+    @Inject(CIIU_TAXONOMY_REPOSITORY)
+    private readonly ciiuRepo: CiiuTaxonomyRepository,
+  ) {}
+
+  async evaluate(
+    ciiuOrigen: string,
+    ciiuDestino: string,
+  ): Promise<InferredMatch> {
+    if (ciiuOrigen === ciiuDestino) {
+      const result: InferredMatch = {
+        hasMatch: true,
+        relationType: 'referente',
+        confidence: SAME_CIIU_CONFIDENCE,
+        reason: SAME_CIIU_REASON,
+      }
+      await this.persist(ciiuOrigen, ciiuDestino, result)
+      return result
+    }
+
+    const cached = await this.cache.get(ciiuOrigen, ciiuDestino)
+    if (cached) {
+      return {
+        hasMatch: cached.hasMatch,
+        relationType: cached.relationType,
+        confidence: cached.confidence ?? 0,
+        reason: cached.reason ?? '',
+      }
+    }
+
+    const [origen, destino] = await Promise.all([
+      this.ciiuRepo.findByCode(ciiuOrigen),
+      this.ciiuRepo.findByCode(ciiuDestino),
+    ])
+    if (!origen || !destino) {
+      const result: InferredMatch = {
+        hasMatch: false,
+        relationType: null,
+        confidence: 0,
+        reason: 'No DIAN data for one or both CIIUs',
+      }
+      await this.persist(ciiuOrigen, ciiuDestino, result)
+      return result
+    }
+
+    const applicableRules = VALUE_CHAIN_RULES.filter(
+      (r) =>
+        (r.ciiuOrigen === ciiuOrigen &&
+          (r.ciiuDestino === ciiuDestino || r.ciiuDestino === '*')) ||
+        (r.ciiuOrigen === ciiuDestino &&
+          (r.ciiuDestino === ciiuOrigen || r.ciiuDestino === '*')),
+    )
+    const applicableEcosystems = ECOSYSTEMS.filter(
+      (e) =>
+        e.ciiuCodes.includes(ciiuOrigen) && e.ciiuCodes.includes(ciiuDestino),
+    )
+
+    const rulesBlock =
+      applicableRules.length > 0
+        ? applicableRules
+            .map(
+              (r) =>
+                `- CIIU ${r.ciiuOrigen} → CIIU ${r.ciiuDestino}: ${r.description} (peso ${r.weight})`,
+            )
+            .join('\n')
+        : '(ninguna regla hardcoded aplica directamente — usa tu criterio)'
+
+    const ecosystemsBlock =
+      applicableEcosystems.length > 0
+        ? applicableEcosystems
+            .map(
+              (e) =>
+                `- Ecosistema "${e.name}": ${e.description}. CIIUs miembros: ${e.ciiuCodes.join(', ')}`,
+            )
+            .join('\n')
+        : '(no comparten ecosistema hardcoded — usa tu criterio)'
+
+    const prompt = `Sos un analista de negocios colombiano experto en cadenas de valor del Magdalena.
+
+CONOCIMIENTO PREVIO (úsalo como GUÍA, podés extender o desviar si ves algo razonable):
+
+Reglas conocidas que aplican a este par:
+${rulesBlock}
+
+Ecosistemas que comparten estos CIIUs:
+${ecosystemsBlock}
+
+PAR A EVALUAR:
+- Actividad A (origen): CIIU ${origen.code} — ${origen.titulo}
+  Sección: ${origen.seccion} (${origen.tituloSeccion})
+  División: ${origen.division} (${origen.tituloDivision})
+- Actividad B (destino): CIIU ${destino.code} — ${destino.titulo}
+  Sección: ${destino.seccion} (${destino.tituloSeccion})
+  División: ${destino.division} (${destino.tituloDivision})
+
+TAREA: ¿Tiene sentido recomendarle a una empresa con CIIU ${origen.code} otra empresa con CIIU ${destino.code}? Si sí, ¿qué tipo de relación tendrían?
+
+REGLAS DE TIPO:
+- "referente": misma o muy similar actividad → sirven de referencia mutua
+- "cliente": A le VENDE su producto/servicio a B
+- "proveedor": A le COMPRA su producto/servicio a B
+- "aliado": sirven al MISMO cliente final, complementarios horizontalmente, no se compiten
+- null: no hay relación de negocio razonable
+
+CONFIDENCE:
+- 0.85+ si la relación es muy clara y común en Colombia
+- 0.65-0.85 si es razonable pero depende del subsegmento
+- 0.5-0.65 si es plausible pero menos común
+- < 0.5 → marcá has_match: false
+
+Responde SOLO con JSON, sin explicaciones adicionales, sin markdown:
+{
+  "has_match": true | false,
+  "relation_type": "referente" | "cliente" | "proveedor" | "aliado" | null,
+  "confidence": 0.0,
+  "reason": "frase corta en español explicando POR QUÉ se relacionan (no copiar literal el título del CIIU)"
+}`
+
+    const result = await this.gemini.inferStructured<InferredMatch>(
+      prompt,
+      validateInferredMatch,
+    )
+    await this.persist(ciiuOrigen, ciiuDestino, result)
+    return result
+  }
+
+  private async persist(
+    ciiuOrigen: string,
+    ciiuDestino: string,
+    result: InferredMatch,
+  ): Promise<void> {
+    await this.cache.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen,
+        ciiuDestino,
+        hasMatch: result.hasMatch,
+        relationType: result.hasMatch ? result.relationType : null,
+        confidence: result.hasMatch ? result.confidence : null,
+        reason: result.reason || null,
+      }),
+    )
+  }
+}
+
+function validateInferredMatch(raw: unknown): InferredMatch {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('AiMatchEngine: expected object response from Gemini')
+  }
+  const r = raw as Record<string, unknown>
+  const confidence =
+    typeof r.confidence === 'number'
+      ? Math.max(0, Math.min(1, r.confidence))
+      : 0
+  const relationType =
+    typeof r.relation_type === 'string' && isRelationType(r.relation_type)
+      ? r.relation_type
+      : null
+  const hasMatch = r.has_match === true && relationType !== null
+  return {
+    hasMatch,
+    relationType,
+    confidence,
+    reason: typeof r.reason === 'string' ? r.reason : '',
+  }
+}

--- a/src/brain/src/recommendations/application/services/AllianceMatcher.ts
+++ b/src/brain/src/recommendations/application/services/AllianceMatcher.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import type { Company } from '@/companies/domain/entities/Company'
+import { ECOSYSTEMS } from '@/recommendations/application/services/ValueChainRules'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+const SAME_MUNICIPIO_SCORE = 0.75
+const DIFF_MUNICIPIO_SCORE = 0.55
+
+@Injectable()
+export class AllianceMatcher {
+  match(companies: Company[]): Map<string, Recommendation[]> {
+    const byCiiu = new Map<string, Company[]>()
+    for (const c of companies) {
+      const arr = byCiiu.get(c.ciiu) ?? []
+      arr.push(c)
+      byCiiu.set(c.ciiu, arr)
+    }
+
+    const out = new Map<string, Recommendation[]>()
+    const seen = new Set<string>()
+
+    for (const eco of ECOSYSTEMS) {
+      const members = eco.ciiuCodes.flatMap((code) => byCiiu.get(code) ?? [])
+      for (let i = 0; i < members.length; i++) {
+        for (let j = i + 1; j < members.length; j++) {
+          const a = members[i]
+          const b = members[j]
+          if (a.ciiu === b.ciiu) continue
+          if (a.id === b.id) continue
+          const dedupeKey = a.id < b.id ? `${a.id}|${b.id}` : `${b.id}|${a.id}`
+          if (seen.has(dedupeKey)) continue
+          seen.add(dedupeKey)
+
+          const score =
+            a.municipio === b.municipio
+              ? SAME_MUNICIPIO_SCORE
+              : DIFF_MUNICIPIO_SCORE
+          const reasonsA = Reasons.empty().add({
+            feature: 'ecosistema_compartido',
+            weight: 0.5,
+            value: eco.id,
+            description: `Ambas en el ecosistema ${eco.name}`,
+          })
+          const reasonsB = Reasons.empty().add({
+            feature: 'ecosistema_compartido',
+            weight: 0.5,
+            value: eco.id,
+            description: `Ambas en el ecosistema ${eco.name}`,
+          })
+
+          appendTo(
+            out,
+            a.id,
+            Recommendation.create({
+              id: randomUUID(),
+              sourceCompanyId: a.id,
+              targetCompanyId: b.id,
+              relationType: 'aliado',
+              score,
+              reasons: reasonsA,
+              source: 'ecosystem',
+            }),
+          )
+          appendTo(
+            out,
+            b.id,
+            Recommendation.create({
+              id: randomUUID(),
+              sourceCompanyId: b.id,
+              targetCompanyId: a.id,
+              relationType: 'aliado',
+              score,
+              reasons: reasonsB,
+              source: 'ecosystem',
+            }),
+          )
+        }
+      }
+    }
+    return out
+  }
+}
+
+function appendTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const arr = map.get(key) ?? []
+  arr.push(value)
+  map.set(key, arr)
+}

--- a/src/brain/src/recommendations/application/services/CandidateSelector.ts
+++ b/src/brain/src/recommendations/application/services/CandidateSelector.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import {
+  ECOSYSTEMS,
+  VALUE_CHAIN_RULES,
+} from '@/recommendations/application/services/ValueChainRules'
+
+export function canonicalPair(a: string, b: string): string {
+  return a <= b ? `${a}|${b}` : `${b}|${a}`
+}
+
+export interface CandidateCacheEntry {
+  hasMatch: boolean
+}
+
+@Injectable()
+export class CandidateSelector {
+  selectCiiuPairs(companies: Company[]): Set<string> {
+    const distinctCiius = Array.from(new Set(companies.map((c) => c.ciiu)))
+    const pairs = new Set<string>()
+
+    for (const a of distinctCiius) {
+      pairs.add(canonicalPair(a, a))
+
+      for (const b of distinctCiius) {
+        if (a === b) continue
+
+        if (a.slice(0, 2) === b.slice(0, 2)) {
+          pairs.add(canonicalPair(a, b))
+          continue
+        }
+
+        const inRules = VALUE_CHAIN_RULES.some(
+          (r) =>
+            (r.ciiuOrigen === a &&
+              (r.ciiuDestino === b || r.ciiuDestino === '*')) ||
+            (r.ciiuOrigen === b &&
+              (r.ciiuDestino === a || r.ciiuDestino === '*')),
+        )
+        if (inRules) {
+          pairs.add(canonicalPair(a, b))
+          continue
+        }
+
+        const inEcosystem = ECOSYSTEMS.some(
+          (e) => e.ciiuCodes.includes(a) && e.ciiuCodes.includes(b),
+        )
+        if (inEcosystem) {
+          pairs.add(canonicalPair(a, b))
+        }
+      }
+    }
+    return pairs
+  }
+
+  selectTargetCompanies(
+    source: Company,
+    allCompanies: Company[],
+    cache: Map<string, CandidateCacheEntry>,
+    topN: number = 30,
+  ): Company[] {
+    return allCompanies
+      .filter((t) => t.id !== source.id)
+      .filter(
+        (t) => cache.get(canonicalPair(source.ciiu, t.ciiu))?.hasMatch === true,
+      )
+      .map((t) => ({ company: t, score: proximityScore(source, t) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topN)
+      .map((x) => x.company)
+  }
+}
+
+function proximityScore(a: Company, b: Company): number {
+  let s = 0
+  if (a.municipio === b.municipio) s += 0.5
+  if (a.etapa === b.etapa) s += 0.3
+  if (a.ciiuDivision === b.ciiuDivision) s += 0.2
+  return s
+}

--- a/src/brain/src/recommendations/application/services/CiiuPairEvaluator.ts
+++ b/src/brain/src/recommendations/application/services/CiiuPairEvaluator.ts
@@ -1,0 +1,69 @@
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
+import { AI_MATCH_CACHE_REPOSITORY } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+
+export interface EvaluateAllStats {
+  total: number
+  cached: number
+  evaluated: number
+  errors: number
+}
+
+export interface EvaluateAllOptions {
+  concurrency?: number
+  onProgress?: (done: number, total: number) => void
+}
+
+@Injectable()
+export class CiiuPairEvaluator {
+  private readonly logger = new Logger(CiiuPairEvaluator.name)
+
+  constructor(
+    private readonly aiEngine: AiMatchEngine,
+    @Inject(AI_MATCH_CACHE_REPOSITORY)
+    private readonly cache: AiMatchCacheRepository,
+  ) {}
+
+  async evaluateAll(
+    pairs: Set<string>,
+    options: EvaluateAllOptions = {},
+  ): Promise<EvaluateAllStats> {
+    const concurrency = options.concurrency ?? 4
+    const stats: EvaluateAllStats = {
+      total: pairs.size,
+      cached: 0,
+      evaluated: 0,
+      errors: 0,
+    }
+    const queue = Array.from(pairs)
+
+    const workers = Array.from({ length: concurrency }, async () => {
+      while (queue.length > 0) {
+        const pair = queue.shift()
+        if (!pair) break
+        const [a, b] = pair.split('|')
+        try {
+          const existing = await this.cache.get(a, b)
+          if (existing) {
+            stats.cached++
+          } else {
+            await this.aiEngine.evaluate(a, b)
+            stats.evaluated++
+          }
+        } catch (e) {
+          stats.errors++
+          const message = e instanceof Error ? e.message : String(e)
+          this.logger.warn(`Failed to evaluate pair ${pair}: ${message}`)
+        }
+        options.onProgress?.(
+          stats.cached + stats.evaluated + stats.errors,
+          stats.total,
+        )
+      }
+    })
+
+    await Promise.all(workers)
+    return stats
+  }
+}

--- a/src/brain/src/recommendations/application/services/FeatureVectorBuilder.ts
+++ b/src/brain/src/recommendations/application/services/FeatureVectorBuilder.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import { ETAPAS, type Etapa } from '@/companies/domain/value-objects/Etapa'
+
+export interface CompanyVector {
+  ciiuClase: string
+  ciiuDivision: string
+  ciiuSeccion: string
+  municipio: string
+  etapaOrdinal: number
+  personalLog: number
+  ingresoLog: number
+}
+
+const PERSONAL_LOG_MAX = Math.log10(10_000 + 1)
+const INGRESO_LOG_MAX = Math.log10(10_000_000_000 + 1)
+
+@Injectable()
+export class FeatureVectorBuilder {
+  build(c: Company): CompanyVector {
+    return {
+      ciiuClase: c.ciiu,
+      ciiuDivision: c.ciiuDivision,
+      ciiuSeccion: c.ciiuSeccion,
+      municipio: c.municipio,
+      etapaOrdinal: etapaOrdinal(c.etapa),
+      personalLog: normalizeLog(c.personal, PERSONAL_LOG_MAX),
+      ingresoLog: normalizeLog(c.ingresoOperacion, INGRESO_LOG_MAX),
+    }
+  }
+
+  proximity(a: CompanyVector, b: CompanyVector): number {
+    let s = 0
+    if (a.municipio === b.municipio) s += 0.4
+    if (a.etapaOrdinal === b.etapaOrdinal) s += 0.3
+    s += (1 - Math.abs(a.personalLog - b.personalLog)) * 0.2
+    s += (1 - Math.abs(a.ingresoLog - b.ingresoLog)) * 0.1
+    return Math.min(s, 1)
+  }
+}
+
+function etapaOrdinal(e: Etapa): number {
+  return ETAPAS.indexOf(e) + 1
+}
+
+function normalizeLog(value: number, max: number): number {
+  if (value <= 0) return 0
+  const log = Math.log10(value + 1)
+  return Math.max(0, Math.min(1, log / max))
+}

--- a/src/brain/src/recommendations/application/services/PeerMatcher.ts
+++ b/src/brain/src/recommendations/application/services/PeerMatcher.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import type { Company } from '@/companies/domain/entities/Company'
+import {
+  FeatureVectorBuilder,
+  type CompanyVector,
+} from '@/recommendations/application/services/FeatureVectorBuilder'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import {
+  Reasons,
+  type Reason,
+} from '@/recommendations/domain/value-objects/Reason'
+
+export interface PeerMatcherOptions {
+  topN?: number
+}
+
+@Injectable()
+export class PeerMatcher {
+  constructor(private readonly vectorBuilder: FeatureVectorBuilder) {}
+
+  match(
+    companies: Company[],
+    options: PeerMatcherOptions = {},
+  ): Map<string, Recommendation[]> {
+    const topN = options.topN ?? 10
+    const vectors = new Map<string, CompanyVector>()
+    for (const c of companies) {
+      vectors.set(c.id, this.vectorBuilder.build(c))
+    }
+
+    const byDivision = new Map<string, Company[]>()
+    for (const c of companies) {
+      const arr = byDivision.get(c.ciiuDivision) ?? []
+      arr.push(c)
+      byDivision.set(c.ciiuDivision, arr)
+    }
+
+    const out = new Map<string, Recommendation[]>()
+    for (const source of companies) {
+      const peers = byDivision.get(source.ciiuDivision) ?? []
+      const scored = peers
+        .filter((p) => p.id !== source.id)
+        .map((target) => {
+          const score = this.vectorBuilder.proximity(
+            vectors.get(source.id)!,
+            vectors.get(target.id)!,
+          )
+          return { target, score }
+        })
+        .filter(({ score }) => score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, topN)
+
+      const recs = scored.map(({ target, score }) =>
+        Recommendation.create({
+          id: randomUUID(),
+          sourceCompanyId: source.id,
+          targetCompanyId: target.id,
+          relationType: 'referente',
+          score,
+          reasons: buildReasons(source, target),
+          source: 'cosine',
+        }),
+      )
+      out.set(source.id, recs)
+    }
+    return out
+  }
+}
+
+function buildReasons(source: Company, target: Company): Reasons {
+  const items: Reason[] = []
+  if (source.ciiu === target.ciiu) {
+    items.push({
+      feature: 'mismo_ciiu_clase',
+      weight: 0.4,
+      value: source.ciiu,
+      description: `Misma clase CIIU ${source.ciiu}`,
+    })
+  } else if (source.ciiuDivision === target.ciiuDivision) {
+    items.push({
+      feature: 'mismo_ciiu_division',
+      weight: 0.25,
+      value: source.ciiuDivision,
+      description: `Misma división CIIU ${source.ciiuDivision}`,
+    })
+  }
+  if (source.municipio === target.municipio) {
+    items.push({
+      feature: 'mismo_municipio',
+      weight: 0.3,
+      value: source.municipio,
+      description: `Mismo municipio: ${source.municipio}`,
+    })
+  }
+  if (source.etapa === target.etapa) {
+    items.push({
+      feature: 'misma_etapa',
+      weight: 0.2,
+      value: source.etapa,
+      description: `Misma etapa: ${source.etapa}`,
+    })
+  }
+  return Reasons.from(items)
+}

--- a/src/brain/src/recommendations/application/services/ValueChainMatcher.ts
+++ b/src/brain/src/recommendations/application/services/ValueChainMatcher.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import type { Company } from '@/companies/domain/entities/Company'
+import { VALUE_CHAIN_RULES } from '@/recommendations/application/services/ValueChainRules'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+const SAME_MUNICIPIO_BOOST = 1
+const DIFF_MUNICIPIO_FACTOR = 0.85
+
+@Injectable()
+export class ValueChainMatcher {
+  match(companies: Company[]): Map<string, Recommendation[]> {
+    const byCiiu = new Map<string, Company[]>()
+    for (const c of companies) {
+      const arr = byCiiu.get(c.ciiu) ?? []
+      arr.push(c)
+      byCiiu.set(c.ciiu, arr)
+    }
+
+    const out = new Map<string, Recommendation[]>()
+    for (const rule of VALUE_CHAIN_RULES) {
+      const sources = byCiiu.get(rule.ciiuOrigen) ?? []
+      const targets =
+        rule.ciiuDestino === '*'
+          ? companies.filter((c) => c.ciiu !== rule.ciiuOrigen)
+          : (byCiiu.get(rule.ciiuDestino) ?? [])
+
+      for (const s of sources) {
+        for (const t of targets) {
+          if (s.id === t.id) continue
+          const factor =
+            s.municipio === t.municipio
+              ? SAME_MUNICIPIO_BOOST
+              : DIFF_MUNICIPIO_FACTOR
+          const score = Math.min(1, rule.weight * factor)
+
+          appendTo(
+            out,
+            s.id,
+            Recommendation.create({
+              id: randomUUID(),
+              sourceCompanyId: s.id,
+              targetCompanyId: t.id,
+              relationType: 'cliente',
+              score,
+              reasons: Reasons.empty().add({
+                feature: 'cadena_valor_directa',
+                weight: rule.weight,
+                description: rule.description,
+              }),
+              source: 'rule',
+            }),
+          )
+          appendTo(
+            out,
+            t.id,
+            Recommendation.create({
+              id: randomUUID(),
+              sourceCompanyId: t.id,
+              targetCompanyId: s.id,
+              relationType: 'proveedor',
+              score,
+              reasons: Reasons.empty().add({
+                feature: 'cadena_valor_inversa',
+                weight: rule.weight,
+                description: rule.description,
+              }),
+              source: 'rule',
+            }),
+          )
+        }
+      }
+    }
+    return out
+  }
+}
+
+function appendTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const arr = map.get(key) ?? []
+  arr.push(value)
+  map.set(key, arr)
+}

--- a/src/brain/src/recommendations/application/services/ValueChainRules.ts
+++ b/src/brain/src/recommendations/application/services/ValueChainRules.ts
@@ -1,0 +1,218 @@
+export interface ValueChainRule {
+  ciiuOrigen: string
+  ciiuDestino: string
+  weight: number
+  description: string
+}
+
+export interface Ecosystem {
+  id: string
+  name: string
+  ciiuCodes: string[]
+  description: string
+}
+
+export const VALUE_CHAIN_RULES: ValueChainRule[] = [
+  {
+    ciiuOrigen: '0122',
+    ciiuDestino: '4631',
+    weight: 0.85,
+    description: 'Banano hacia mayoristas de alimentos',
+  },
+  {
+    ciiuOrigen: '0126',
+    ciiuDestino: '4631',
+    weight: 0.85,
+    description: 'Palma de aceite hacia mayoristas',
+  },
+  {
+    ciiuOrigen: '0121',
+    ciiuDestino: '4720',
+    weight: 0.8,
+    description: 'Frutas tropicales hacia minoristas alimentos',
+  },
+  {
+    ciiuOrigen: '4631',
+    ciiuDestino: '5611',
+    weight: 0.85,
+    description: 'Mayorista de alimentos abastece restaurantes',
+  },
+  {
+    ciiuOrigen: '4631',
+    ciiuDestino: '5630',
+    weight: 0.75,
+    description: 'Mayorista abastece bares',
+  },
+  {
+    ciiuOrigen: '4719',
+    ciiuDestino: '5611',
+    weight: 0.7,
+    description: 'Mayorista general hacia restaurantes',
+  },
+  {
+    ciiuOrigen: '4923',
+    ciiuDestino: '4290',
+    weight: 0.85,
+    description: 'Transporte de carga para construcción',
+  },
+  {
+    ciiuOrigen: '4923',
+    ciiuDestino: '4631',
+    weight: 0.8,
+    description: 'Transporte de carga para mayoristas',
+  },
+  {
+    ciiuOrigen: '4923',
+    ciiuDestino: '0122',
+    weight: 0.75,
+    description: 'Transporte de carga para agro',
+  },
+  {
+    ciiuOrigen: '6810',
+    ciiuDestino: '4921',
+    weight: 0.85,
+    description: 'Alquiler de vehículos para flotas de transporte',
+  },
+  {
+    ciiuOrigen: '6810',
+    ciiuDestino: '4923',
+    weight: 0.85,
+    description: 'Alquiler de vehículos para flotas de carga',
+  },
+  {
+    ciiuOrigen: '4111',
+    ciiuDestino: '4290',
+    weight: 0.85,
+    description: 'Movimiento de tierra para construcción general',
+  },
+  {
+    ciiuOrigen: '4752',
+    ciiuDestino: '4290',
+    weight: 0.85,
+    description: 'Ferretería abastece obras',
+  },
+  {
+    ciiuOrigen: '7112',
+    ciiuDestino: '4290',
+    weight: 0.85,
+    description: 'Ingeniería para construcción',
+  },
+  {
+    ciiuOrigen: '6910',
+    ciiuDestino: '4290',
+    weight: 0.65,
+    description: 'Servicios legales para constructoras',
+  },
+  {
+    ciiuOrigen: '7912',
+    ciiuDestino: '5511',
+    weight: 0.85,
+    description: 'Seguridad para hoteles',
+  },
+  {
+    ciiuOrigen: '7912',
+    ciiuDestino: '4290',
+    weight: 0.75,
+    description: 'Seguridad para obras',
+  },
+  {
+    ciiuOrigen: '7020',
+    ciiuDestino: '5511',
+    weight: 0.6,
+    description: 'Eventos corporativos en hoteles',
+  },
+  {
+    ciiuOrigen: '4921',
+    ciiuDestino: '5511',
+    weight: 0.85,
+    description: 'Transporte turístico hacia hoteles',
+  },
+  {
+    ciiuOrigen: '4921',
+    ciiuDestino: '5519',
+    weight: 0.85,
+    description: 'Transporte turístico hacia hostales',
+  },
+  {
+    ciiuOrigen: '7310',
+    ciiuDestino: '5611',
+    weight: 0.65,
+    description: 'Publicidad para restaurantes',
+  },
+  {
+    ciiuOrigen: '7310',
+    ciiuDestino: '5511',
+    weight: 0.65,
+    description: 'Publicidad para hoteles',
+  },
+  {
+    ciiuOrigen: '6910',
+    ciiuDestino: '*',
+    weight: 0.4,
+    description: 'Servicios legales B2B universal',
+  },
+  {
+    ciiuOrigen: '7020',
+    ciiuDestino: '*',
+    weight: 0.4,
+    description: 'Servicios contables/asesoría B2B universal',
+  },
+]
+
+export const ECOSYSTEMS: Ecosystem[] = [
+  {
+    id: 'turismo',
+    name: 'Turismo',
+    ciiuCodes: ['5511', '5519', '5611', '5630', '4921', '6810'],
+    description: 'Empresas que sirven al turista que visita Santa Marta',
+  },
+  {
+    id: 'construccion',
+    name: 'Construcción',
+    ciiuCodes: ['4290', '4111', '7112', '4752', '6910', '4923'],
+    description: 'Cadena del proyecto inmobiliario y obra civil',
+  },
+  {
+    id: 'servicios-profesionales',
+    name: 'Servicios Profesionales B2B',
+    ciiuCodes: ['6910', '7020', '7490', '7310'],
+    description: 'Servicios complementarios para empresas',
+  },
+  {
+    id: 'agro-exportador',
+    name: 'Agro Exportador',
+    ciiuCodes: ['0122', '0126', '0121', '4631', '4923'],
+    description: 'Cadena agro-exportador del Magdalena',
+  },
+  {
+    id: 'salud',
+    name: 'Salud',
+    ciiuCodes: ['8610', '8621', '8692', '7912'],
+    description: 'Ecosistema de servicios de salud',
+  },
+  {
+    id: 'educacion',
+    name: 'Educación',
+    ciiuCodes: ['8512', '8551', '8559'],
+    description: 'Ecosistema educativo formal y no formal',
+  },
+]
+
+export function findRulesForPair(
+  ciiuOrigen: string,
+  ciiuDestino: string,
+  rules: ValueChainRule[] = VALUE_CHAIN_RULES,
+): ValueChainRule[] {
+  return rules.filter(
+    (r) =>
+      r.ciiuOrigen === ciiuOrigen &&
+      (r.ciiuDestino === '*' || r.ciiuDestino === ciiuDestino),
+  )
+}
+
+export function findEcosystemsContaining(
+  ciiu: string,
+  ecosystems: Ecosystem[] = ECOSYSTEMS,
+): Ecosystem[] {
+  return ecosystems.filter((e) => e.ciiuCodes.includes(ciiu))
+}

--- a/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
+++ b/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
@@ -1,0 +1,62 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { UseCase } from '@/shared/domain/UseCase'
+import { GEMINI_PORT } from '@/shared/shared.module'
+
+export interface ExplainRecommendationInput {
+  recommendationId: string
+}
+
+export interface ExplainRecommendationResult {
+  explanation: string
+}
+
+@Injectable()
+export class ExplainRecommendation implements UseCase<
+  ExplainRecommendationInput,
+  ExplainRecommendationResult
+> {
+  constructor(
+    @Inject(RECOMMENDATION_REPOSITORY)
+    private readonly recRepo: RecommendationRepository,
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+  ) {}
+
+  async execute(
+    input: ExplainRecommendationInput,
+  ): Promise<ExplainRecommendationResult> {
+    const rec = await this.recRepo.findById(input.recommendationId)
+    if (!rec) {
+      throw new Error(`Recommendation not found: ${input.recommendationId}`)
+    }
+    if (rec.explanation) {
+      return { explanation: rec.explanation }
+    }
+
+    const [source, target] = await Promise.all([
+      this.companyRepo.findById(rec.sourceCompanyId),
+      this.companyRepo.findById(rec.targetCompanyId),
+    ])
+    if (!source || !target) {
+      throw new Error(
+        `Companies not found for recommendation ${input.recommendationId}`,
+      )
+    }
+
+    const prompt = `Sos un asesor empresarial colombiano. Explicá en 2-3 frases por qué la empresa "${source.razonSocial}" (CIIU ${source.ciiu}, ${source.municipio}) podría conectarse con "${target.razonSocial}" (CIIU ${target.ciiu}, ${target.municipio}) como ${rec.relationType}.
+
+Razones estructuradas detectadas: ${JSON.stringify(rec.reasons.toJson())}
+
+Tono: profesional pero cercano, en español rioplatense neutro. Termina con un siguiente paso concreto que el empresario debería hacer.`
+
+    const explanation = await this.gemini.generateText(prompt)
+    await this.recRepo.updateExplanation(rec.id, explanation)
+    return { explanation }
+  }
+}

--- a/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
@@ -1,0 +1,284 @@
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import type { Company } from '@/companies/domain/entities/Company'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import {
+  CandidateSelector,
+  canonicalPair,
+} from '@/recommendations/application/services/CandidateSelector'
+import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
+import {
+  FeatureVectorBuilder,
+  type CompanyVector,
+} from '@/recommendations/application/services/FeatureVectorBuilder'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { AI_MATCH_CACHE_REPOSITORY } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import {
+  inverseRelation,
+  type RelationType,
+  RELATION_TYPES,
+} from '@/recommendations/domain/value-objects/RelationType'
+import { env } from '@/shared/infrastructure/env'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GenerateRecommendationsInput {
+  enableAi?: boolean
+}
+
+export interface GenerateRecommendationsResult {
+  totalRecommendations: number
+  companiesWithRecs: number
+  byRelationType: Record<RelationType, number>
+}
+
+const MIN_CONFIDENCE = 0.5
+const TOP_PER_TYPE = 5
+const TOP_TOTAL = 20
+const AI_WEIGHT = 0.6
+const PROXIMITY_WEIGHT = 0.4
+
+@Injectable()
+export class GenerateRecommendations implements UseCase<
+  GenerateRecommendationsInput,
+  GenerateRecommendationsResult
+> {
+  private readonly logger = new Logger(GenerateRecommendations.name)
+
+  constructor(
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    @Inject(RECOMMENDATION_REPOSITORY)
+    private readonly recRepo: RecommendationRepository,
+    @Inject(AI_MATCH_CACHE_REPOSITORY)
+    private readonly cache: AiMatchCacheRepository,
+    private readonly candidateSelector: CandidateSelector,
+    private readonly ciiuPairEvaluator: CiiuPairEvaluator,
+    private readonly featureBuilder: FeatureVectorBuilder,
+    private readonly peer: PeerMatcher,
+    private readonly valueChain: ValueChainMatcher,
+    private readonly alliance: AllianceMatcher,
+  ) {}
+
+  async execute(
+    input: GenerateRecommendationsInput = {},
+  ): Promise<GenerateRecommendationsResult> {
+    const aiEnabled = resolveAiEnabled(input.enableAi)
+
+    const companies = (await this.companyRepo.findAll()).filter(
+      (c) => c.estado === 'ACTIVO',
+    )
+
+    let recsBySource: Map<string, Recommendation[]>
+    if (aiEnabled) {
+      try {
+        const pairs = this.candidateSelector.selectCiiuPairs(companies)
+        const stats = await this.ciiuPairEvaluator.evaluateAll(pairs, {
+          concurrency: 4,
+        })
+        this.logger.log(
+          `AI eval stats: total=${stats.total} cached=${stats.cached} evaluated=${stats.evaluated} errors=${stats.errors}`,
+        )
+        recsBySource = await this.expandFromCache(companies)
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        this.logger.error(
+          `AI orchestration failed: ${message} — falling back to hardcoded matchers`,
+        )
+        recsBySource = this.runFallback(companies)
+      }
+    } else {
+      this.logger.log('AI disabled — using hardcoded matchers')
+      recsBySource = this.runFallback(companies)
+    }
+
+    const limited = this.limit(this.dedupe(recsBySource))
+
+    await this.recRepo.deleteAll()
+    await this.recRepo.saveAll(flatten(limited))
+
+    return computeStats(limited)
+  }
+
+  private async expandFromCache(
+    companies: Company[],
+  ): Promise<Map<string, Recommendation[]>> {
+    const allEntries = await this.cache.findAll()
+    const cacheMap = new Map<
+      string,
+      { confidence: number; relationType: RelationType; reason: string }
+    >()
+    for (const e of allEntries) {
+      if (!e.hasMatch || !e.relationType) continue
+      if ((e.confidence ?? 0) < MIN_CONFIDENCE) continue
+      cacheMap.set(canonicalPair(e.ciiuOrigen, e.ciiuDestino), {
+        confidence: e.confidence ?? 0,
+        relationType: e.relationType,
+        reason: e.reason ?? '',
+      })
+    }
+
+    const vectors = new Map<string, CompanyVector>(
+      companies.map((c) => [c.id, this.featureBuilder.build(c)]),
+    )
+
+    const out = new Map<string, Recommendation[]>()
+    for (const source of companies) {
+      const sourceVec = vectors.get(source.id)!
+      for (const target of companies) {
+        if (source.id === target.id) continue
+        const entry = cacheMap.get(canonicalPair(source.ciiu, target.ciiu))
+        if (!entry) continue
+
+        const proximity = this.featureBuilder.proximity(
+          sourceVec,
+          vectors.get(target.id)!,
+        )
+        const score = Math.min(
+          1,
+          entry.confidence * (AI_WEIGHT + PROXIMITY_WEIGHT * proximity),
+        )
+
+        const relationType =
+          source.ciiu <= target.ciiu
+            ? entry.relationType
+            : inverseRelation(entry.relationType)
+
+        const reasons = Reasons.from([
+          {
+            feature: 'ai_inferido',
+            weight: entry.confidence,
+            description: entry.reason,
+          },
+        ])
+        const reasonsWithMunicipio =
+          source.municipio === target.municipio
+            ? reasons.add({
+                feature: 'mismo_municipio',
+                weight: 0.2,
+                value: source.municipio,
+                description: `Ambas en ${source.municipio}`,
+              })
+            : reasons
+
+        appendTo(
+          out,
+          source.id,
+          Recommendation.create({
+            id: randomUUID(),
+            sourceCompanyId: source.id,
+            targetCompanyId: target.id,
+            relationType,
+            score,
+            reasons: reasonsWithMunicipio,
+            source: 'ai-inferred',
+          }),
+        )
+      }
+    }
+    return out
+  }
+
+  private runFallback(companies: Company[]): Map<string, Recommendation[]> {
+    const out = new Map<string, Recommendation[]>()
+    mergeInto(out, this.peer.match(companies, { topN: TOP_PER_TYPE }))
+    mergeInto(out, this.valueChain.match(companies))
+    mergeInto(out, this.alliance.match(companies))
+    return out
+  }
+
+  private dedupe(
+    recs: Map<string, Recommendation[]>,
+  ): Map<string, Recommendation[]> {
+    const out = new Map<string, Recommendation[]>()
+    for (const [sourceId, list] of recs) {
+      const byKey = new Map<string, Recommendation>()
+      for (const rec of list) {
+        const key = `${rec.targetCompanyId}|${rec.relationType}`
+        const existing = byKey.get(key)
+        if (!existing || rec.score > existing.score) {
+          byKey.set(key, rec)
+        }
+      }
+      out.set(sourceId, Array.from(byKey.values()))
+    }
+    return out
+  }
+
+  private limit(
+    recs: Map<string, Recommendation[]>,
+  ): Map<string, Recommendation[]> {
+    const out = new Map<string, Recommendation[]>()
+    for (const [sourceId, list] of recs) {
+      const byType = new Map<RelationType, Recommendation[]>()
+      const sorted = [...list].sort((a, b) => b.score - a.score)
+      for (const rec of sorted) {
+        const arr = byType.get(rec.relationType) ?? []
+        if (arr.length < TOP_PER_TYPE) {
+          arr.push(rec)
+          byType.set(rec.relationType, arr)
+        }
+      }
+      const merged = Array.from(byType.values()).flat()
+      const trimmed = merged
+        .sort((a, b) => b.score - a.score)
+        .slice(0, TOP_TOTAL)
+      out.set(sourceId, trimmed)
+    }
+    return out
+  }
+}
+
+function resolveAiEnabled(override: boolean | undefined): boolean {
+  if (override !== undefined) return override
+  return env.AI_MATCH_INFERENCE_ENABLED === 'true'
+}
+
+function flatten(recs: Map<string, Recommendation[]>): Recommendation[] {
+  return Array.from(recs.values()).flat()
+}
+
+function appendTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const arr = map.get(key) ?? []
+  arr.push(value)
+  map.set(key, arr)
+}
+
+function mergeInto(
+  target: Map<string, Recommendation[]>,
+  source: Map<string, Recommendation[]>,
+): void {
+  for (const [key, list] of source) {
+    const existing = target.get(key) ?? []
+    target.set(key, existing.concat(list))
+  }
+}
+
+function computeStats(
+  recs: Map<string, Recommendation[]>,
+): GenerateRecommendationsResult {
+  const byRelationType: Record<RelationType, number> = {
+    referente: 0,
+    cliente: 0,
+    proveedor: 0,
+    aliado: 0,
+  }
+  let total = 0
+  let companiesWithRecs = 0
+  for (const list of recs.values()) {
+    if (list.length > 0) companiesWithRecs++
+    for (const rec of list) {
+      total++
+      byRelationType[rec.relationType]++
+    }
+  }
+  void RELATION_TYPES
+  return { totalRecommendations: total, companiesWithRecs, byRelationType }
+}

--- a/src/brain/src/recommendations/application/use-cases/GetCompanyRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GetCompanyRecommendations.ts
@@ -1,0 +1,107 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
+import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
+import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { Reason } from '@/recommendations/domain/value-objects/Reason'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+import type { RecommendationSource } from '@/recommendations/domain/entities/Recommendation'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GetCompanyRecommendationsInput {
+  companyId: string
+  type?: RelationType
+  limit?: number
+}
+
+export interface RecommendationTargetView {
+  id: string
+  razonSocial: string
+  ciiu: string
+  ciiuSeccion: string
+  ciiuDivision: string
+  municipio: string
+  etapa: string
+  personal: number
+  ingreso: number
+}
+
+export interface RecommendationView {
+  id: string
+  targetCompany: RecommendationTargetView | null
+  relationType: RelationType
+  score: number
+  reasons: Reason[]
+  source: RecommendationSource
+  explanation: string | null
+}
+
+export interface GetCompanyRecommendationsResult {
+  recommendations: RecommendationView[]
+}
+
+const DEFAULT_LIMIT = 10
+
+@Injectable()
+export class GetCompanyRecommendations implements UseCase<
+  GetCompanyRecommendationsInput,
+  GetCompanyRecommendationsResult
+> {
+  constructor(
+    @Inject(RECOMMENDATION_REPOSITORY)
+    private readonly recRepo: RecommendationRepository,
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+  ) {}
+
+  async execute(
+    input: GetCompanyRecommendationsInput,
+  ): Promise<GetCompanyRecommendationsResult> {
+    const limit = input.limit ?? DEFAULT_LIMIT
+    const recs = input.type
+      ? await this.recRepo.findBySourceAndType(
+          input.companyId,
+          input.type,
+          limit,
+        )
+      : await this.recRepo.findBySource(input.companyId, limit)
+
+    const targetIds = Array.from(new Set(recs.map((r) => r.targetCompanyId)))
+    const targets = await Promise.all(
+      targetIds.map((id) => this.companyRepo.findById(id)),
+    )
+    const targetMap = new Map<string, Company>()
+    for (const t of targets) {
+      if (t) targetMap.set(t.id, t)
+    }
+
+    return {
+      recommendations: recs.map((r) => ({
+        id: r.id,
+        targetCompany: targetMap.has(r.targetCompanyId)
+          ? toTargetView(targetMap.get(r.targetCompanyId)!)
+          : null,
+        relationType: r.relationType,
+        score: r.score,
+        reasons: r.reasons.toJson(),
+        source: r.source,
+        explanation: r.explanation,
+      })),
+    }
+  }
+}
+
+function toTargetView(c: Company): RecommendationTargetView {
+  return {
+    id: c.id,
+    razonSocial: c.razonSocial,
+    ciiu: c.ciiu,
+    ciiuSeccion: c.ciiuSeccion,
+    ciiuDivision: c.ciiuDivision,
+    municipio: c.municipio,
+    etapa: c.etapa,
+    personal: c.personal,
+    ingreso: c.ingresoOperacion,
+  }
+}

--- a/src/brain/src/recommendations/domain/entities/AiMatchCacheEntry.ts
+++ b/src/brain/src/recommendations/domain/entities/AiMatchCacheEntry.ts
@@ -1,0 +1,88 @@
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+
+interface AiMatchCacheEntryProps {
+  ciiuOrigen: string
+  ciiuDestino: string
+  hasMatch: boolean
+  relationType: RelationType | null
+  confidence: number | null
+  reason: string | null
+  cachedAt: Date
+}
+
+export interface CreateAiMatchCacheEntryInput {
+  ciiuOrigen: string
+  ciiuDestino: string
+  hasMatch: boolean
+  relationType?: RelationType | null
+  confidence?: number | null
+  reason?: string | null
+  cachedAt?: Date
+}
+
+export class AiMatchCacheEntry {
+  private constructor(private readonly props: AiMatchCacheEntryProps) {
+    Object.freeze(this.props)
+  }
+
+  static create(data: CreateAiMatchCacheEntryInput): AiMatchCacheEntry {
+    const ciiuOrigen = data.ciiuOrigen?.trim() ?? ''
+    if (ciiuOrigen.length === 0) {
+      throw new Error('AiMatchCacheEntry.ciiuOrigen cannot be empty')
+    }
+    const ciiuDestino = data.ciiuDestino?.trim() ?? ''
+    if (ciiuDestino.length === 0) {
+      throw new Error('AiMatchCacheEntry.ciiuDestino cannot be empty')
+    }
+    if (data.hasMatch && !data.relationType) {
+      throw new Error(
+        'AiMatchCacheEntry with hasMatch=true requires a relationType',
+      )
+    }
+    if (
+      data.confidence !== null &&
+      data.confidence !== undefined &&
+      (data.confidence < 0 || data.confidence > 1)
+    ) {
+      throw new Error(
+        `AiMatchCacheEntry.confidence must be between 0 and 1, got ${data.confidence}`,
+      )
+    }
+
+    return new AiMatchCacheEntry({
+      ciiuOrigen,
+      ciiuDestino,
+      hasMatch: data.hasMatch,
+      relationType: data.relationType ?? null,
+      confidence: data.confidence ?? null,
+      reason: data.reason ?? null,
+      cachedAt: data.cachedAt ?? new Date(),
+    })
+  }
+
+  get ciiuOrigen(): string {
+    return this.props.ciiuOrigen
+  }
+  get ciiuDestino(): string {
+    return this.props.ciiuDestino
+  }
+  get hasMatch(): boolean {
+    return this.props.hasMatch
+  }
+  get relationType(): RelationType | null {
+    return this.props.relationType
+  }
+  get confidence(): number | null {
+    return this.props.confidence
+  }
+  get reason(): string | null {
+    return this.props.reason
+  }
+  get cachedAt(): Date {
+    return this.props.cachedAt
+  }
+
+  get key(): string {
+    return `${this.props.ciiuOrigen}->${this.props.ciiuDestino}`
+  }
+}

--- a/src/brain/src/recommendations/domain/entities/Recommendation.ts
+++ b/src/brain/src/recommendations/domain/entities/Recommendation.ts
@@ -1,0 +1,115 @@
+import { Entity } from '@/shared/domain/Entity'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+export const RECOMMENDATION_SOURCES = [
+  'rule',
+  'cosine',
+  'ecosystem',
+  'ai-inferred',
+] as const
+
+export type RecommendationSource = (typeof RECOMMENDATION_SOURCES)[number]
+
+export function isRecommendationSource(s: string): s is RecommendationSource {
+  return (RECOMMENDATION_SOURCES as readonly string[]).includes(s)
+}
+
+interface RecommendationProps {
+  sourceCompanyId: string
+  targetCompanyId: string
+  relationType: RelationType
+  score: number
+  reasons: Reasons
+  source: RecommendationSource
+  explanation: string | null
+  explanationCachedAt: Date | null
+}
+
+export interface CreateRecommendationInput {
+  id: string
+  sourceCompanyId: string
+  targetCompanyId: string
+  relationType: RelationType
+  score: number
+  reasons: Reasons
+  source: RecommendationSource
+  explanation?: string | null
+  explanationCachedAt?: Date | null
+}
+
+export class Recommendation extends Entity<string> {
+  private readonly props: RecommendationProps
+
+  private constructor(id: string, props: RecommendationProps) {
+    super(id)
+    this.props = Object.freeze(props)
+  }
+
+  static create(data: CreateRecommendationInput): Recommendation {
+    const id = data.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('Recommendation.id cannot be empty')
+    }
+    const sourceCompanyId = data.sourceCompanyId?.trim() ?? ''
+    if (sourceCompanyId.length === 0) {
+      throw new Error('Recommendation.sourceCompanyId cannot be empty')
+    }
+    const targetCompanyId = data.targetCompanyId?.trim() ?? ''
+    if (targetCompanyId.length === 0) {
+      throw new Error('Recommendation.targetCompanyId cannot be empty')
+    }
+    if (sourceCompanyId === targetCompanyId) {
+      throw new Error('Cannot recommend a company to itself')
+    }
+    if (data.score < 0 || data.score > 1) {
+      throw new Error(
+        `Recommendation.score must be between 0 and 1, got ${data.score}`,
+      )
+    }
+
+    return new Recommendation(id, {
+      sourceCompanyId,
+      targetCompanyId,
+      relationType: data.relationType,
+      score: data.score,
+      reasons: data.reasons,
+      source: data.source,
+      explanation: data.explanation ?? null,
+      explanationCachedAt: data.explanationCachedAt ?? null,
+    })
+  }
+
+  withExplanation(explanation: string, cachedAt: Date): Recommendation {
+    return new Recommendation(this.id, {
+      ...this.props,
+      explanation,
+      explanationCachedAt: cachedAt,
+    })
+  }
+
+  get sourceCompanyId(): string {
+    return this.props.sourceCompanyId
+  }
+  get targetCompanyId(): string {
+    return this.props.targetCompanyId
+  }
+  get relationType(): RelationType {
+    return this.props.relationType
+  }
+  get score(): number {
+    return this.props.score
+  }
+  get reasons(): Reasons {
+    return this.props.reasons
+  }
+  get source(): RecommendationSource {
+    return this.props.source
+  }
+  get explanation(): string | null {
+    return this.props.explanation
+  }
+  get explanationCachedAt(): Date | null {
+    return this.props.explanationCachedAt
+  }
+}

--- a/src/brain/src/recommendations/domain/repositories/AiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/domain/repositories/AiMatchCacheRepository.ts
@@ -9,4 +9,5 @@ export interface AiMatchCacheRepository {
   ): Promise<AiMatchCacheEntry | null>
   put(entry: AiMatchCacheEntry): Promise<void>
   size(): Promise<number>
+  findAll(): Promise<AiMatchCacheEntry[]>
 }

--- a/src/brain/src/recommendations/domain/repositories/AiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/domain/repositories/AiMatchCacheRepository.ts
@@ -1,0 +1,12 @@
+import type { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+
+export const AI_MATCH_CACHE_REPOSITORY = Symbol('AI_MATCH_CACHE_REPOSITORY')
+
+export interface AiMatchCacheRepository {
+  get(
+    ciiuOrigen: string,
+    ciiuDestino: string,
+  ): Promise<AiMatchCacheEntry | null>
+  put(entry: AiMatchCacheEntry): Promise<void>
+  size(): Promise<number>
+}

--- a/src/brain/src/recommendations/domain/repositories/RecommendationRepository.ts
+++ b/src/brain/src/recommendations/domain/repositories/RecommendationRepository.ts
@@ -1,0 +1,18 @@
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+
+export const RECOMMENDATION_REPOSITORY = Symbol('RECOMMENDATION_REPOSITORY')
+
+export interface RecommendationRepository {
+  saveAll(recs: Recommendation[]): Promise<void>
+  findById(id: string): Promise<Recommendation | null>
+  findBySource(sourceId: string, limit?: number): Promise<Recommendation[]>
+  findBySourceAndType(
+    sourceId: string,
+    type: RelationType,
+    limit?: number,
+  ): Promise<Recommendation[]>
+  updateExplanation(id: string, explanation: string): Promise<void>
+  countBySource(sourceId: string): Promise<number>
+  deleteAll(): Promise<void>
+}

--- a/src/brain/src/recommendations/domain/value-objects/Reason.ts
+++ b/src/brain/src/recommendations/domain/value-objects/Reason.ts
@@ -1,0 +1,42 @@
+export type ReasonFeature =
+  | 'mismo_ciiu_clase'
+  | 'mismo_ciiu_division'
+  | 'mismo_ciiu_seccion'
+  | 'mismo_municipio'
+  | 'misma_etapa'
+  | 'misma_macro_sector'
+  | 'cadena_valor_directa'
+  | 'cadena_valor_inversa'
+  | 'ecosistema_compartido'
+  | 'ai_inferido'
+
+export interface Reason {
+  feature: ReasonFeature
+  weight: number
+  value?: string | number
+  description: string
+}
+
+export class Reasons {
+  private constructor(private readonly items: readonly Reason[]) {}
+
+  static empty(): Reasons {
+    return new Reasons([])
+  }
+
+  static from(items: Reason[]): Reasons {
+    return new Reasons([...items])
+  }
+
+  add(reason: Reason): Reasons {
+    return new Reasons([...this.items, reason])
+  }
+
+  totalWeight(): number {
+    return this.items.reduce((sum, r) => sum + r.weight, 0)
+  }
+
+  toJson(): Reason[] {
+    return [...this.items]
+  }
+}

--- a/src/brain/src/recommendations/domain/value-objects/RelationType.ts
+++ b/src/brain/src/recommendations/domain/value-objects/RelationType.ts
@@ -1,0 +1,25 @@
+export const RELATION_TYPES = [
+  'referente',
+  'cliente',
+  'proveedor',
+  'aliado',
+] as const
+
+export type RelationType = (typeof RELATION_TYPES)[number]
+
+export function isRelationType(value: string): value is RelationType {
+  return (RELATION_TYPES as readonly string[]).includes(value)
+}
+
+export function inverseRelation(t: RelationType): RelationType {
+  switch (t) {
+    case 'cliente':
+      return 'proveedor'
+    case 'proveedor':
+      return 'cliente'
+    case 'referente':
+      return 'referente'
+    case 'aliado':
+      return 'aliado'
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/http/company-recommendations.controller.ts
+++ b/src/brain/src/recommendations/infrastructure/http/company-recommendations.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Param, Query } from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import {
+  GetCompanyRecommendations,
+  type GetCompanyRecommendationsResult,
+} from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import {
+  isRelationType,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+
+@ApiTags('recommendations')
+@Controller('companies')
+export class CompanyRecommendationsController {
+  constructor(
+    private readonly getCompanyRecommendations: GetCompanyRecommendations,
+  ) {}
+
+  @Get(':id/recommendations')
+  @ApiOperation({ summary: 'List recommendations for a given company' })
+  async list(
+    @Param('id') id: string,
+    @Query('type') type?: string,
+    @Query('limit') limit?: string,
+  ): Promise<GetCompanyRecommendationsResult> {
+    const relationType =
+      type && isRelationType(type) ? (type as RelationType) : undefined
+    const parsedLimit = limit ? parseInt(limit, 10) : undefined
+    const safeLimit =
+      parsedLimit && Number.isFinite(parsedLimit) && parsedLimit > 0
+        ? parsedLimit
+        : undefined
+
+    return this.getCompanyRecommendations.execute({
+      companyId: id,
+      type: relationType,
+      limit: safeLimit,
+    })
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/http/recommendations.controller.ts
+++ b/src/brain/src/recommendations/infrastructure/http/recommendations.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  NotFoundException,
+  Param,
+  Post,
+} from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import { ExplainRecommendation } from '@/recommendations/application/use-cases/ExplainRecommendation'
+import {
+  GenerateRecommendations,
+  type GenerateRecommendationsResult,
+} from '@/recommendations/application/use-cases/GenerateRecommendations'
+
+interface GenerateRequest {
+  enableAi?: boolean
+}
+
+@ApiTags('recommendations')
+@Controller('recommendations')
+export class RecommendationsController {
+  constructor(
+    private readonly generateRecommendations: GenerateRecommendations,
+    private readonly explainRecommendation: ExplainRecommendation,
+  ) {}
+
+  @Post('generate')
+  @ApiOperation({
+    summary: 'Regenerate recommendations for every active company',
+  })
+  async generate(
+    @Body() body: GenerateRequest = {},
+  ): Promise<GenerateRecommendationsResult> {
+    return this.generateRecommendations.execute({ enableAi: body.enableAi })
+  }
+
+  @Post(':id/explain')
+  @ApiOperation({
+    summary: 'Generate or return cached natural-language explanation',
+  })
+  async explain(@Param('id') id: string): Promise<{ explanation: string }> {
+    try {
+      return await this.explainRecommendation.execute({ recommendationId: id })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      if (message.startsWith('Recommendation not found')) {
+        throw new NotFoundException(message)
+      }
+      throw e
+    }
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common'
+import type { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+
+@Injectable()
+export class InMemoryAiMatchCacheRepository implements AiMatchCacheRepository {
+  private readonly store = new Map<string, AiMatchCacheEntry>()
+
+  async get(
+    ciiuOrigen: string,
+    ciiuDestino: string,
+  ): Promise<AiMatchCacheEntry | null> {
+    return this.store.get(this.keyOf(ciiuOrigen, ciiuDestino)) ?? null
+  }
+
+  async put(entry: AiMatchCacheEntry): Promise<void> {
+    this.store.set(entry.key, entry)
+  }
+
+  async size(): Promise<number> {
+    return this.store.size
+  }
+
+  private keyOf(origen: string, destino: string): string {
+    return `${origen}->${destino}`
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository.ts
@@ -21,6 +21,10 @@ export class InMemoryAiMatchCacheRepository implements AiMatchCacheRepository {
     return this.store.size
   }
 
+  async findAll(): Promise<AiMatchCacheEntry[]> {
+    return Array.from(this.store.values())
+  }
+
   private keyOf(origen: string, destino: string): string {
     return `${origen}->${destino}`
   }

--- a/src/brain/src/recommendations/infrastructure/repositories/InMemoryRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/InMemoryRecommendationRepository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+
+@Injectable()
+export class InMemoryRecommendationRepository implements RecommendationRepository {
+  private readonly store = new Map<string, Recommendation>()
+
+  async saveAll(recs: Recommendation[]): Promise<void> {
+    for (const r of recs) {
+      this.store.set(r.id, r)
+    }
+  }
+
+  async findById(id: string): Promise<Recommendation | null> {
+    return this.store.get(id) ?? null
+  }
+
+  async findBySource(
+    sourceId: string,
+    limit?: number,
+  ): Promise<Recommendation[]> {
+    const matched = Array.from(this.store.values())
+      .filter((r) => r.sourceCompanyId === sourceId)
+      .sort((a, b) => b.score - a.score)
+    return limit !== undefined ? matched.slice(0, limit) : matched
+  }
+
+  async findBySourceAndType(
+    sourceId: string,
+    type: RelationType,
+    limit?: number,
+  ): Promise<Recommendation[]> {
+    const matched = Array.from(this.store.values())
+      .filter((r) => r.sourceCompanyId === sourceId && r.relationType === type)
+      .sort((a, b) => b.score - a.score)
+    return limit !== undefined ? matched.slice(0, limit) : matched
+  }
+
+  async updateExplanation(id: string, explanation: string): Promise<void> {
+    const existing = this.store.get(id)
+    if (!existing) return
+    this.store.set(id, existing.withExplanation(explanation, new Date()))
+  }
+
+  async countBySource(sourceId: string): Promise<number> {
+    let n = 0
+    for (const r of this.store.values()) {
+      if (r.sourceCompanyId === sourceId) n++
+    }
+    return n
+  }
+
+  async deleteAll(): Promise<void> {
+    this.store.clear()
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseAiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseAiMatchCacheRepository.ts
@@ -1,0 +1,83 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import { isRelationType } from '@/recommendations/domain/value-objects/RelationType'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'ai_match_cache'
+
+interface CacheRow {
+  ciiu_origen: string
+  ciiu_destino: string
+  has_match: boolean
+  relation_type: string | null
+  confidence: number | null
+  reason: string | null
+  cached_at: string
+}
+
+@Injectable()
+export class SupabaseAiMatchCacheRepository implements AiMatchCacheRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async get(
+    ciiuOrigen: string,
+    ciiuDestino: string,
+  ): Promise<AiMatchCacheEntry | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('ciiu_origen', ciiuOrigen)
+      .eq('ciiu_destino', ciiuDestino)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as CacheRow) : null
+  }
+
+  async put(entry: AiMatchCacheEntry): Promise<void> {
+    const { error } = await this.db.from(TABLE).upsert(this.toRow(entry), {
+      onConflict: 'ciiu_origen,ciiu_destino',
+    })
+    if (error) throw error
+  }
+
+  async size(): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+    if (error) throw error
+    return count ?? 0
+  }
+
+  private toEntity(row: CacheRow): AiMatchCacheEntry {
+    if (row.relation_type !== null && !isRelationType(row.relation_type)) {
+      throw new Error(
+        `Unknown ai_match_cache relation_type from DB: ${row.relation_type}`,
+      )
+    }
+    return AiMatchCacheEntry.create({
+      ciiuOrigen: row.ciiu_origen,
+      ciiuDestino: row.ciiu_destino,
+      hasMatch: row.has_match,
+      relationType: row.relation_type,
+      confidence: row.confidence,
+      reason: row.reason,
+      cachedAt: new Date(row.cached_at),
+    })
+  }
+
+  private toRow(entry: AiMatchCacheEntry): CacheRow {
+    return {
+      ciiu_origen: entry.ciiuOrigen,
+      ciiu_destino: entry.ciiuDestino,
+      has_match: entry.hasMatch,
+      relation_type: entry.relationType,
+      confidence: entry.confidence,
+      reason: entry.reason,
+      cached_at: entry.cachedAt.toISOString(),
+    }
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseAiMatchCacheRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseAiMatchCacheRepository.ts
@@ -52,6 +52,12 @@ export class SupabaseAiMatchCacheRepository implements AiMatchCacheRepository {
     return count ?? 0
   }
 
+  async findAll(): Promise<AiMatchCacheEntry[]> {
+    const { data, error } = await this.db.from(TABLE).select('*')
+    if (error) throw error
+    return ((data ?? []) as CacheRow[]).map((r) => this.toEntity(r))
+  }
+
   private toEntity(row: CacheRow): AiMatchCacheEntry {
     if (row.relation_type !== null && !isRelationType(row.relation_type)) {
       throw new Error(

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
@@ -1,0 +1,162 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import {
+  isRecommendationSource,
+  type RecommendationSource,
+} from '@/recommendations/domain/entities/Recommendation'
+import {
+  isRelationType,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+import {
+  Reasons,
+  type Reason,
+} from '@/recommendations/domain/value-objects/Reason'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'recommendations'
+const CHUNK_SIZE = 500
+
+interface RecommendationRow {
+  id: string
+  source_company_id: string
+  target_company_id: string
+  relation_type: string
+  score: number
+  reasons: unknown
+  source: string
+  explanation: string | null
+  explanation_cached_at: string | null
+}
+
+@Injectable()
+export class SupabaseRecommendationRepository implements RecommendationRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async saveAll(recs: Recommendation[]): Promise<void> {
+    if (recs.length === 0) return
+    const rows = recs.map((r) => this.toRow(r))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'id' })
+      if (error) throw error
+    }
+  }
+
+  async findById(id: string): Promise<Recommendation | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('id', id)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as RecommendationRow) : null
+  }
+
+  async findBySource(
+    sourceId: string,
+    limit?: number,
+  ): Promise<Recommendation[]> {
+    let query = this.db
+      .from(TABLE)
+      .select('*')
+      .eq('source_company_id', sourceId)
+      .order('score', { ascending: false })
+    if (limit !== undefined) query = query.limit(limit)
+    const { data, error } = await query
+    if (error) throw error
+    return ((data ?? []) as RecommendationRow[]).map((r) => this.toEntity(r))
+  }
+
+  async findBySourceAndType(
+    sourceId: string,
+    type: RelationType,
+    limit?: number,
+  ): Promise<Recommendation[]> {
+    let query = this.db
+      .from(TABLE)
+      .select('*')
+      .eq('source_company_id', sourceId)
+      .eq('relation_type', type)
+      .order('score', { ascending: false })
+    if (limit !== undefined) query = query.limit(limit)
+    const { data, error } = await query
+    if (error) throw error
+    return ((data ?? []) as RecommendationRow[]).map((r) => this.toEntity(r))
+  }
+
+  async updateExplanation(id: string, explanation: string): Promise<void> {
+    const { error } = await this.db
+      .from(TABLE)
+      .update({
+        explanation,
+        explanation_cached_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  async countBySource(sourceId: string): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+      .eq('source_company_id', sourceId)
+    if (error) throw error
+    return count ?? 0
+  }
+
+  async deleteAll(): Promise<void> {
+    const { error } = await this.db.from(TABLE).delete().neq('id', '')
+    if (error) throw error
+  }
+
+  private toEntity(row: RecommendationRow): Recommendation {
+    if (!isRecommendationSource(row.source)) {
+      throw new Error(`Unknown recommendation source from DB: ${row.source}`)
+    }
+    if (!isRelationType(row.relation_type)) {
+      throw new Error(
+        `Unknown recommendation relation_type from DB: ${row.relation_type}`,
+      )
+    }
+    const reasons = Array.isArray(row.reasons)
+      ? Reasons.from(row.reasons as Reason[])
+      : Reasons.empty()
+
+    return Recommendation.create({
+      id: row.id,
+      sourceCompanyId: row.source_company_id,
+      targetCompanyId: row.target_company_id,
+      relationType: row.relation_type,
+      score: row.score,
+      reasons,
+      source: row.source as RecommendationSource,
+      explanation: row.explanation,
+      explanationCachedAt: row.explanation_cached_at
+        ? new Date(row.explanation_cached_at)
+        : null,
+    })
+  }
+
+  private toRow(r: Recommendation): RecommendationRow {
+    return {
+      id: r.id,
+      source_company_id: r.sourceCompanyId,
+      target_company_id: r.targetCompanyId,
+      relation_type: r.relationType,
+      score: r.score,
+      reasons: r.reasons.toJson(),
+      source: r.source,
+      explanation: r.explanation,
+      explanation_cached_at: r.explanationCachedAt
+        ? r.explanationCachedAt.toISOString()
+        : null,
+    }
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
@@ -13,6 +13,7 @@ import {
   Reasons,
   type Reason,
 } from '@/recommendations/domain/value-objects/Reason'
+import type { Json } from '@/shared/infrastructure/supabase/database.types'
 import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
 import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
 
@@ -25,7 +26,7 @@ interface RecommendationRow {
   target_company_id: string
   relation_type: string
   score: number
-  reasons: unknown
+  reasons: Json
   source: string
   explanation: string | null
   explanation_cached_at: string | null
@@ -126,7 +127,7 @@ export class SupabaseRecommendationRepository implements RecommendationRepositor
       )
     }
     const reasons = Array.isArray(row.reasons)
-      ? Reasons.from(row.reasons as Reason[])
+      ? Reasons.from(row.reasons as unknown as Reason[])
       : Reasons.empty()
 
     return Recommendation.create({
@@ -151,7 +152,7 @@ export class SupabaseRecommendationRepository implements RecommendationRepositor
       target_company_id: r.targetCompanyId,
       relation_type: r.relationType,
       score: r.score,
-      reasons: r.reasons.toJson(),
+      reasons: r.reasons.toJson() as unknown as Json,
       source: r.source,
       explanation: r.explanation,
       explanation_cached_at: r.explanationCachedAt

--- a/src/brain/src/recommendations/recommendations.module.ts
+++ b/src/brain/src/recommendations/recommendations.module.ts
@@ -1,0 +1,52 @@
+import { Module } from '@nestjs/common'
+import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
+import { CompaniesModule } from '@/companies/companies.module'
+import { AiMatchEngine } from './application/services/AiMatchEngine'
+import { AllianceMatcher } from './application/services/AllianceMatcher'
+import { CandidateSelector } from './application/services/CandidateSelector'
+import { CiiuPairEvaluator } from './application/services/CiiuPairEvaluator'
+import { FeatureVectorBuilder } from './application/services/FeatureVectorBuilder'
+import { PeerMatcher } from './application/services/PeerMatcher'
+import { ValueChainMatcher } from './application/services/ValueChainMatcher'
+import { ExplainRecommendation } from './application/use-cases/ExplainRecommendation'
+import { GenerateRecommendations } from './application/use-cases/GenerateRecommendations'
+import { GetCompanyRecommendations } from './application/use-cases/GetCompanyRecommendations'
+import { AI_MATCH_CACHE_REPOSITORY } from './domain/repositories/AiMatchCacheRepository'
+import { RECOMMENDATION_REPOSITORY } from './domain/repositories/RecommendationRepository'
+import { CompanyRecommendationsController } from './infrastructure/http/company-recommendations.controller'
+import { RecommendationsController } from './infrastructure/http/recommendations.controller'
+import { SupabaseAiMatchCacheRepository } from './infrastructure/repositories/SupabaseAiMatchCacheRepository'
+import { SupabaseRecommendationRepository } from './infrastructure/repositories/SupabaseRecommendationRepository'
+
+@Module({
+  imports: [CiiuTaxonomyModule, CompaniesModule],
+  controllers: [RecommendationsController, CompanyRecommendationsController],
+  providers: [
+    {
+      provide: RECOMMENDATION_REPOSITORY,
+      useClass: SupabaseRecommendationRepository,
+    },
+    {
+      provide: AI_MATCH_CACHE_REPOSITORY,
+      useClass: SupabaseAiMatchCacheRepository,
+    },
+    AiMatchEngine,
+    AllianceMatcher,
+    CandidateSelector,
+    CiiuPairEvaluator,
+    FeatureVectorBuilder,
+    PeerMatcher,
+    ValueChainMatcher,
+    GenerateRecommendations,
+    GetCompanyRecommendations,
+    ExplainRecommendation,
+  ],
+  exports: [
+    RECOMMENDATION_REPOSITORY,
+    AI_MATCH_CACHE_REPOSITORY,
+    GenerateRecommendations,
+    GetCompanyRecommendations,
+    ExplainRecommendation,
+  ],
+})
+export class RecommendationsModule {}


### PR DESCRIPTION
## Summary

Implements **Phase 5 — Recommendations Context**, the AI-first matching engine described in `docs/2026-04-25-brain-clustering-engine-implementation.md`.

- 16 plan tasks across 18 commits, all on top of `main` (post Phase 4 merge `f125761`)
- Adds the full `src/brain/src/recommendations/` bounded context: 4 domain types, 4 repos (2 ports + Supabase + InMemory adapters), 7 application services, 3 use cases, and 2 HTTP controllers wired into a new `RecommendationsModule`
- Brain test suite **412/412** (Phase 4 baseline 226 + 186 new tests across 17 files)
- TDD respected throughout — every task RED → GREEN → REFACTOR

## What's inside

**Domain (Tasks 5.1–5.4)** — `RelationType` VO with `inverseRelation`, immutable `Reasons` collection with structured features, `Recommendation` entity with score/relation invariants, `AiMatchCacheEntry` entity, and two repositories (recommendation + AI cache) with Supabase + InMemory adapters.

**AI engine (Tasks 5.5–5.8)** — `ValueChainRules` static registry (24 rules + 6 ecosystems) used as both Gemini prompt context and fallback data. `AiMatchEngine` with same-CIIU short-circuit, cache-first lookup, and rules+ecosystems-aware prompt. `CandidateSelector` for O(n²)-avoiding pre-filtering. `CiiuPairEvaluator` with concurrency-limited workers to fill the cache.

**Fallback matchers (Tasks 5.9–5.12)** — `FeatureVectorBuilder` with normalized log magnitudes + etapa ordinals. `PeerMatcher` (cosine within division → `referente`), `ValueChainMatcher` (rules → `cliente`/`proveedor`), `AllianceMatcher` (ecosystems → `aliado`).

**Use cases & HTTP (Tasks 5.13–5.16)** — `GenerateRecommendations` AI-first orchestration with hardcoded fallback (env-toggleable, dedupes by source+target+type, caps top 5/type and top 20 total). `GetCompanyRecommendations` with target hydration. `ExplainRecommendation` lazy Gemini + cache. Two controllers: `POST /recommendations/generate`, `POST /recommendations/:id/explain`, `GET /companies/:id/recommendations?type=&limit=`. Module wired into `app.module.ts`.

## Notable decisions caught by tests

- `AiMatchEngine` validator degrades `hasMatch=true → false` when Gemini returns an invalid `relation_type` — surfaced by the `treats invalid relation_type from Gemini as null` test, which broke the cache invariant
- Cache stores entries in canonical-pair direction (`a < b`); `GenerateRecommendations.expandFromCache` inverts `relationType` when `source.ciiu > target.ciiu` so cliente↔proveedor flip correctly. Symmetric types (referente/aliado) untouched
- `AiMatchCacheRepository.findAll()` was added mid-phase (Task 5.13) so the use case can index the cache by canonical pair in one pass — port + both adapters + their tests updated in the same commit
- Final fix `adb8145` aligns the Supabase `reasons` column type with the generated `Json` type from `database.types.ts` (was tripping `tsc` in the pre-push hook)

## Test plan

- [x] `bun test:run` from `src/brain` — 412/412 passing
- [x] `bun typecheck` from `src/brain` — clean
- [x] Pre-push hook (front + brain typecheck + tests) green
- [ ] Smoke `POST /recommendations/generate` against staging Supabase once merged
- [ ] Smoke `GET /companies/:id/recommendations` after a generate run

## Out of scope

Phase 6 (Agent Context: scan runs, scheduled cron, opportunity detector) starts after this merges — it depends on the use cases this PR exports.