### PR TITLE
feat(brain): phase 6 — agent context with incremental scan and opportunity detection

### DIFF
--- a/src/brain/__tests__/agent/AgentController.test.ts
+++ b/src/brain/__tests__/agent/AgentController.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentController } from '@/agent/infrastructure/http/agent.controller'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+import { GetAgentEvents } from '@/agent/application/use-cases/GetAgentEvents'
+import { MarkEventAsRead } from '@/agent/application/use-cases/MarkEventAsRead'
+import type { RunIncrementalScan } from '@/agent/application/use-cases/RunIncrementalScan'
+import type { ScanRunRepository } from '@/agent/domain/repositories/ScanRunRepository'
+import { InMemoryAgentEventRepository } from '@/agent/infrastructure/repositories/InMemoryAgentEventRepository'
+
+const T = (iso: string): Date => new Date(iso)
+
+interface Wiring {
+  controller: AgentController
+  runScan: { execute: ReturnType<typeof vi.fn> }
+  scanRepo: ScanRunRepository & {
+    findLatest: ReturnType<typeof vi.fn>
+    countByStatus: ReturnType<typeof vi.fn>
+  }
+  eventRepo: InMemoryAgentEventRepository
+}
+
+function makeWiring(): Wiring {
+  const runScan = {
+    execute: vi.fn(async () => ({
+      runId: 'run-1',
+      status: 'completed' as const,
+      companiesScanned: 5,
+      clustersGenerated: 2,
+      recommendationsGenerated: 10,
+      eventsEmitted: 1,
+    })),
+  }
+  const scanRepo = {
+    save: vi.fn(),
+    findLatest: vi.fn(),
+    findLatestCompleted: vi.fn(),
+    countByStatus: vi.fn(),
+  } as unknown as Wiring['scanRepo']
+  const eventRepo = new InMemoryAgentEventRepository()
+  const getEvents = new GetAgentEvents(eventRepo)
+  const markRead = new MarkEventAsRead(eventRepo)
+  const controller = new AgentController(
+    runScan as unknown as RunIncrementalScan,
+    scanRepo,
+    getEvents,
+    markRead,
+  )
+  return { controller, runScan, scanRepo, eventRepo }
+}
+
+describe('AgentController', () => {
+  let wiring: Wiring
+
+  beforeEach(() => {
+    wiring = makeWiring()
+  })
+
+  describe('POST /agent/scan', () => {
+    it('triggers a manual scan and returns the result', async () => {
+      const result = await wiring.controller.triggerScan()
+
+      expect(wiring.runScan.execute).toHaveBeenCalledWith({ trigger: 'manual' })
+      expect(result.runId).toBe('run-1')
+      expect(result.status).toBe('completed')
+    })
+  })
+
+  describe('GET /agent/status', () => {
+    it('returns latest run plus counts by status', async () => {
+      const latest = ScanRun.start({
+        id: 'run-1',
+        trigger: 'cron',
+        now: T('2026-04-26T10:00:00Z'),
+      }).complete(
+        {
+          companiesScanned: 5,
+          clustersGenerated: 2,
+          recommendationsGenerated: 10,
+          eventsEmitted: 1,
+        },
+        T('2026-04-26T10:01:00Z'),
+      )
+      wiring.scanRepo.findLatest.mockResolvedValueOnce(latest)
+      wiring.scanRepo.countByStatus
+        .mockResolvedValueOnce(7) // completed
+        .mockResolvedValueOnce(0) // running
+        .mockResolvedValueOnce(1) // failed
+        .mockResolvedValueOnce(0) // partial
+
+      const status = await wiring.controller.getStatus()
+
+      expect(status.latest).toEqual(
+        expect.objectContaining({
+          id: 'run-1',
+          status: 'completed',
+          trigger: 'cron',
+          companiesScanned: 5,
+          clustersGenerated: 2,
+          recommendationsGenerated: 10,
+          eventsEmitted: 1,
+          durationMs: 60000,
+        }),
+      )
+      expect(status.counts).toEqual({
+        completed: 7,
+        running: 0,
+        failed: 1,
+        partial: 0,
+      })
+    })
+
+    it('returns null latest when no scans exist yet', async () => {
+      wiring.scanRepo.findLatest.mockResolvedValueOnce(null)
+      wiring.scanRepo.countByStatus.mockResolvedValue(0)
+
+      const status = await wiring.controller.getStatus()
+
+      expect(status.latest).toBeNull()
+      expect(status.counts).toEqual({
+        completed: 0,
+        running: 0,
+        failed: 0,
+        partial: 0,
+      })
+    })
+  })
+
+  describe('GET /agent/events', () => {
+    it('returns events for the company', async () => {
+      await wiring.eventRepo.saveAll([
+        AgentEvent.create({
+          id: 'a',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: { score: 0.9 },
+          now: T('2026-04-26T10:00:00Z'),
+        }),
+      ])
+
+      const result = await wiring.controller.getEvents(
+        'c-1',
+        undefined,
+        undefined,
+      )
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0]!.id).toBe('a')
+    })
+
+    it('forwards unread=true and a numeric limit', async () => {
+      await wiring.eventRepo.saveAll([
+        AgentEvent.create({
+          id: 'a',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: {},
+          now: T('2026-04-26T10:00:00Z'),
+        }),
+        AgentEvent.create({
+          id: 'b',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: {},
+          now: T('2026-04-26T11:00:00Z'),
+        }),
+      ])
+
+      const result = await wiring.controller.getEvents('c-1', 'true', '1')
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0]!.id).toBe('b')
+    })
+
+    it('treats unread=false (or absent) as showing all events', async () => {
+      const read = AgentEvent.create({
+        id: 'a',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: {},
+        now: T('2026-04-26T10:00:00Z'),
+      }).markAsRead()
+      await wiring.eventRepo.saveAll([read])
+
+      const result = await wiring.controller.getEvents(
+        'c-1',
+        'false',
+        undefined,
+      )
+      expect(result.events).toHaveLength(1)
+    })
+
+    it('ignores limit when not a positive integer', async () => {
+      await wiring.eventRepo.saveAll([
+        AgentEvent.create({
+          id: 'a',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: {},
+          now: T('2026-04-26T10:00:00Z'),
+        }),
+        AgentEvent.create({
+          id: 'b',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: {},
+          now: T('2026-04-26T11:00:00Z'),
+        }),
+      ])
+
+      const result = await wiring.controller.getEvents('c-1', undefined, 'abc')
+      expect(result.events).toHaveLength(2)
+    })
+  })
+
+  describe('POST /agent/events/:id/read', () => {
+    it('marks the event as read', async () => {
+      await wiring.eventRepo.saveAll([
+        AgentEvent.create({
+          id: 'a',
+          companyId: 'c-1',
+          eventType: 'new_high_score_match',
+          payload: {},
+          now: T('2026-04-26T10:00:00Z'),
+        }),
+      ])
+
+      await wiring.controller.markEventRead('a')
+
+      const events = await wiring.eventRepo.findByCompany('c-1')
+      expect(events[0]!.read).toBe(true)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/AgentEvent.test.ts
+++ b/src/brain/__tests__/agent/AgentEvent.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+
+const T0 = new Date('2026-04-26T10:00:00Z')
+
+describe('AgentEvent', () => {
+  describe('create', () => {
+    it('creates an unread event with the provided createdAt', () => {
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: { recommendationId: 'r-1', score: 0.9 },
+        now: T0,
+      })
+
+      expect(ev.id).toBe('ev-1')
+      expect(ev.companyId).toBe('c-1')
+      expect(ev.eventType).toBe('new_high_score_match')
+      expect(ev.payload).toEqual({ recommendationId: 'r-1', score: 0.9 })
+      expect(ev.read).toBe(false)
+      expect(ev.createdAt).toEqual(T0)
+    })
+
+    it('rejects empty id', () => {
+      expect(() =>
+        AgentEvent.create({
+          id: '',
+          companyId: 'c-1',
+          eventType: 'new_cluster_member',
+          payload: {},
+          now: T0,
+        }),
+      ).toThrow(/id cannot be empty/)
+    })
+
+    it('rejects empty companyId', () => {
+      expect(() =>
+        AgentEvent.create({
+          id: 'ev-1',
+          companyId: '   ',
+          eventType: 'new_cluster_member',
+          payload: {},
+          now: T0,
+        }),
+      ).toThrow(/companyId cannot be empty/)
+    })
+
+    it('accepts an empty payload object', () => {
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_cluster_member',
+        payload: {},
+        now: T0,
+      })
+      expect(ev.payload).toEqual({})
+    })
+  })
+
+  describe('markAsRead', () => {
+    it('returns a new instance with read=true', () => {
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: { score: 0.9 },
+        now: T0,
+      })
+
+      const read = ev.markAsRead()
+
+      expect(read).not.toBe(ev)
+      expect(read.read).toBe(true)
+      expect(ev.read).toBe(false)
+    })
+
+    it('preserves payload, eventType, companyId, createdAt', () => {
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_value_chain_partner',
+        payload: { foo: 'bar' },
+        now: T0,
+      })
+      const read = ev.markAsRead()
+
+      expect(read.companyId).toBe('c-1')
+      expect(read.eventType).toBe('new_value_chain_partner')
+      expect(read.payload).toEqual({ foo: 'bar' })
+      expect(read.createdAt).toEqual(ev.createdAt)
+    })
+  })
+
+  describe('hydrate', () => {
+    it('rebuilds an instance from stored props', () => {
+      const ev = AgentEvent.hydrate({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: { score: 0.9 },
+        read: true,
+        createdAt: new Date('2026-04-25T08:00:00Z'),
+      })
+
+      expect(ev.id).toBe('ev-1')
+      expect(ev.read).toBe(true)
+      expect(ev.createdAt).toEqual(new Date('2026-04-25T08:00:00Z'))
+    })
+  })
+})

--- a/src/brain/__tests__/agent/AgentScheduler.test.ts
+++ b/src/brain/__tests__/agent/AgentScheduler.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/infrastructure/env', () => ({
+  env: {
+    AGENT_CRON_SCHEDULE: '*/60 * * * * *',
+    AGENT_ENABLED: 'true',
+  },
+}))
+
+import { env } from '@/shared/infrastructure/env'
+import { AgentScheduler } from '@/agent/infrastructure/scheduler/AgentScheduler'
+import type { RunIncrementalScan } from '@/agent/application/use-cases/RunIncrementalScan'
+
+const stubRunScan = (): {
+  scheduler: AgentScheduler
+  runScan: { execute: ReturnType<typeof vi.fn> }
+} => {
+  const runScan = {
+    execute: vi.fn(async () => ({
+      runId: 'run-1',
+      status: 'completed' as const,
+      companiesScanned: 1,
+      clustersGenerated: 1,
+      recommendationsGenerated: 1,
+      eventsEmitted: 0,
+    })),
+  }
+  return {
+    scheduler: new AgentScheduler(runScan as unknown as RunIncrementalScan),
+    runScan,
+  }
+}
+
+describe('AgentScheduler', () => {
+  beforeEach(() => {
+    ;(env as { AGENT_ENABLED: string }).AGENT_ENABLED = 'true'
+  })
+
+  describe('handleScan', () => {
+    it('runs the incremental scan with trigger=cron when enabled', async () => {
+      const { scheduler, runScan } = stubRunScan()
+      await scheduler.handleScan()
+
+      expect(runScan.execute).toHaveBeenCalledWith({ trigger: 'cron' })
+    })
+
+    it('does nothing when AGENT_ENABLED is "false"', async () => {
+      ;(env as { AGENT_ENABLED: string }).AGENT_ENABLED = 'false'
+      const { scheduler, runScan } = stubRunScan()
+      await scheduler.handleScan()
+
+      expect(runScan.execute).not.toHaveBeenCalled()
+    })
+
+    it('skips when a previous run is still in progress (re-entry guard)', async () => {
+      const { scheduler, runScan } = stubRunScan()
+      let resolveFirst!: () => void
+      runScan.execute.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = () =>
+              resolve({
+                runId: 'run-1',
+                status: 'completed',
+                companiesScanned: 0,
+                clustersGenerated: 0,
+                recommendationsGenerated: 0,
+                eventsEmitted: 0,
+              })
+          }),
+      )
+
+      const first = scheduler.handleScan()
+      // While first is still pending, fire a second tick
+      const second = scheduler.handleScan()
+      await second // returns immediately because first is still running
+
+      expect(runScan.execute).toHaveBeenCalledTimes(1)
+
+      resolveFirst()
+      await first
+    })
+
+    it('catches errors from runScan and does not rethrow', async () => {
+      const { scheduler, runScan } = stubRunScan()
+      runScan.execute.mockRejectedValueOnce(new Error('scan blew up'))
+
+      await expect(scheduler.handleScan()).resolves.toBeUndefined()
+    })
+
+    it('clears the running flag after success so the next tick can run', async () => {
+      const { scheduler, runScan } = stubRunScan()
+      await scheduler.handleScan()
+      await scheduler.handleScan()
+
+      expect(runScan.execute).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the running flag after failure so the next tick can run', async () => {
+      const { scheduler, runScan } = stubRunScan()
+      runScan.execute.mockRejectedValueOnce(new Error('first one fails'))
+
+      await scheduler.handleScan()
+      await scheduler.handleScan()
+
+      expect(runScan.execute).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/EventType.test.ts
+++ b/src/brain/__tests__/agent/EventType.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EVENT_TYPES,
+  isEventType,
+} from '@/agent/domain/value-objects/EventType'
+
+describe('EventType', () => {
+  it('exposes the three event type literals', () => {
+    expect(EVENT_TYPES).toEqual([
+      'new_high_score_match',
+      'new_value_chain_partner',
+      'new_cluster_member',
+    ])
+  })
+
+  it('isEventType returns true for valid values', () => {
+    expect(isEventType('new_high_score_match')).toBe(true)
+    expect(isEventType('new_value_chain_partner')).toBe(true)
+    expect(isEventType('new_cluster_member')).toBe(true)
+  })
+
+  it('isEventType returns false for unknown values', () => {
+    expect(isEventType('something_else')).toBe(false)
+    expect(isEventType('')).toBe(false)
+    expect(isEventType('NEW_HIGH_SCORE_MATCH')).toBe(false)
+  })
+})

--- a/src/brain/__tests__/agent/GetAgentEvents.test.ts
+++ b/src/brain/__tests__/agent/GetAgentEvents.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { GetAgentEvents } from '@/agent/application/use-cases/GetAgentEvents'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import { InMemoryAgentEventRepository } from '@/agent/infrastructure/repositories/InMemoryAgentEventRepository'
+
+const T = (iso: string): Date => new Date(iso)
+
+describe('GetAgentEvents', () => {
+  let repo: InMemoryAgentEventRepository
+  let useCase: GetAgentEvents
+
+  beforeEach(() => {
+    repo = new InMemoryAgentEventRepository()
+    useCase = new GetAgentEvents(repo)
+  })
+
+  it('returns events for a company sorted by createdAt desc', async () => {
+    await repo.saveAll([
+      AgentEvent.create({
+        id: 'a',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: {},
+        now: T('2026-04-26T09:00:00Z'),
+      }),
+      AgentEvent.create({
+        id: 'b',
+        companyId: 'c-1',
+        eventType: 'new_cluster_member',
+        payload: {},
+        now: T('2026-04-26T11:00:00Z'),
+      }),
+    ])
+
+    const result = await useCase.execute({ companyId: 'c-1' })
+    expect(result.events.map((e) => e.id)).toEqual(['b', 'a'])
+  })
+
+  it('forwards unreadOnly and limit options to the repo', async () => {
+    const read = AgentEvent.create({
+      id: 'a',
+      companyId: 'c-1',
+      eventType: 'new_high_score_match',
+      payload: {},
+      now: T('2026-04-26T09:00:00Z'),
+    }).markAsRead()
+    await repo.saveAll([
+      read,
+      AgentEvent.create({
+        id: 'b',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: {},
+        now: T('2026-04-26T10:00:00Z'),
+      }),
+      AgentEvent.create({
+        id: 'c',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: {},
+        now: T('2026-04-26T11:00:00Z'),
+      }),
+    ])
+
+    const result = await useCase.execute({
+      companyId: 'c-1',
+      unreadOnly: true,
+      limit: 1,
+    })
+
+    expect(result.events.map((e) => e.id)).toEqual(['c'])
+  })
+
+  it('returns empty when company has no events', async () => {
+    const result = await useCase.execute({ companyId: 'nope' })
+    expect(result.events).toEqual([])
+  })
+
+  it('rejects empty companyId', async () => {
+    await expect(useCase.execute({ companyId: '' })).rejects.toThrow(
+      /companyId cannot be empty/,
+    )
+    await expect(useCase.execute({ companyId: '   ' })).rejects.toThrow(
+      /companyId cannot be empty/,
+    )
+  })
+})

--- a/src/brain/__tests__/agent/InMemoryAgentEventRepository.test.ts
+++ b/src/brain/__tests__/agent/InMemoryAgentEventRepository.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import { InMemoryAgentEventRepository } from '@/agent/infrastructure/repositories/InMemoryAgentEventRepository'
+
+const T = (iso: string): Date => new Date(iso)
+
+const makeEvent = (
+  overrides: Partial<{
+    id: string
+    companyId: string
+    eventType:
+      | 'new_high_score_match'
+      | 'new_value_chain_partner'
+      | 'new_cluster_member'
+    payload: Record<string, unknown>
+    now: Date
+  }> = {},
+): AgentEvent =>
+  AgentEvent.create({
+    id: 'ev-1',
+    companyId: 'c-1',
+    eventType: 'new_high_score_match',
+    payload: { score: 0.9 },
+    now: T('2026-04-26T10:00:00Z'),
+    ...overrides,
+  })
+
+describe('InMemoryAgentEventRepository', () => {
+  let repo: InMemoryAgentEventRepository
+
+  beforeEach(() => {
+    repo = new InMemoryAgentEventRepository()
+  })
+
+  describe('saveAll', () => {
+    it('persists every event keyed by id', async () => {
+      await repo.saveAll([
+        makeEvent({ id: 'a' }),
+        makeEvent({ id: 'b', companyId: 'c-2' }),
+      ])
+      const result = await repo.findByCompany('c-1')
+      expect(result.map((e) => e.id)).toEqual(['a'])
+    })
+
+    it('upserts when the same id is saved twice', async () => {
+      await repo.saveAll([makeEvent({ id: 'a' })])
+      const updated = makeEvent({ id: 'a' }).markAsRead()
+      await repo.saveAll([updated])
+      const result = await repo.findByCompany('c-1')
+      expect(result[0]!.read).toBe(true)
+    })
+
+    it('is a no-op for empty array', async () => {
+      await repo.saveAll([])
+      expect(await repo.countUnreadForCompany('c-1')).toBe(0)
+    })
+  })
+
+  describe('findByCompany', () => {
+    it('returns events for a company sorted by createdAt desc', async () => {
+      await repo.saveAll([
+        makeEvent({ id: 'a', now: T('2026-04-26T09:00:00Z') }),
+        makeEvent({ id: 'b', now: T('2026-04-26T11:00:00Z') }),
+        makeEvent({ id: 'c', now: T('2026-04-26T10:00:00Z') }),
+      ])
+      const result = await repo.findByCompany('c-1')
+      expect(result.map((e) => e.id)).toEqual(['b', 'c', 'a'])
+    })
+
+    it('filters out other companies', async () => {
+      await repo.saveAll([
+        makeEvent({ id: 'a', companyId: 'c-1' }),
+        makeEvent({ id: 'b', companyId: 'c-2' }),
+      ])
+      expect(await repo.findByCompany('c-2')).toHaveLength(1)
+    })
+
+    it('with unreadOnly=true filters out events already read', async () => {
+      const a = makeEvent({ id: 'a' }).markAsRead()
+      const b = makeEvent({ id: 'b' })
+      await repo.saveAll([a, b])
+      const result = await repo.findByCompany('c-1', { unreadOnly: true })
+      expect(result.map((e) => e.id)).toEqual(['b'])
+    })
+
+    it('respects limit', async () => {
+      await repo.saveAll([
+        makeEvent({ id: 'a', now: T('2026-04-26T09:00:00Z') }),
+        makeEvent({ id: 'b', now: T('2026-04-26T10:00:00Z') }),
+        makeEvent({ id: 'c', now: T('2026-04-26T11:00:00Z') }),
+      ])
+      const result = await repo.findByCompany('c-1', { limit: 2 })
+      expect(result).toHaveLength(2)
+      expect(result.map((e) => e.id)).toEqual(['c', 'b'])
+    })
+
+    it('returns empty when no events', async () => {
+      expect(await repo.findByCompany('nope')).toEqual([])
+    })
+  })
+
+  describe('markAsRead', () => {
+    it('flips an unread event to read', async () => {
+      await repo.saveAll([makeEvent({ id: 'a' })])
+      await repo.markAsRead('a')
+      const result = await repo.findByCompany('c-1')
+      expect(result[0]!.read).toBe(true)
+    })
+
+    it('is a no-op for unknown id', async () => {
+      await expect(repo.markAsRead('missing')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('countUnreadForCompany', () => {
+    it('counts only unread events for the company', async () => {
+      const read = makeEvent({ id: 'a' }).markAsRead()
+      await repo.saveAll([
+        read,
+        makeEvent({ id: 'b' }),
+        makeEvent({ id: 'c' }),
+        makeEvent({ id: 'd', companyId: 'other' }),
+      ])
+      expect(await repo.countUnreadForCompany('c-1')).toBe(2)
+    })
+
+    it('returns 0 when no events', async () => {
+      expect(await repo.countUnreadForCompany('c-1')).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/InMemoryScanRunRepository.test.ts
+++ b/src/brain/__tests__/agent/InMemoryScanRunRepository.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+import { InMemoryScanRunRepository } from '@/agent/infrastructure/repositories/InMemoryScanRunRepository'
+
+const T = (iso: string): Date => new Date(iso)
+
+describe('InMemoryScanRunRepository', () => {
+  let repo: InMemoryScanRunRepository
+
+  beforeEach(() => {
+    repo = new InMemoryScanRunRepository()
+  })
+
+  describe('save', () => {
+    it('persists a scan run and reflects later updates by id (upsert)', async () => {
+      const start = ScanRun.start({
+        id: 'run-1',
+        trigger: 'cron',
+        now: T('2026-04-26T10:00:00Z'),
+      })
+      await repo.save(start)
+      const completed = start.complete(
+        {
+          companiesScanned: 5,
+          clustersGenerated: 1,
+          recommendationsGenerated: 3,
+          eventsEmitted: 2,
+        },
+        T('2026-04-26T10:01:00Z'),
+      )
+      await repo.save(completed)
+
+      const latest = await repo.findLatest()
+      expect(latest!.id).toBe('run-1')
+      expect(latest!.status).toBe('completed')
+      expect(latest!.companiesScanned).toBe(5)
+    })
+  })
+
+  describe('findLatest', () => {
+    it('returns the most recently started run regardless of status', async () => {
+      await repo.save(
+        ScanRun.start({
+          id: 'a',
+          trigger: 'cron',
+          now: T('2026-04-26T09:00:00Z'),
+        }),
+      )
+      await repo.save(
+        ScanRun.start({
+          id: 'b',
+          trigger: 'manual',
+          now: T('2026-04-26T10:00:00Z'),
+        }),
+      )
+
+      const latest = await repo.findLatest()
+      expect(latest!.id).toBe('b')
+    })
+
+    it('returns null when no runs exist', async () => {
+      expect(await repo.findLatest()).toBeNull()
+    })
+  })
+
+  describe('findLatestCompleted', () => {
+    it('returns the most recently completed run, ignoring running/failed/partial', async () => {
+      const a = ScanRun.start({
+        id: 'a',
+        trigger: 'cron',
+        now: T('2026-04-26T09:00:00Z'),
+      }).complete(
+        {
+          companiesScanned: 1,
+          clustersGenerated: 0,
+          recommendationsGenerated: 0,
+          eventsEmitted: 0,
+        },
+        T('2026-04-26T09:01:00Z'),
+      )
+      const b = ScanRun.start({
+        id: 'b',
+        trigger: 'cron',
+        now: T('2026-04-26T10:00:00Z'),
+      }).complete(
+        {
+          companiesScanned: 2,
+          clustersGenerated: 0,
+          recommendationsGenerated: 0,
+          eventsEmitted: 0,
+        },
+        T('2026-04-26T10:01:00Z'),
+      )
+      const c = ScanRun.start({
+        id: 'c',
+        trigger: 'cron',
+        now: T('2026-04-26T11:00:00Z'),
+      })
+      const d = ScanRun.start({
+        id: 'd',
+        trigger: 'cron',
+        now: T('2026-04-26T12:00:00Z'),
+      }).fail('boom', T('2026-04-26T12:00:30Z'))
+
+      await repo.save(a)
+      await repo.save(b)
+      await repo.save(c)
+      await repo.save(d)
+
+      const latest = await repo.findLatestCompleted()
+      expect(latest!.id).toBe('b')
+    })
+
+    it('returns null when no completed runs exist', async () => {
+      await repo.save(
+        ScanRun.start({
+          id: 'a',
+          trigger: 'cron',
+          now: T('2026-04-26T09:00:00Z'),
+        }),
+      )
+      expect(await repo.findLatestCompleted()).toBeNull()
+    })
+  })
+
+  describe('countByStatus', () => {
+    it('counts runs by status', async () => {
+      const t = T('2026-04-26T10:00:00Z')
+      await repo.save(ScanRun.start({ id: 'a', trigger: 'cron', now: t }))
+      await repo.save(
+        ScanRun.start({ id: 'b', trigger: 'cron', now: t }).complete(
+          {
+            companiesScanned: 0,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          t,
+        ),
+      )
+      await repo.save(
+        ScanRun.start({ id: 'c', trigger: 'cron', now: t }).complete(
+          {
+            companiesScanned: 0,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          t,
+        ),
+      )
+      await repo.save(
+        ScanRun.start({ id: 'd', trigger: 'cron', now: t }).fail('boom', t),
+      )
+
+      expect(await repo.countByStatus('completed')).toBe(2)
+      expect(await repo.countByStatus('running')).toBe(1)
+      expect(await repo.countByStatus('failed')).toBe(1)
+      expect(await repo.countByStatus('partial')).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/MarkEventAsRead.test.ts
+++ b/src/brain/__tests__/agent/MarkEventAsRead.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { MarkEventAsRead } from '@/agent/application/use-cases/MarkEventAsRead'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import { InMemoryAgentEventRepository } from '@/agent/infrastructure/repositories/InMemoryAgentEventRepository'
+
+describe('MarkEventAsRead', () => {
+  let repo: InMemoryAgentEventRepository
+  let useCase: MarkEventAsRead
+
+  beforeEach(() => {
+    repo = new InMemoryAgentEventRepository()
+    useCase = new MarkEventAsRead(repo)
+  })
+
+  it('marks an existing event as read', async () => {
+    await repo.saveAll([
+      AgentEvent.create({
+        id: 'a',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: {},
+        now: new Date('2026-04-26T10:00:00Z'),
+      }),
+    ])
+
+    await useCase.execute({ eventId: 'a' })
+
+    const events = await repo.findByCompany('c-1')
+    expect(events[0]!.read).toBe(true)
+  })
+
+  it('is a no-op for unknown id', async () => {
+    await expect(
+      useCase.execute({ eventId: 'missing' }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects empty eventId', async () => {
+    await expect(useCase.execute({ eventId: '' })).rejects.toThrow(
+      /eventId cannot be empty/,
+    )
+  })
+})

--- a/src/brain/__tests__/agent/OpportunityDetector.test.ts
+++ b/src/brain/__tests__/agent/OpportunityDetector.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest'
+import { OpportunityDetector } from '@/agent/application/services/OpportunityDetector'
+import {
+  Recommendation,
+  type CreateRecommendationInput,
+} from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+const T = new Date('2026-04-26T10:00:00Z')
+
+const makeRec = (
+  overrides: Partial<CreateRecommendationInput> = {},
+): Recommendation =>
+  Recommendation.create({
+    id: 'rec-1',
+    sourceCompanyId: 'a',
+    targetCompanyId: 'b',
+    relationType: 'cliente',
+    score: 0.5,
+    reasons: Reasons.empty(),
+    source: 'rule',
+    ...overrides,
+  })
+
+const key = (s: string, t: string, type: string): string => `${s}|${t}|${type}`
+
+describe('OpportunityDetector', () => {
+  describe('new_high_score_match', () => {
+    it('emits when a new rec has score >= 0.75', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'aliado',
+        score: 0.85,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_high_score_match')
+      expect(events[0]!.companyId).toBe('a')
+      expect(events[0]!.payload).toEqual({
+        recommendationId: 'r1',
+        targetId: 'b',
+        score: 0.85,
+        type: 'aliado',
+      })
+      expect(events[0]!.createdAt).toEqual(T)
+    })
+
+    it('does not emit when the rec key already existed in previous scan', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.9,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set([key('a', 'b', 'cliente')]),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+
+    it('emits exactly one event per recommendation (high_score wins over value_chain)', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.9, // crosses both thresholds
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_high_score_match')
+    })
+  })
+
+  describe('new_value_chain_partner', () => {
+    it('emits for cliente with score >= 0.65 and < 0.75', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.7,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_value_chain_partner')
+      expect(events[0]!.payload).toEqual({
+        recommendationId: 'r1',
+        targetId: 'b',
+        type: 'cliente',
+      })
+    })
+
+    it('emits for proveedor with score >= 0.65', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'proveedor',
+        score: 0.65,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_value_chain_partner')
+    })
+
+    it('does NOT emit for aliado or referente even with score >= 0.65', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [
+          makeRec({
+            id: 'r1',
+            relationType: 'aliado',
+            targetCompanyId: 'b',
+            score: 0.7,
+          }),
+          makeRec({
+            id: 'r2',
+            relationType: 'referente',
+            targetCompanyId: 'c',
+            score: 0.7,
+          }),
+        ],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+
+    it('does not emit when score < 0.65', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        relationType: 'cliente',
+        score: 0.6,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+
+    it('does not emit when key already existed', () => {
+      const detector = new OpportunityDetector()
+      const rec = makeRec({
+        id: 'r1',
+        sourceCompanyId: 'a',
+        targetCompanyId: 'b',
+        relationType: 'cliente',
+        score: 0.7,
+      })
+
+      const events = detector.detect({
+        newRecs: [rec],
+        previousRecKeys: new Set([key('a', 'b', 'cliente')]),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+  })
+
+  describe('new_cluster_member', () => {
+    it('emits one event per existing member when a new member joins their cluster', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map([['cluster-1', ['c-new']]]),
+        existingClusterMemberships: new Map([
+          ['cluster-1', ['c-existing-1', 'c-existing-2']],
+        ]),
+        now: T,
+      })
+
+      expect(events).toHaveLength(2)
+      expect(events.map((e) => e.companyId).sort()).toEqual([
+        'c-existing-1',
+        'c-existing-2',
+      ])
+      expect(events[0]!.eventType).toBe('new_cluster_member')
+      expect(events[0]!.payload).toMatchObject({
+        clusterId: 'cluster-1',
+        newCompanyId: 'c-new',
+      })
+    })
+
+    it('emits multiple events when multiple new members join a cluster with multiple existing members', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map([['cluster-1', ['c-new-1', 'c-new-2']]]),
+        existingClusterMemberships: new Map([['cluster-1', ['c-existing']]]),
+        now: T,
+      })
+
+      expect(events).toHaveLength(2)
+      expect(
+        events.every(
+          (e) =>
+            e.eventType === 'new_cluster_member' &&
+            e.companyId === 'c-existing',
+        ),
+      ).toBe(true)
+      expect(
+        events
+          .map((e) => (e.payload as { newCompanyId: string }).newCompanyId)
+          .sort(),
+      ).toEqual(['c-new-1', 'c-new-2'])
+    })
+
+    it('does not notify a company about itself joining', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map([['cluster-1', ['c-1']]]),
+        existingClusterMemberships: new Map([['cluster-1', ['c-1']]]),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+
+    it('does not emit for clusters with no existing members', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map([['cluster-1', ['c-1', 'c-2']]]),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events).toHaveLength(0)
+    })
+  })
+
+  describe('combined detection', () => {
+    it('emits a mix of rec and cluster events in a single pass', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [
+          makeRec({
+            id: 'r1',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'b',
+            relationType: 'cliente',
+            score: 0.9,
+          }),
+          makeRec({
+            id: 'r2',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'c',
+            relationType: 'proveedor',
+            score: 0.7,
+          }),
+        ],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map([['cluster-1', ['c-new']]]),
+        existingClusterMemberships: new Map([['cluster-1', ['c-existing']]]),
+        now: T,
+      })
+
+      expect(events).toHaveLength(3)
+      const types = events.map((e) => e.eventType).sort()
+      expect(types).toEqual([
+        'new_cluster_member',
+        'new_high_score_match',
+        'new_value_chain_partner',
+      ])
+    })
+
+    it('every emitted event has a non-empty id and the provided createdAt', () => {
+      const detector = new OpportunityDetector()
+      const events = detector.detect({
+        newRecs: [
+          makeRec({
+            id: 'r1',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'b',
+            relationType: 'cliente',
+            score: 0.9,
+          }),
+        ],
+        previousRecKeys: new Set(),
+        newClusterMemberships: new Map(),
+        existingClusterMemberships: new Map(),
+        now: T,
+      })
+
+      expect(events[0]!.id.length).toBeGreaterThan(0)
+      expect(events[0]!.createdAt).toEqual(T)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/RunIncrementalScan.test.ts
+++ b/src/brain/__tests__/agent/RunIncrementalScan.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OpportunityDetector } from '@/agent/application/services/OpportunityDetector'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+import { RunIncrementalScan } from '@/agent/application/use-cases/RunIncrementalScan'
+import { InMemoryAgentEventRepository } from '@/agent/infrastructure/repositories/InMemoryAgentEventRepository'
+import { InMemoryScanRunRepository } from '@/agent/infrastructure/repositories/InMemoryScanRunRepository'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import {
+  Recommendation,
+  type CreateRecommendationInput,
+} from '@/recommendations/domain/entities/Recommendation'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+
+const makeCompany = (
+  id: string,
+  overrides: Partial<{ ciiu: string }> = {},
+): Company =>
+  Company.create({
+    id,
+    razonSocial: `Company ${id}`,
+    ciiu: overrides.ciiu ?? 'G4711',
+    municipio: 'Bogotá',
+    estado: 'ACTIVO',
+  })
+
+const makeRec = (
+  overrides: Partial<CreateRecommendationInput>,
+): Recommendation =>
+  Recommendation.create({
+    id: 'rec-x',
+    sourceCompanyId: 'a',
+    targetCompanyId: 'b',
+    relationType: 'cliente',
+    score: 0.5,
+    reasons: Reasons.empty(),
+    source: 'rule',
+    ...overrides,
+  })
+
+interface Stubs {
+  scanRepo: InMemoryScanRunRepository
+  companyRepo: InMemoryCompanyRepository
+  recRepo: InMemoryRecommendationRepository
+  membershipRepo: InMemoryClusterMembershipRepository
+  eventRepo: InMemoryAgentEventRepository
+  syncCompanies: { execute: ReturnType<typeof vi.fn> }
+  generateClusters: { execute: ReturnType<typeof vi.fn> }
+  generateRecs: { execute: ReturnType<typeof vi.fn> }
+  detector: OpportunityDetector
+}
+
+const makeStubs = (): Stubs => ({
+  scanRepo: new InMemoryScanRunRepository(),
+  companyRepo: new InMemoryCompanyRepository(),
+  recRepo: new InMemoryRecommendationRepository(),
+  membershipRepo: new InMemoryClusterMembershipRepository(),
+  eventRepo: new InMemoryAgentEventRepository(),
+  syncCompanies: { execute: vi.fn(async () => ({ synced: 0 })) },
+  generateClusters: {
+    execute: vi.fn(async () => ({
+      predefinedClusters: 0,
+      heuristicClusters: 0,
+      totalMemberships: 0,
+    })),
+  },
+  generateRecs: {
+    execute: vi.fn(async () => ({
+      totalRecommendations: 0,
+      companiesWithRecs: 0,
+      byRelationType: { cliente: 0, proveedor: 0, aliado: 0, referente: 0 },
+    })),
+  },
+  detector: new OpportunityDetector(),
+})
+
+const buildUseCase = (stubs: Stubs): RunIncrementalScan =>
+  new RunIncrementalScan(
+    stubs.scanRepo,
+    stubs.companyRepo,
+    stubs.syncCompanies as never,
+    stubs.generateClusters as never,
+    stubs.generateRecs as never,
+    stubs.detector,
+    stubs.recRepo,
+    stubs.eventRepo,
+    stubs.membershipRepo,
+  )
+
+describe('RunIncrementalScan', () => {
+  let stubs: Stubs
+
+  beforeEach(() => {
+    stubs = makeStubs()
+  })
+
+  describe('first run (no previous scan)', () => {
+    it('uses epoch as since and runs the full pipeline', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a'), makeCompany('b')])
+
+      const result = await useCase.execute({ trigger: 'cron' })
+
+      expect(result.status).toBe('completed')
+      expect(stubs.syncCompanies.execute).toHaveBeenCalledWith({
+        since: new Date(0),
+      })
+      expect(stubs.generateClusters.execute).toHaveBeenCalled()
+      expect(stubs.generateRecs.execute).toHaveBeenCalled()
+    })
+  })
+
+  describe('subsequent run (previous completed scan exists)', () => {
+    it('uses the last completed scan completedAt as since', async () => {
+      const useCase = buildUseCase(stubs)
+      const lastCompletedAt = new Date('2026-04-26T09:00:00Z')
+      await stubs.scanRepo.save(
+        ScanRun.start({
+          id: 'prev',
+          trigger: 'cron',
+          now: new Date('2026-04-26T08:55:00Z'),
+        }).complete(
+          {
+            companiesScanned: 1,
+            clustersGenerated: 1,
+            recommendationsGenerated: 1,
+            eventsEmitted: 0,
+          },
+          lastCompletedAt,
+        ),
+      )
+      await stubs.companyRepo.saveMany([makeCompany('a')])
+
+      await useCase.execute({ trigger: 'cron' })
+
+      expect(stubs.syncCompanies.execute).toHaveBeenCalledWith({
+        since: lastCompletedAt,
+      })
+    })
+
+    it('short-circuits to a zero-stat completed run when no companies are updated', async () => {
+      const useCase = buildUseCase(stubs)
+      const lastCompletedAt = new Date('2026-04-26T09:00:00Z')
+      await stubs.scanRepo.save(
+        ScanRun.start({
+          id: 'prev',
+          trigger: 'cron',
+          now: new Date('2026-04-26T08:55:00Z'),
+        }).complete(
+          {
+            companiesScanned: 0,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          lastCompletedAt,
+        ),
+      )
+      // companyRepo empty → findUpdatedSince returns []
+
+      const result = await useCase.execute({ trigger: 'cron' })
+
+      expect(result.status).toBe('completed')
+      expect(result.companiesScanned).toBe(0)
+      expect(stubs.generateClusters.execute).not.toHaveBeenCalled()
+      expect(stubs.generateRecs.execute).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('orchestration order', () => {
+    it('snapshots previous rec keys BEFORE regenerating recommendations', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a'), makeCompany('b')])
+      // previous rec — would be in snapshot
+      await stubs.recRepo.saveAll([
+        makeRec({
+          id: 'old',
+          sourceCompanyId: 'a',
+          targetCompanyId: 'b',
+          relationType: 'cliente',
+          score: 0.9,
+        }),
+      ])
+
+      // generateRecs replaces with same key — should NOT trigger event
+      stubs.generateRecs.execute.mockImplementationOnce(async () => {
+        await stubs.recRepo.deleteAll()
+        await stubs.recRepo.saveAll([
+          makeRec({
+            id: 'new',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'b',
+            relationType: 'cliente',
+            score: 0.95,
+          }),
+        ])
+        return {
+          totalRecommendations: 1,
+          companiesWithRecs: 1,
+          byRelationType: { cliente: 1, proveedor: 0, aliado: 0, referente: 0 },
+        }
+      })
+
+      await useCase.execute({ trigger: 'cron' })
+
+      const events = await stubs.eventRepo.findByCompany('a')
+      expect(events).toHaveLength(0)
+    })
+
+    it('emits a high_score event for a brand-new high-score rec', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a'), makeCompany('b')])
+      // no previous recs
+
+      stubs.generateRecs.execute.mockImplementationOnce(async () => {
+        await stubs.recRepo.saveAll([
+          makeRec({
+            id: 'new',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'b',
+            relationType: 'aliado',
+            score: 0.9,
+          }),
+        ])
+        return {
+          totalRecommendations: 1,
+          companiesWithRecs: 1,
+          byRelationType: { cliente: 0, proveedor: 0, aliado: 1, referente: 0 },
+        }
+      })
+
+      const result = await useCase.execute({ trigger: 'cron' })
+
+      const events = await stubs.eventRepo.findByCompany('a')
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_high_score_match')
+      expect(result.eventsEmitted).toBe(1)
+    })
+
+    it('emits cluster_member events when clusters change', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([
+        makeCompany('a'),
+        makeCompany('b'),
+        makeCompany('c'),
+      ])
+      // pre-existing membership: cluster-1 has just 'a'
+      await stubs.membershipRepo.saveMany([
+        { clusterId: 'cluster-1', companyId: 'a' },
+      ])
+
+      stubs.generateClusters.execute.mockImplementationOnce(async () => {
+        await stubs.membershipRepo.deleteAll()
+        await stubs.membershipRepo.saveMany([
+          { clusterId: 'cluster-1', companyId: 'a' },
+          { clusterId: 'cluster-1', companyId: 'b' },
+        ])
+        return {
+          predefinedClusters: 1,
+          heuristicClusters: 0,
+          totalMemberships: 2,
+        }
+      })
+
+      const result = await useCase.execute({ trigger: 'cron' })
+
+      const events = await stubs.eventRepo.findByCompany('a')
+      expect(events).toHaveLength(1)
+      expect(events[0]!.eventType).toBe('new_cluster_member')
+      expect(events[0]!.payload).toMatchObject({
+        clusterId: 'cluster-1',
+        newCompanyId: 'b',
+      })
+      expect(result.eventsEmitted).toBe(1)
+    })
+  })
+
+  describe('persistence', () => {
+    it('saves a running scan first, then a completed scan with stats', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a')])
+
+      stubs.generateClusters.execute.mockResolvedValueOnce({
+        predefinedClusters: 2,
+        heuristicClusters: 1,
+        totalMemberships: 5,
+      })
+      stubs.generateRecs.execute.mockResolvedValueOnce({
+        totalRecommendations: 17,
+        companiesWithRecs: 3,
+        byRelationType: { cliente: 5, proveedor: 4, aliado: 5, referente: 3 },
+      })
+
+      const result = await useCase.execute({ trigger: 'manual' })
+
+      expect(result.status).toBe('completed')
+      expect(result.clustersGenerated).toBe(3)
+      expect(result.recommendationsGenerated).toBe(17)
+      expect(result.companiesScanned).toBe(1)
+
+      const persisted = await stubs.scanRepo.findLatest()
+      expect(persisted!.status).toBe('completed')
+      expect(persisted!.trigger).toBe('manual')
+      expect(persisted!.clustersGenerated).toBe(3)
+      expect(persisted!.recommendationsGenerated).toBe(17)
+    })
+
+    it('persists eventsEmitted in the saved scan', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a'), makeCompany('b')])
+
+      stubs.generateRecs.execute.mockImplementationOnce(async () => {
+        await stubs.recRepo.saveAll([
+          makeRec({
+            id: 'new',
+            sourceCompanyId: 'a',
+            targetCompanyId: 'b',
+            relationType: 'cliente',
+            score: 0.9,
+          }),
+        ])
+        return {
+          totalRecommendations: 1,
+          companiesWithRecs: 1,
+          byRelationType: { cliente: 1, proveedor: 0, aliado: 0, referente: 0 },
+        }
+      })
+
+      await useCase.execute({ trigger: 'cron' })
+
+      const persisted = await stubs.scanRepo.findLatest()
+      expect(persisted!.eventsEmitted).toBe(1)
+    })
+  })
+
+  describe('failure handling', () => {
+    it('marks the scan as failed and rethrows when sync throws', async () => {
+      const useCase = buildUseCase(stubs)
+      stubs.syncCompanies.execute.mockRejectedValueOnce(new Error('sync down'))
+
+      await expect(useCase.execute({ trigger: 'cron' })).rejects.toThrow(
+        /sync down/,
+      )
+
+      const persisted = await stubs.scanRepo.findLatest()
+      expect(persisted!.status).toBe('failed')
+      expect(persisted!.errorMessage).toBe('sync down')
+    })
+
+    it('marks the scan as failed when generateClusters throws', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a')])
+      stubs.generateClusters.execute.mockRejectedValueOnce(
+        new Error('cluster boom'),
+      )
+
+      await expect(useCase.execute({ trigger: 'cron' })).rejects.toThrow(
+        /cluster boom/,
+      )
+
+      const persisted = await stubs.scanRepo.findLatest()
+      expect(persisted!.status).toBe('failed')
+      expect(persisted!.errorMessage).toBe('cluster boom')
+    })
+
+    it('marks the scan as failed when generateRecs throws', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a')])
+      stubs.generateRecs.execute.mockRejectedValueOnce(new Error('rec boom'))
+
+      await expect(useCase.execute({ trigger: 'cron' })).rejects.toThrow(
+        /rec boom/,
+      )
+
+      const persisted = await stubs.scanRepo.findLatest()
+      expect(persisted!.status).toBe('failed')
+    })
+  })
+
+  describe('result shape', () => {
+    it('returns a runId, status, and stats', async () => {
+      const useCase = buildUseCase(stubs)
+      await stubs.companyRepo.saveMany([makeCompany('a')])
+
+      const result = await useCase.execute({ trigger: 'cron' })
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          runId: expect.any(String),
+          status: 'completed',
+          companiesScanned: expect.any(Number),
+          clustersGenerated: expect.any(Number),
+          recommendationsGenerated: expect.any(Number),
+          eventsEmitted: expect.any(Number),
+        }),
+      )
+      expect(result.runId.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/ScanRun.test.ts
+++ b/src/brain/__tests__/agent/ScanRun.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+
+const T0 = new Date('2026-04-26T10:00:00Z')
+const T1 = new Date('2026-04-26T10:05:00Z')
+
+describe('ScanRun', () => {
+  describe('start', () => {
+    it('creates a running scan with zeroed stats and the provided startedAt', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+
+      expect(run.id).toBe('run-1')
+      expect(run.status).toBe('running')
+      expect(run.trigger).toBe('cron')
+      expect(run.startedAt).toEqual(T0)
+      expect(run.completedAt).toBeNull()
+      expect(run.errorMessage).toBeNull()
+      expect(run.companiesScanned).toBe(0)
+      expect(run.clustersGenerated).toBe(0)
+      expect(run.recommendationsGenerated).toBe(0)
+      expect(run.eventsEmitted).toBe(0)
+    })
+
+    it('rejects empty id', () => {
+      expect(() =>
+        ScanRun.start({ id: '', trigger: 'manual', now: T0 }),
+      ).toThrow(/id cannot be empty/)
+      expect(() =>
+        ScanRun.start({ id: '   ', trigger: 'manual', now: T0 }),
+      ).toThrow(/id cannot be empty/)
+    })
+
+    it('accepts manual trigger', () => {
+      const run = ScanRun.start({ id: 'run-2', trigger: 'manual', now: T0 })
+      expect(run.trigger).toBe('manual')
+    })
+  })
+
+  describe('complete', () => {
+    it('returns a new instance with completed status, stats and the provided completedAt', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      const completed = run.complete(
+        {
+          companiesScanned: 12,
+          clustersGenerated: 4,
+          recommendationsGenerated: 30,
+          eventsEmitted: 5,
+        },
+        T1,
+      )
+
+      expect(completed).not.toBe(run)
+      expect(completed.status).toBe('completed')
+      expect(completed.completedAt).toEqual(T1)
+      expect(completed.companiesScanned).toBe(12)
+      expect(completed.clustersGenerated).toBe(4)
+      expect(completed.recommendationsGenerated).toBe(30)
+      expect(completed.eventsEmitted).toBe(5)
+      expect(completed.errorMessage).toBeNull()
+    })
+
+    it('preserves the original instance (immutability)', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      run.complete(
+        {
+          companiesScanned: 1,
+          clustersGenerated: 0,
+          recommendationsGenerated: 0,
+          eventsEmitted: 0,
+        },
+        T1,
+      )
+      expect(run.status).toBe('running')
+      expect(run.companiesScanned).toBe(0)
+    })
+
+    it('rejects negative stats', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      expect(() =>
+        run.complete(
+          {
+            companiesScanned: -1,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          T1,
+        ),
+      ).toThrow(/stats must be non-negative/)
+    })
+  })
+
+  describe('fail', () => {
+    it('returns a new instance with failed status and error message', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      const failed = run.fail('boom', T1)
+
+      expect(failed).not.toBe(run)
+      expect(failed.status).toBe('failed')
+      expect(failed.completedAt).toEqual(T1)
+      expect(failed.errorMessage).toBe('boom')
+      expect(failed.companiesScanned).toBe(0)
+    })
+
+    it('rejects empty message', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      expect(() => run.fail('', T1)).toThrow(/message cannot be empty/)
+      expect(() => run.fail('   ', T1)).toThrow(/message cannot be empty/)
+    })
+  })
+
+  describe('partial', () => {
+    it('returns a new instance with partial status, stats and error message', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      const partial = run.partial(
+        {
+          companiesScanned: 12,
+          clustersGenerated: 4,
+          recommendationsGenerated: 30,
+          eventsEmitted: 5,
+        },
+        'gemini timed out, fallback ran',
+        T1,
+      )
+
+      expect(partial).not.toBe(run)
+      expect(partial.status).toBe('partial')
+      expect(partial.completedAt).toEqual(T1)
+      expect(partial.errorMessage).toBe('gemini timed out, fallback ran')
+      expect(partial.companiesScanned).toBe(12)
+    })
+
+    it('rejects empty message', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      expect(() =>
+        run.partial(
+          {
+            companiesScanned: 0,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          '',
+          T1,
+        ),
+      ).toThrow(/message cannot be empty/)
+    })
+  })
+
+  describe('durationMs', () => {
+    it('returns the elapsed time when completed', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      const t = new Date('2026-04-26T10:00:01.500Z')
+      const completed = run.complete(
+        {
+          companiesScanned: 0,
+          clustersGenerated: 0,
+          recommendationsGenerated: 0,
+          eventsEmitted: 0,
+        },
+        t,
+      )
+
+      expect(completed.durationMs).toBe(1500)
+    })
+
+    it('returns null when still running', () => {
+      const run = ScanRun.start({ id: 'run-1', trigger: 'cron', now: T0 })
+      expect(run.durationMs).toBeNull()
+    })
+  })
+
+  describe('hydrate', () => {
+    it('rebuilds an instance from stored props (used by repository toEntity)', () => {
+      const run = ScanRun.hydrate({
+        id: 'run-1',
+        startedAt: T0,
+        completedAt: T1,
+        companiesScanned: 12,
+        clustersGenerated: 4,
+        recommendationsGenerated: 30,
+        eventsEmitted: 5,
+        status: 'completed',
+        trigger: 'cron',
+        errorMessage: null,
+      })
+
+      expect(run.id).toBe('run-1')
+      expect(run.status).toBe('completed')
+      expect(run.durationMs).toBe(5 * 60 * 1000)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/SupabaseAgentEventRepository.test.ts
+++ b/src/brain/__tests__/agent/SupabaseAgentEventRepository.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import { SupabaseAgentEventRepository } from '@/agent/infrastructure/repositories/SupabaseAgentEventRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of [
+    'from',
+    'select',
+    'eq',
+    'upsert',
+    'update',
+    'order',
+    'limit',
+  ] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  id: 'ev-1',
+  company_id: 'c-1',
+  event_type: 'new_high_score_match',
+  payload: { score: 0.9 },
+  read: false,
+  created_at: '2026-04-26T10:00:00Z',
+}
+
+describe('SupabaseAgentEventRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseAgentEventRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseAgentEventRepository(fake.db)
+  })
+
+  describe('saveAll', () => {
+    it('upserts rows with onConflict id', async () => {
+      fake.setNext({ data: null, error: null })
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_high_score_match',
+        payload: { score: 0.9 },
+        now: new Date('2026-04-26T10:00:00Z'),
+      })
+
+      await repo.saveAll([ev])
+
+      expect(fake.spies.from).toHaveBeenCalledWith('agent_events')
+      expect(fake.spies.upsert).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'ev-1',
+            company_id: 'c-1',
+            event_type: 'new_high_score_match',
+            payload: { score: 0.9 },
+            read: false,
+            created_at: '2026-04-26T10:00:00.000Z',
+          }),
+        ]),
+        { onConflict: 'id' },
+      )
+    })
+
+    it('is a no-op for empty array', async () => {
+      await repo.saveAll([])
+      expect(fake.spies.upsert).not.toHaveBeenCalled()
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      const ev = AgentEvent.create({
+        id: 'ev-1',
+        companyId: 'c-1',
+        eventType: 'new_cluster_member',
+        payload: {},
+        now: new Date('2026-04-26T10:00:00Z'),
+      })
+      await expect(repo.saveAll([ev])).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('findByCompany', () => {
+    it('filters by company_id and orders by created_at desc', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const result = await repo.findByCompany('c-1')
+
+      expect(fake.spies.from).toHaveBeenCalledWith('agent_events')
+      expect(fake.spies.eq).toHaveBeenCalledWith('company_id', 'c-1')
+      expect(fake.spies.order).toHaveBeenCalledWith('created_at', {
+        ascending: false,
+      })
+      expect(fake.spies.limit).not.toHaveBeenCalled()
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('ev-1')
+    })
+
+    it('with unreadOnly=true filters read=false', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      await repo.findByCompany('c-1', { unreadOnly: true })
+
+      expect(fake.spies.eq).toHaveBeenCalledWith('read', false)
+    })
+
+    it('applies limit when provided', async () => {
+      fake.setNext({ data: [], error: null })
+      await repo.findByCompany('c-1', { limit: 5 })
+      expect(fake.spies.limit).toHaveBeenCalledWith(5)
+    })
+
+    it('throws when row event_type is unknown', async () => {
+      fake.setNext({
+        data: [{ ...validRow, event_type: 'wat' }],
+        error: null,
+      })
+      await expect(repo.findByCompany('c-1')).rejects.toThrow(
+        /Unknown agent_event event_type/,
+      )
+    })
+
+    it('returns [] when data is null', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findByCompany('c-1')).toEqual([])
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findByCompany('c-1')).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('markAsRead', () => {
+    it('updates read=true filtered by id', async () => {
+      fake.setNext({ data: null, error: null })
+      await repo.markAsRead('ev-1')
+
+      expect(fake.spies.update).toHaveBeenCalledWith({ read: true })
+      expect(fake.spies.eq).toHaveBeenCalledWith('id', 'ev-1')
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.markAsRead('ev-1')).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('countUnreadForCompany', () => {
+    it('counts events with read=false for the company', async () => {
+      fake.setNext({ data: null, error: null, count: 3 })
+      const n = await repo.countUnreadForCompany('c-1')
+
+      expect(n).toBe(3)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+      expect(fake.spies.eq).toHaveBeenCalledWith('company_id', 'c-1')
+      expect(fake.spies.eq).toHaveBeenCalledWith('read', false)
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.countUnreadForCompany('c-1')).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/agent/SupabaseScanRunRepository.test.ts
+++ b/src/brain/__tests__/agent/SupabaseScanRunRepository.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+import { SupabaseScanRunRepository } from '@/agent/infrastructure/repositories/SupabaseScanRunRepository'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+type Resolved = { data: unknown; error: unknown; count?: number | null }
+
+function createFakeDb() {
+  let resolved: Resolved = { data: null, error: null }
+
+  const builder = {
+    from: vi.fn(),
+    select: vi.fn(),
+    eq: vi.fn(),
+    upsert: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+    then: (
+      onF: (r: Resolved) => unknown,
+      onR?: (e: unknown) => unknown,
+    ): Promise<unknown> => Promise.resolve(resolved).then(onF, onR),
+  }
+
+  for (const fn of [
+    'from',
+    'select',
+    'eq',
+    'upsert',
+    'order',
+    'limit',
+  ] as const) {
+    builder[fn].mockReturnValue(builder)
+  }
+  builder.maybeSingle.mockImplementation(() => Promise.resolve(resolved))
+
+  return {
+    db: builder as unknown as BrainSupabaseClient,
+    setNext: (value: Resolved) => {
+      resolved = value
+    },
+    spies: builder,
+  }
+}
+
+const validRow = {
+  id: 'run-1',
+  started_at: '2026-04-26T10:00:00Z',
+  completed_at: '2026-04-26T10:01:00Z',
+  companies_scanned: 5,
+  clusters_generated: 1,
+  recommendations_generated: 3,
+  events_emitted: 2,
+  status: 'completed',
+  trigger: 'cron',
+  error_message: null,
+  duration_ms: 60000,
+}
+
+describe('SupabaseScanRunRepository', () => {
+  let fake: ReturnType<typeof createFakeDb>
+  let repo: SupabaseScanRunRepository
+
+  beforeEach(() => {
+    fake = createFakeDb()
+    repo = new SupabaseScanRunRepository(fake.db)
+  })
+
+  describe('save', () => {
+    it('upserts the row including computed duration_ms when completed', async () => {
+      fake.setNext({ data: null, error: null })
+      const run = ScanRun.start({
+        id: 'run-1',
+        trigger: 'cron',
+        now: new Date('2026-04-26T10:00:00Z'),
+      }).complete(
+        {
+          companiesScanned: 5,
+          clustersGenerated: 1,
+          recommendationsGenerated: 3,
+          eventsEmitted: 2,
+        },
+        new Date('2026-04-26T10:01:00Z'),
+      )
+
+      await repo.save(run)
+
+      expect(fake.spies.from).toHaveBeenCalledWith('scan_runs')
+      expect(fake.spies.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'run-1',
+          status: 'completed',
+          trigger: 'cron',
+          started_at: '2026-04-26T10:00:00.000Z',
+          completed_at: '2026-04-26T10:01:00.000Z',
+          companies_scanned: 5,
+          clusters_generated: 1,
+          recommendations_generated: 3,
+          events_emitted: 2,
+          duration_ms: 60000,
+          error_message: null,
+        }),
+        { onConflict: 'id' },
+      )
+    })
+
+    it('persists null completed_at and null duration_ms when running', async () => {
+      fake.setNext({ data: null, error: null })
+      const run = ScanRun.start({
+        id: 'run-1',
+        trigger: 'cron',
+        now: new Date('2026-04-26T10:00:00Z'),
+      })
+
+      await repo.save(run)
+
+      expect(fake.spies.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'running',
+          completed_at: null,
+          duration_ms: null,
+        }),
+        { onConflict: 'id' },
+      )
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      const run = ScanRun.start({
+        id: 'run-1',
+        trigger: 'cron',
+        now: new Date('2026-04-26T10:00:00Z'),
+      })
+      await expect(repo.save(run)).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('findLatest', () => {
+    it('selects latest by started_at desc with limit 1', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const run = await repo.findLatest()
+
+      expect(fake.spies.from).toHaveBeenCalledWith('scan_runs')
+      expect(fake.spies.order).toHaveBeenCalledWith('started_at', {
+        ascending: false,
+      })
+      expect(fake.spies.limit).toHaveBeenCalledWith(1)
+      expect(run!.id).toBe('run-1')
+      expect(run!.status).toBe('completed')
+    })
+
+    it('returns null when row missing', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findLatest()).toBeNull()
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findLatest()).rejects.toThrow(/boom/)
+    })
+
+    it('throws when row status is unknown', async () => {
+      fake.setNext({ data: { ...validRow, status: 'wat' }, error: null })
+      await expect(repo.findLatest()).rejects.toThrow(/Unknown ScanRun status/)
+    })
+
+    it('throws when row trigger is unknown', async () => {
+      fake.setNext({ data: { ...validRow, trigger: 'wat' }, error: null })
+      await expect(repo.findLatest()).rejects.toThrow(/Unknown ScanRun trigger/)
+    })
+  })
+
+  describe('findLatestCompleted', () => {
+    it('filters by status=completed and orders by completed_at desc', async () => {
+      fake.setNext({ data: validRow, error: null })
+      const run = await repo.findLatestCompleted()
+
+      expect(fake.spies.eq).toHaveBeenCalledWith('status', 'completed')
+      expect(fake.spies.order).toHaveBeenCalledWith('completed_at', {
+        ascending: false,
+      })
+      expect(fake.spies.limit).toHaveBeenCalledWith(1)
+      expect(run!.id).toBe('run-1')
+    })
+
+    it('returns null when none completed', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(await repo.findLatestCompleted()).toBeNull()
+    })
+  })
+
+  describe('countByStatus', () => {
+    it('uses count exact head true and filters by status', async () => {
+      fake.setNext({ data: null, error: null, count: 7 })
+      const n = await repo.countByStatus('completed')
+
+      expect(n).toBe(7)
+      expect(fake.spies.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      })
+      expect(fake.spies.eq).toHaveBeenCalledWith('status', 'completed')
+    })
+
+    it('returns 0 when count is null', async () => {
+      fake.setNext({ data: null, error: null, count: null })
+      expect(await repo.countByStatus('failed')).toBe(0)
+    })
+  })
+})

--- a/src/brain/__tests__/clusters/InMemoryClusterMembershipRepository.test.ts
+++ b/src/brain/__tests__/clusters/InMemoryClusterMembershipRepository.test.ts
@@ -53,4 +53,36 @@ describe('InMemoryClusterMembershipRepository', () => {
     await repo.saveMany([])
     expect(await repo.count()).toBe(0)
   })
+
+  describe('snapshot', () => {
+    it('returns a Map of clusterId to companyIds for every stored membership', async () => {
+      await repo.saveMany([
+        { clusterId: 'pred-1', companyId: 'c-1' },
+        { clusterId: 'pred-1', companyId: 'c-2' },
+        { clusterId: 'pred-2', companyId: 'c-1' },
+        { clusterId: 'pred-2', companyId: 'c-3' },
+      ])
+
+      const snap = await repo.snapshot()
+      expect(snap).toBeInstanceOf(Map)
+      expect(snap.size).toBe(2)
+      expect(snap.get('pred-1')!.sort()).toEqual(['c-1', 'c-2'])
+      expect(snap.get('pred-2')!.sort()).toEqual(['c-1', 'c-3'])
+    })
+
+    it('returns an empty Map when store is empty', async () => {
+      const snap = await repo.snapshot()
+      expect(snap.size).toBe(0)
+    })
+
+    it('does not include duplicate companyIds within the same cluster', async () => {
+      await repo.saveMany([
+        { clusterId: 'pred-1', companyId: 'c-1' },
+        { clusterId: 'pred-1', companyId: 'c-1' },
+      ])
+
+      const snap = await repo.snapshot()
+      expect(snap.get('pred-1')).toEqual(['c-1'])
+    })
+  })
 })

--- a/src/brain/__tests__/clusters/SupabaseClusterMembershipRepository.test.ts
+++ b/src/brain/__tests__/clusters/SupabaseClusterMembershipRepository.test.ts
@@ -144,4 +144,37 @@ describe('SupabaseClusterMembershipRepository', () => {
       expect(await repo.count()).toBe(0)
     })
   })
+
+  describe('snapshot', () => {
+    it('selects both columns and groups company_ids by cluster_id', async () => {
+      fake.setNext({
+        data: [
+          { cluster_id: 'pred-1', company_id: 'c-1' },
+          { cluster_id: 'pred-1', company_id: 'c-2' },
+          { cluster_id: 'pred-2', company_id: 'c-3' },
+        ],
+        error: null,
+      })
+
+      const snap = await repo.snapshot()
+
+      expect(fake.spies.from).toHaveBeenCalledWith('cluster_members')
+      expect(fake.spies.select).toHaveBeenCalledWith('cluster_id, company_id')
+      expect(snap).toBeInstanceOf(Map)
+      expect(snap.size).toBe(2)
+      expect(snap.get('pred-1')!.sort()).toEqual(['c-1', 'c-2'])
+      expect(snap.get('pred-2')).toEqual(['c-3'])
+    })
+
+    it('returns empty Map when no rows', async () => {
+      fake.setNext({ data: [], error: null })
+      const snap = await repo.snapshot()
+      expect(snap.size).toBe(0)
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.snapshot()).rejects.toThrow(/boom/)
+    })
+  })
 })

--- a/src/brain/__tests__/recommendations/InMemoryRecommendationRepository.test.ts
+++ b/src/brain/__tests__/recommendations/InMemoryRecommendationRepository.test.ts
@@ -157,4 +157,82 @@ describe('InMemoryRecommendationRepository', () => {
     expect(await repo.findById('r1')).toBeNull()
     expect(await repo.countBySource('a')).toBe(0)
   })
+
+  describe('findAll', () => {
+    it('returns every stored recommendation', async () => {
+      await repo.saveAll([
+        makeRec({ id: 'r1' }),
+        makeRec({ id: 'r2', sourceCompanyId: 'x', targetCompanyId: 'y' }),
+        makeRec({ id: 'r3', targetCompanyId: 'c', relationType: 'proveedor' }),
+      ])
+
+      const all = await repo.findAll()
+      expect(all).toHaveLength(3)
+      expect(all.map((r) => r.id).sort()).toEqual(['r1', 'r2', 'r3'])
+    })
+
+    it('returns empty array when store is empty', async () => {
+      expect(await repo.findAll()).toEqual([])
+    })
+  })
+
+  describe('snapshotKeys', () => {
+    it('returns a Set of source|target|type keys for every stored rec', async () => {
+      await repo.saveAll([
+        makeRec({
+          id: 'r1',
+          sourceCompanyId: 'a',
+          targetCompanyId: 'b',
+          relationType: 'cliente',
+        }),
+        makeRec({
+          id: 'r2',
+          sourceCompanyId: 'a',
+          targetCompanyId: 'b',
+          relationType: 'proveedor',
+        }),
+        makeRec({
+          id: 'r3',
+          sourceCompanyId: 'x',
+          targetCompanyId: 'y',
+          relationType: 'aliado',
+        }),
+      ])
+
+      const keys = await repo.snapshotKeys()
+      expect(keys).toBeInstanceOf(Set)
+      expect(keys.size).toBe(3)
+      expect(keys.has('a|b|cliente')).toBe(true)
+      expect(keys.has('a|b|proveedor')).toBe(true)
+      expect(keys.has('x|y|aliado')).toBe(true)
+    })
+
+    it('returns an empty Set when store is empty', async () => {
+      const keys = await repo.snapshotKeys()
+      expect(keys.size).toBe(0)
+    })
+
+    it('does not include score in the key (different scores collapse)', async () => {
+      await repo.saveAll([
+        makeRec({
+          id: 'r1',
+          sourceCompanyId: 'a',
+          targetCompanyId: 'b',
+          relationType: 'cliente',
+          score: 0.3,
+        }),
+        makeRec({
+          id: 'r2',
+          sourceCompanyId: 'a',
+          targetCompanyId: 'b',
+          relationType: 'cliente',
+          score: 0.9,
+        }),
+      ])
+
+      const keys = await repo.snapshotKeys()
+      expect(keys.size).toBe(1)
+      expect(keys.has('a|b|cliente')).toBe(true)
+    })
+  })
 })

--- a/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
+++ b/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
@@ -257,4 +257,69 @@ describe('SupabaseRecommendationRepository', () => {
       await expect(repo.deleteAll()).rejects.toThrow(/boom/)
     })
   })
+
+  describe('findAll', () => {
+    it('selects all rows and maps them to entities', async () => {
+      fake.setNext({ data: [validRow], error: null })
+      const all = await repo.findAll()
+
+      expect(fake.spies.from).toHaveBeenCalledWith('recommendations')
+      expect(fake.spies.select).toHaveBeenCalledWith('*')
+      expect(all).toHaveLength(1)
+      expect(all[0]).toBeInstanceOf(Recommendation)
+      expect(all[0]!.id).toBe('rec-1')
+    })
+
+    it('returns empty array when no rows', async () => {
+      fake.setNext({ data: [], error: null })
+      expect(await repo.findAll()).toEqual([])
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.findAll()).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('snapshotKeys', () => {
+    it('selects only key columns and builds source|target|type keys', async () => {
+      fake.setNext({
+        data: [
+          {
+            source_company_id: 'a',
+            target_company_id: 'b',
+            relation_type: 'cliente',
+          },
+          {
+            source_company_id: 'x',
+            target_company_id: 'y',
+            relation_type: 'aliado',
+          },
+        ],
+        error: null,
+      })
+
+      const keys = await repo.snapshotKeys()
+
+      expect(fake.spies.from).toHaveBeenCalledWith('recommendations')
+      expect(fake.spies.select).toHaveBeenCalledWith(
+        'source_company_id, target_company_id, relation_type',
+      )
+      expect(keys).toBeInstanceOf(Set)
+      expect(keys.size).toBe(2)
+      expect(keys.has('a|b|cliente')).toBe(true)
+      expect(keys.has('x|y|aliado')).toBe(true)
+    })
+
+    it('returns empty Set when no rows', async () => {
+      fake.setNext({ data: [], error: null })
+      const keys = await repo.snapshotKeys()
+      expect(keys.size).toBe(0)
+    })
+
+    it('throws on error', async () => {
+      fake.setNext({ data: null, error: new Error('boom') })
+      await expect(repo.snapshotKeys()).rejects.toThrow(/boom/)
+    })
+  })
 })

--- a/src/brain/src/agent/agent.module.ts
+++ b/src/brain/src/agent/agent.module.ts
@@ -1,0 +1,42 @@
+import { Module } from '@nestjs/common'
+import { ClustersModule } from '@/clusters/clusters.module'
+import { CompaniesModule } from '@/companies/companies.module'
+import { RecommendationsModule } from '@/recommendations/recommendations.module'
+import { OpportunityDetector } from './application/services/OpportunityDetector'
+import { GetAgentEvents } from './application/use-cases/GetAgentEvents'
+import { MarkEventAsRead } from './application/use-cases/MarkEventAsRead'
+import { RunIncrementalScan } from './application/use-cases/RunIncrementalScan'
+import { AGENT_EVENT_REPOSITORY } from './domain/repositories/AgentEventRepository'
+import { SCAN_RUN_REPOSITORY } from './domain/repositories/ScanRunRepository'
+import { AgentController } from './infrastructure/http/agent.controller'
+import { SupabaseAgentEventRepository } from './infrastructure/repositories/SupabaseAgentEventRepository'
+import { SupabaseScanRunRepository } from './infrastructure/repositories/SupabaseScanRunRepository'
+import { AgentScheduler } from './infrastructure/scheduler/AgentScheduler'
+
+@Module({
+  imports: [CompaniesModule, ClustersModule, RecommendationsModule],
+  controllers: [AgentController],
+  providers: [
+    {
+      provide: SCAN_RUN_REPOSITORY,
+      useClass: SupabaseScanRunRepository,
+    },
+    {
+      provide: AGENT_EVENT_REPOSITORY,
+      useClass: SupabaseAgentEventRepository,
+    },
+    OpportunityDetector,
+    RunIncrementalScan,
+    GetAgentEvents,
+    MarkEventAsRead,
+    AgentScheduler,
+  ],
+  exports: [
+    SCAN_RUN_REPOSITORY,
+    AGENT_EVENT_REPOSITORY,
+    RunIncrementalScan,
+    GetAgentEvents,
+    MarkEventAsRead,
+  ],
+})
+export class AgentModule {}

--- a/src/brain/src/agent/application/services/OpportunityDetector.ts
+++ b/src/brain/src/agent/application/services/OpportunityDetector.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+
+const HIGH_SCORE_THRESHOLD = 0.75
+const VALUE_CHAIN_THRESHOLD = 0.65
+
+export interface DetectInput {
+  newRecs: Recommendation[]
+  previousRecKeys: Set<string>
+  newClusterMemberships: Map<string, string[]>
+  existingClusterMemberships: Map<string, string[]>
+  now: Date
+}
+
+@Injectable()
+export class OpportunityDetector {
+  detect(input: DetectInput): AgentEvent[] {
+    const events: AgentEvent[] = []
+
+    for (const rec of input.newRecs) {
+      const k = `${rec.sourceCompanyId}|${rec.targetCompanyId}|${rec.relationType}`
+      if (input.previousRecKeys.has(k)) continue
+
+      if (rec.score >= HIGH_SCORE_THRESHOLD) {
+        events.push(
+          AgentEvent.create({
+            id: randomUUID(),
+            companyId: rec.sourceCompanyId,
+            eventType: 'new_high_score_match',
+            payload: {
+              recommendationId: rec.id,
+              targetId: rec.targetCompanyId,
+              score: rec.score,
+              type: rec.relationType,
+            },
+            now: input.now,
+          }),
+        )
+      } else if (
+        (rec.relationType === 'cliente' || rec.relationType === 'proveedor') &&
+        rec.score >= VALUE_CHAIN_THRESHOLD
+      ) {
+        events.push(
+          AgentEvent.create({
+            id: randomUUID(),
+            companyId: rec.sourceCompanyId,
+            eventType: 'new_value_chain_partner',
+            payload: {
+              recommendationId: rec.id,
+              targetId: rec.targetCompanyId,
+              type: rec.relationType,
+            },
+            now: input.now,
+          }),
+        )
+      }
+    }
+
+    for (const [clusterId, newMembers] of input.newClusterMemberships) {
+      const existingMembers =
+        input.existingClusterMemberships.get(clusterId) ?? []
+      for (const existing of existingMembers) {
+        for (const newMember of newMembers) {
+          if (existing === newMember) continue
+          events.push(
+            AgentEvent.create({
+              id: randomUUID(),
+              companyId: existing,
+              eventType: 'new_cluster_member',
+              payload: { clusterId, newCompanyId: newMember },
+              now: input.now,
+            }),
+          )
+        }
+      }
+    }
+
+    return events
+  }
+}

--- a/src/brain/src/agent/application/use-cases/GetAgentEvents.ts
+++ b/src/brain/src/agent/application/use-cases/GetAgentEvents.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@nestjs/common'
+import type { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import {
+  AGENT_EVENT_REPOSITORY,
+  type AgentEventRepository,
+} from '@/agent/domain/repositories/AgentEventRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GetAgentEventsInput {
+  companyId: string
+  unreadOnly?: boolean
+  limit?: number
+}
+
+export interface GetAgentEventsOutput {
+  events: AgentEvent[]
+}
+
+@Injectable()
+export class GetAgentEvents implements UseCase<
+  GetAgentEventsInput,
+  GetAgentEventsOutput
+> {
+  constructor(
+    @Inject(AGENT_EVENT_REPOSITORY)
+    private readonly repo: AgentEventRepository,
+  ) {}
+
+  async execute(input: GetAgentEventsInput): Promise<GetAgentEventsOutput> {
+    const companyId = input.companyId?.trim() ?? ''
+    if (companyId.length === 0) {
+      throw new Error('GetAgentEvents.companyId cannot be empty')
+    }
+    const events = await this.repo.findByCompany(companyId, {
+      unreadOnly: input.unreadOnly,
+      limit: input.limit,
+    })
+    return { events }
+  }
+}

--- a/src/brain/src/agent/application/use-cases/MarkEventAsRead.ts
+++ b/src/brain/src/agent/application/use-cases/MarkEventAsRead.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from '@nestjs/common'
+import {
+  AGENT_EVENT_REPOSITORY,
+  type AgentEventRepository,
+} from '@/agent/domain/repositories/AgentEventRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface MarkEventAsReadInput {
+  eventId: string
+}
+
+@Injectable()
+export class MarkEventAsRead implements UseCase<MarkEventAsReadInput, void> {
+  constructor(
+    @Inject(AGENT_EVENT_REPOSITORY)
+    private readonly repo: AgentEventRepository,
+  ) {}
+
+  async execute(input: MarkEventAsReadInput): Promise<void> {
+    const eventId = input.eventId?.trim() ?? ''
+    if (eventId.length === 0) {
+      throw new Error('MarkEventAsRead.eventId cannot be empty')
+    }
+    await this.repo.markAsRead(eventId)
+  }
+}

--- a/src/brain/src/agent/application/use-cases/RunIncrementalScan.ts
+++ b/src/brain/src/agent/application/use-cases/RunIncrementalScan.ts
@@ -1,0 +1,176 @@
+// NestJS reads constructor paramtypes via emitDecoratorMetadata at runtime.
+// Class deps without @Inject() must keep their value-imports — `import type`
+// would erase the binding and break DI.
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import { OpportunityDetector } from '@/agent/application/services/OpportunityDetector'
+import {
+  ScanRun,
+  type ScanRunStatus,
+  type ScanRunTrigger,
+} from '@/agent/domain/entities/ScanRun'
+import {
+  AGENT_EVENT_REPOSITORY,
+  type AgentEventRepository,
+} from '@/agent/domain/repositories/AgentEventRepository'
+import {
+  SCAN_RUN_REPOSITORY,
+  type ScanRunRepository,
+} from '@/agent/domain/repositories/ScanRunRepository'
+import {
+  CLUSTER_MEMBERSHIP_REPOSITORY,
+  type ClusterMembershipRepository,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import { GenerateClusters } from '@/clusters/application/use-cases/GenerateClusters'
+import {
+  COMPANY_REPOSITORY,
+  type CompanyRepository,
+} from '@/companies/domain/repositories/CompanyRepository'
+import { SyncCompaniesFromSource } from '@/companies/application/use-cases/SyncCompaniesFromSource'
+import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
+import {
+  RECOMMENDATION_REPOSITORY,
+  type RecommendationRepository,
+} from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface RunIncrementalScanInput {
+  trigger: ScanRunTrigger
+}
+
+export interface ScanRunResult {
+  runId: string
+  status: ScanRunStatus
+  companiesScanned: number
+  clustersGenerated: number
+  recommendationsGenerated: number
+  eventsEmitted: number
+}
+
+@Injectable()
+export class RunIncrementalScan implements UseCase<
+  RunIncrementalScanInput,
+  ScanRunResult
+> {
+  private readonly logger = new Logger(RunIncrementalScan.name)
+
+  constructor(
+    @Inject(SCAN_RUN_REPOSITORY)
+    private readonly scanRepo: ScanRunRepository,
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    private readonly syncCompanies: SyncCompaniesFromSource,
+    private readonly generateClusters: GenerateClusters,
+    private readonly generateRecs: GenerateRecommendations,
+    private readonly detector: OpportunityDetector,
+    @Inject(RECOMMENDATION_REPOSITORY)
+    private readonly recRepo: RecommendationRepository,
+    @Inject(AGENT_EVENT_REPOSITORY)
+    private readonly eventRepo: AgentEventRepository,
+    @Inject(CLUSTER_MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: ClusterMembershipRepository,
+  ) {}
+
+  async execute(input: RunIncrementalScanInput): Promise<ScanRunResult> {
+    const id = randomUUID()
+    let run = ScanRun.start({ id, trigger: input.trigger, now: new Date() })
+    await this.scanRepo.save(run)
+
+    try {
+      const last = await this.scanRepo.findLatestCompleted()
+      const since = last?.completedAt ?? new Date(0)
+
+      await this.syncCompanies.execute({ since })
+
+      const updated = await this.companyRepo.findUpdatedSince(since)
+
+      if (updated.length === 0 && last !== null) {
+        run = run.complete(
+          {
+            companiesScanned: 0,
+            clustersGenerated: 0,
+            recommendationsGenerated: 0,
+            eventsEmitted: 0,
+          },
+          new Date(),
+        )
+        await this.scanRepo.save(run)
+        return {
+          runId: id,
+          status: 'completed',
+          companiesScanned: 0,
+          clustersGenerated: 0,
+          recommendationsGenerated: 0,
+          eventsEmitted: 0,
+        }
+      }
+
+      const previousRecKeys = await this.recRepo.snapshotKeys()
+      const previousMemberships = await this.membershipRepo.snapshot()
+
+      const clusterStats = await this.generateClusters.execute()
+      const recStats = await this.generateRecs.execute({})
+
+      const newRecs = await this.recRepo.findAll()
+      const newMemberships = await this.membershipRepo.snapshot()
+      const newClusterMemberships = diffMemberships(
+        newMemberships,
+        previousMemberships,
+      )
+
+      const events = this.detector.detect({
+        newRecs,
+        previousRecKeys,
+        newClusterMemberships,
+        existingClusterMemberships: previousMemberships,
+        now: new Date(),
+      })
+      await this.eventRepo.saveAll(events)
+
+      const clustersGenerated =
+        clusterStats.predefinedClusters + clusterStats.heuristicClusters
+
+      run = run.complete(
+        {
+          companiesScanned: updated.length,
+          clustersGenerated,
+          recommendationsGenerated: recStats.totalRecommendations,
+          eventsEmitted: events.length,
+        },
+        new Date(),
+      )
+      await this.scanRepo.save(run)
+
+      return {
+        runId: id,
+        status: 'completed',
+        companiesScanned: updated.length,
+        clustersGenerated,
+        recommendationsGenerated: recStats.totalRecommendations,
+        eventsEmitted: events.length,
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      run = run.fail(message, new Date())
+      await this.scanRepo.save(run)
+      this.logger.error(`Scan ${id} failed: ${message}`)
+      throw e
+    }
+  }
+}
+
+function diffMemberships(
+  next: Map<string, string[]>,
+  prev: Map<string, string[]>,
+): Map<string, string[]> {
+  const result = new Map<string, string[]>()
+  for (const [clusterId, members] of next) {
+    const prevMembers = new Set(prev.get(clusterId) ?? [])
+    const newOnes = members.filter((m) => !prevMembers.has(m))
+    if (newOnes.length > 0) {
+      result.set(clusterId, newOnes)
+    }
+  }
+  return result
+}

--- a/src/brain/src/agent/domain/entities/AgentEvent.ts
+++ b/src/brain/src/agent/domain/entities/AgentEvent.ts
@@ -1,0 +1,78 @@
+import { Entity } from '@/shared/domain/Entity'
+import type { EventType } from '@/agent/domain/value-objects/EventType'
+
+interface AgentEventProps {
+  companyId: string
+  eventType: EventType
+  payload: Record<string, unknown>
+  read: boolean
+  createdAt: Date
+}
+
+export interface CreateAgentEventInput {
+  id: string
+  companyId: string
+  eventType: EventType
+  payload: Record<string, unknown>
+  now: Date
+}
+
+export interface HydrateAgentEventInput extends AgentEventProps {
+  id: string
+}
+
+export class AgentEvent extends Entity<string> {
+  private readonly props: AgentEventProps
+
+  private constructor(id: string, props: AgentEventProps) {
+    super(id)
+    this.props = Object.freeze(props)
+  }
+
+  static create(input: CreateAgentEventInput): AgentEvent {
+    const id = input.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('AgentEvent.id cannot be empty')
+    }
+    const companyId = input.companyId?.trim() ?? ''
+    if (companyId.length === 0) {
+      throw new Error('AgentEvent.companyId cannot be empty')
+    }
+    return new AgentEvent(id, {
+      companyId,
+      eventType: input.eventType,
+      payload: input.payload,
+      read: false,
+      createdAt: input.now,
+    })
+  }
+
+  static hydrate(input: HydrateAgentEventInput): AgentEvent {
+    const id = input.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('AgentEvent.id cannot be empty')
+    }
+    const { id: _id, ...props } = input
+    return new AgentEvent(id, props)
+  }
+
+  markAsRead(): AgentEvent {
+    return new AgentEvent(this.id, { ...this.props, read: true })
+  }
+
+  get companyId(): string {
+    return this.props.companyId
+  }
+  get eventType(): EventType {
+    return this.props.eventType
+  }
+  get payload(): Record<string, unknown> {
+    return this.props.payload
+  }
+  get read(): boolean {
+    return this.props.read
+  }
+  get createdAt(): Date {
+    return this.props.createdAt
+  }
+}

--- a/src/brain/src/agent/domain/entities/ScanRun.ts
+++ b/src/brain/src/agent/domain/entities/ScanRun.ts
@@ -1,0 +1,151 @@
+import { Entity } from '@/shared/domain/Entity'
+
+export type ScanRunStatus = 'running' | 'completed' | 'failed' | 'partial'
+export type ScanRunTrigger = 'cron' | 'manual'
+
+export interface ScanRunStats {
+  companiesScanned: number
+  clustersGenerated: number
+  recommendationsGenerated: number
+  eventsEmitted: number
+}
+
+interface ScanRunProps {
+  startedAt: Date
+  completedAt: Date | null
+  companiesScanned: number
+  clustersGenerated: number
+  recommendationsGenerated: number
+  eventsEmitted: number
+  status: ScanRunStatus
+  trigger: ScanRunTrigger
+  errorMessage: string | null
+}
+
+export interface StartScanRunInput {
+  id: string
+  trigger: ScanRunTrigger
+  now: Date
+}
+
+export interface HydrateScanRunInput extends ScanRunProps {
+  id: string
+}
+
+export class ScanRun extends Entity<string> {
+  private readonly props: ScanRunProps
+
+  private constructor(id: string, props: ScanRunProps) {
+    super(id)
+    this.props = Object.freeze(props)
+  }
+
+  static start(input: StartScanRunInput): ScanRun {
+    const id = input.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('ScanRun.id cannot be empty')
+    }
+    return new ScanRun(id, {
+      startedAt: input.now,
+      completedAt: null,
+      companiesScanned: 0,
+      clustersGenerated: 0,
+      recommendationsGenerated: 0,
+      eventsEmitted: 0,
+      status: 'running',
+      trigger: input.trigger,
+      errorMessage: null,
+    })
+  }
+
+  static hydrate(input: HydrateScanRunInput): ScanRun {
+    const id = input.id?.trim() ?? ''
+    if (id.length === 0) {
+      throw new Error('ScanRun.id cannot be empty')
+    }
+    const { id: _id, ...props } = input
+    return new ScanRun(id, props)
+  }
+
+  complete(stats: ScanRunStats, now: Date): ScanRun {
+    ScanRun.assertStats(stats)
+    return new ScanRun(this.id, {
+      ...this.props,
+      ...stats,
+      completedAt: now,
+      status: 'completed',
+      errorMessage: null,
+    })
+  }
+
+  fail(message: string, now: Date): ScanRun {
+    const trimmed = message?.trim() ?? ''
+    if (trimmed.length === 0) {
+      throw new Error('ScanRun.fail message cannot be empty')
+    }
+    return new ScanRun(this.id, {
+      ...this.props,
+      completedAt: now,
+      status: 'failed',
+      errorMessage: trimmed,
+    })
+  }
+
+  partial(stats: ScanRunStats, message: string, now: Date): ScanRun {
+    ScanRun.assertStats(stats)
+    const trimmed = message?.trim() ?? ''
+    if (trimmed.length === 0) {
+      throw new Error('ScanRun.partial message cannot be empty')
+    }
+    return new ScanRun(this.id, {
+      ...this.props,
+      ...stats,
+      completedAt: now,
+      status: 'partial',
+      errorMessage: trimmed,
+    })
+  }
+
+  private static assertStats(stats: ScanRunStats): void {
+    if (
+      stats.companiesScanned < 0 ||
+      stats.clustersGenerated < 0 ||
+      stats.recommendationsGenerated < 0 ||
+      stats.eventsEmitted < 0
+    ) {
+      throw new Error('ScanRun stats must be non-negative')
+    }
+  }
+
+  get startedAt(): Date {
+    return this.props.startedAt
+  }
+  get completedAt(): Date | null {
+    return this.props.completedAt
+  }
+  get companiesScanned(): number {
+    return this.props.companiesScanned
+  }
+  get clustersGenerated(): number {
+    return this.props.clustersGenerated
+  }
+  get recommendationsGenerated(): number {
+    return this.props.recommendationsGenerated
+  }
+  get eventsEmitted(): number {
+    return this.props.eventsEmitted
+  }
+  get status(): ScanRunStatus {
+    return this.props.status
+  }
+  get trigger(): ScanRunTrigger {
+    return this.props.trigger
+  }
+  get errorMessage(): string | null {
+    return this.props.errorMessage
+  }
+  get durationMs(): number | null {
+    if (!this.props.completedAt) return null
+    return this.props.completedAt.getTime() - this.props.startedAt.getTime()
+  }
+}

--- a/src/brain/src/agent/domain/repositories/AgentEventRepository.ts
+++ b/src/brain/src/agent/domain/repositories/AgentEventRepository.ts
@@ -1,0 +1,18 @@
+import type { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+
+export const AGENT_EVENT_REPOSITORY = Symbol('AGENT_EVENT_REPOSITORY')
+
+export interface FindByCompanyOptions {
+  unreadOnly?: boolean
+  limit?: number
+}
+
+export interface AgentEventRepository {
+  saveAll(events: AgentEvent[]): Promise<void>
+  findByCompany(
+    companyId: string,
+    options?: FindByCompanyOptions,
+  ): Promise<AgentEvent[]>
+  markAsRead(eventId: string): Promise<void>
+  countUnreadForCompany(companyId: string): Promise<number>
+}

--- a/src/brain/src/agent/domain/repositories/ScanRunRepository.ts
+++ b/src/brain/src/agent/domain/repositories/ScanRunRepository.ts
@@ -1,0 +1,10 @@
+import type { ScanRun, ScanRunStatus } from '@/agent/domain/entities/ScanRun'
+
+export const SCAN_RUN_REPOSITORY = Symbol('SCAN_RUN_REPOSITORY')
+
+export interface ScanRunRepository {
+  save(run: ScanRun): Promise<void>
+  findLatest(): Promise<ScanRun | null>
+  findLatestCompleted(): Promise<ScanRun | null>
+  countByStatus(status: ScanRunStatus): Promise<number>
+}

--- a/src/brain/src/agent/domain/value-objects/EventType.ts
+++ b/src/brain/src/agent/domain/value-objects/EventType.ts
@@ -1,0 +1,11 @@
+export const EVENT_TYPES = [
+  'new_high_score_match',
+  'new_value_chain_partner',
+  'new_cluster_member',
+] as const
+
+export type EventType = (typeof EVENT_TYPES)[number]
+
+export function isEventType(value: string): value is EventType {
+  return (EVENT_TYPES as readonly string[]).includes(value)
+}

--- a/src/brain/src/agent/infrastructure/http/agent.controller.ts
+++ b/src/brain/src/agent/infrastructure/http/agent.controller.ts
@@ -1,0 +1,120 @@
+// NestJS reads constructor paramtypes via emitDecoratorMetadata at runtime.
+// Class deps without @Inject() must keep their value-imports — `import type`
+// would erase the binding and break DI.
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import { Controller, Get, Inject, Param, Post, Query } from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import { GetAgentEvents } from '@/agent/application/use-cases/GetAgentEvents'
+import { MarkEventAsRead } from '@/agent/application/use-cases/MarkEventAsRead'
+import {
+  RunIncrementalScan,
+  type ScanRunResult,
+} from '@/agent/application/use-cases/RunIncrementalScan'
+import type { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import type {
+  ScanRunStatus,
+  ScanRunTrigger,
+} from '@/agent/domain/entities/ScanRun'
+import {
+  SCAN_RUN_REPOSITORY,
+  type ScanRunRepository,
+} from '@/agent/domain/repositories/ScanRunRepository'
+
+interface ScanRunView {
+  id: string
+  status: ScanRunStatus
+  trigger: ScanRunTrigger
+  startedAt: string
+  completedAt: string | null
+  companiesScanned: number
+  clustersGenerated: number
+  recommendationsGenerated: number
+  eventsEmitted: number
+  durationMs: number | null
+  errorMessage: string | null
+}
+
+interface AgentStatus {
+  latest: ScanRunView | null
+  counts: Record<ScanRunStatus, number>
+}
+
+@ApiTags('agent')
+@Controller('agent')
+export class AgentController {
+  constructor(
+    private readonly runScan: RunIncrementalScan,
+    @Inject(SCAN_RUN_REPOSITORY)
+    private readonly scanRepo: ScanRunRepository,
+    private readonly getEventsUseCase: GetAgentEvents,
+    private readonly markReadUseCase: MarkEventAsRead,
+  ) {}
+
+  @Post('scan')
+  @ApiOperation({ summary: 'Trigger a manual incremental scan' })
+  async triggerScan(): Promise<ScanRunResult> {
+    return this.runScan.execute({ trigger: 'manual' })
+  }
+
+  @Get('status')
+  @ApiOperation({ summary: 'Latest scan run + count by status' })
+  async getStatus(): Promise<AgentStatus> {
+    const [latest, completed, running, failed, partial] = await Promise.all([
+      this.scanRepo.findLatest(),
+      this.scanRepo.countByStatus('completed'),
+      this.scanRepo.countByStatus('running'),
+      this.scanRepo.countByStatus('failed'),
+      this.scanRepo.countByStatus('partial'),
+    ])
+
+    return {
+      latest: latest
+        ? {
+            id: latest.id,
+            status: latest.status,
+            trigger: latest.trigger,
+            startedAt: latest.startedAt.toISOString(),
+            completedAt: latest.completedAt
+              ? latest.completedAt.toISOString()
+              : null,
+            companiesScanned: latest.companiesScanned,
+            clustersGenerated: latest.clustersGenerated,
+            recommendationsGenerated: latest.recommendationsGenerated,
+            eventsEmitted: latest.eventsEmitted,
+            durationMs: latest.durationMs,
+            errorMessage: latest.errorMessage,
+          }
+        : null,
+      counts: { completed, running, failed, partial },
+    }
+  }
+
+  @Get('events')
+  @ApiOperation({ summary: 'List agent events for a company' })
+  async getEvents(
+    @Query('companyId') companyId: string,
+    @Query('unread') unread: string | undefined,
+    @Query('limit') limit: string | undefined,
+  ): Promise<{ events: AgentEvent[] }> {
+    const unreadOnly = unread === 'true'
+    const parsedLimit = parseLimit(limit)
+    return this.getEventsUseCase.execute({
+      companyId,
+      unreadOnly,
+      limit: parsedLimit,
+    })
+  }
+
+  @Post('events/:id/read')
+  @ApiOperation({ summary: 'Mark an agent event as read' })
+  async markEventRead(@Param('id') id: string): Promise<void> {
+    await this.markReadUseCase.execute({ eventId: id })
+  }
+}
+
+function parseLimit(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return undefined
+  return n
+}

--- a/src/brain/src/agent/infrastructure/repositories/InMemoryAgentEventRepository.ts
+++ b/src/brain/src/agent/infrastructure/repositories/InMemoryAgentEventRepository.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common'
+import type { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import type {
+  AgentEventRepository,
+  FindByCompanyOptions,
+} from '@/agent/domain/repositories/AgentEventRepository'
+
+@Injectable()
+export class InMemoryAgentEventRepository implements AgentEventRepository {
+  private readonly store = new Map<string, AgentEvent>()
+
+  async saveAll(events: AgentEvent[]): Promise<void> {
+    for (const e of events) {
+      this.store.set(e.id, e)
+    }
+  }
+
+  async findByCompany(
+    companyId: string,
+    options?: FindByCompanyOptions,
+  ): Promise<AgentEvent[]> {
+    const matched = Array.from(this.store.values()).filter(
+      (e) => e.companyId === companyId,
+    )
+    const filtered = options?.unreadOnly
+      ? matched.filter((e) => !e.read)
+      : matched
+    const sorted = filtered.sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    )
+    return options?.limit !== undefined
+      ? sorted.slice(0, options.limit)
+      : sorted
+  }
+
+  async markAsRead(eventId: string): Promise<void> {
+    const existing = this.store.get(eventId)
+    if (!existing) return
+    this.store.set(eventId, existing.markAsRead())
+  }
+
+  async countUnreadForCompany(companyId: string): Promise<number> {
+    let n = 0
+    for (const e of this.store.values()) {
+      if (e.companyId === companyId && !e.read) n++
+    }
+    return n
+  }
+}

--- a/src/brain/src/agent/infrastructure/repositories/InMemoryScanRunRepository.ts
+++ b/src/brain/src/agent/infrastructure/repositories/InMemoryScanRunRepository.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common'
+import type { ScanRun, ScanRunStatus } from '@/agent/domain/entities/ScanRun'
+import type { ScanRunRepository } from '@/agent/domain/repositories/ScanRunRepository'
+
+@Injectable()
+export class InMemoryScanRunRepository implements ScanRunRepository {
+  private readonly store = new Map<string, ScanRun>()
+
+  async save(run: ScanRun): Promise<void> {
+    this.store.set(run.id, run)
+  }
+
+  async findLatest(): Promise<ScanRun | null> {
+    const all = Array.from(this.store.values())
+    if (all.length === 0) return null
+    return all.reduce((acc, r) =>
+      r.startedAt.getTime() > acc.startedAt.getTime() ? r : acc,
+    )
+  }
+
+  async findLatestCompleted(): Promise<ScanRun | null> {
+    const completed = Array.from(this.store.values()).filter(
+      (r) => r.status === 'completed',
+    )
+    if (completed.length === 0) return null
+    return completed.reduce((acc, r) =>
+      (r.completedAt?.getTime() ?? 0) > (acc.completedAt?.getTime() ?? 0)
+        ? r
+        : acc,
+    )
+  }
+
+  async countByStatus(status: ScanRunStatus): Promise<number> {
+    let n = 0
+    for (const r of this.store.values()) {
+      if (r.status === status) n++
+    }
+    return n
+  }
+}

--- a/src/brain/src/agent/infrastructure/repositories/SupabaseAgentEventRepository.ts
+++ b/src/brain/src/agent/infrastructure/repositories/SupabaseAgentEventRepository.ts
@@ -1,0 +1,109 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { AgentEvent } from '@/agent/domain/entities/AgentEvent'
+import type {
+  AgentEventRepository,
+  FindByCompanyOptions,
+} from '@/agent/domain/repositories/AgentEventRepository'
+import {
+  isEventType,
+  type EventType,
+} from '@/agent/domain/value-objects/EventType'
+import type { Json } from '@/shared/infrastructure/supabase/database.types'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'agent_events'
+const CHUNK_SIZE = 500
+
+interface AgentEventRow {
+  id: string
+  company_id: string
+  event_type: string
+  payload: Json
+  read: boolean
+  created_at: string
+}
+
+@Injectable()
+export class SupabaseAgentEventRepository implements AgentEventRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async saveAll(events: AgentEvent[]): Promise<void> {
+    if (events.length === 0) return
+    const rows = events.map((e) => this.toRow(e))
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + CHUNK_SIZE)
+      const { error } = await this.db
+        .from(TABLE)
+        .upsert(chunk, { onConflict: 'id' })
+      if (error) throw error
+    }
+  }
+
+  async findByCompany(
+    companyId: string,
+    options?: FindByCompanyOptions,
+  ): Promise<AgentEvent[]> {
+    let query = this.db
+      .from(TABLE)
+      .select('*')
+      .eq('company_id', companyId)
+      .order('created_at', { ascending: false })
+    if (options?.unreadOnly) {
+      query = query.eq('read', false)
+    }
+    if (options?.limit !== undefined) {
+      query = query.limit(options.limit)
+    }
+    const { data, error } = await query
+    if (error) throw error
+    return ((data ?? []) as AgentEventRow[]).map((r) => this.toEntity(r))
+  }
+
+  async markAsRead(eventId: string): Promise<void> {
+    const { error } = await this.db
+      .from(TABLE)
+      .update({ read: true })
+      .eq('id', eventId)
+    if (error) throw error
+  }
+
+  async countUnreadForCompany(companyId: string): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+      .eq('company_id', companyId)
+      .eq('read', false)
+    if (error) throw error
+    return count ?? 0
+  }
+
+  private toRow(e: AgentEvent): AgentEventRow {
+    return {
+      id: e.id,
+      company_id: e.companyId,
+      event_type: e.eventType,
+      payload: e.payload as unknown as Json,
+      read: e.read,
+      created_at: e.createdAt.toISOString(),
+    }
+  }
+
+  private toEntity(row: AgentEventRow): AgentEvent {
+    if (!isEventType(row.event_type)) {
+      throw new Error(
+        `Unknown agent_event event_type from DB: ${row.event_type}`,
+      )
+    }
+    return AgentEvent.hydrate({
+      id: row.id,
+      companyId: row.company_id,
+      eventType: row.event_type as EventType,
+      payload: (row.payload ?? {}) as Record<string, unknown>,
+      read: row.read,
+      createdAt: new Date(row.created_at),
+    })
+  }
+}

--- a/src/brain/src/agent/infrastructure/repositories/SupabaseScanRunRepository.ts
+++ b/src/brain/src/agent/infrastructure/repositories/SupabaseScanRunRepository.ts
@@ -1,0 +1,111 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ScanRun } from '@/agent/domain/entities/ScanRun'
+import type {
+  ScanRunStatus,
+  ScanRunTrigger,
+} from '@/agent/domain/entities/ScanRun'
+import type { ScanRunRepository } from '@/agent/domain/repositories/ScanRunRepository'
+import { SUPABASE_CLIENT } from '@/shared/infrastructure/supabase/SupabaseClient'
+import type { BrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+const TABLE = 'scan_runs'
+
+const STATUSES: ScanRunStatus[] = ['running', 'completed', 'failed', 'partial']
+const TRIGGERS: ScanRunTrigger[] = ['cron', 'manual']
+
+interface ScanRunRow {
+  id: string
+  started_at: string
+  completed_at: string | null
+  companies_scanned: number
+  clusters_generated: number
+  recommendations_generated: number
+  events_emitted: number
+  status: string
+  trigger: string
+  error_message: string | null
+  duration_ms: number | null
+}
+
+@Injectable()
+export class SupabaseScanRunRepository implements ScanRunRepository {
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly db: BrainSupabaseClient,
+  ) {}
+
+  async save(run: ScanRun): Promise<void> {
+    const { error } = await this.db
+      .from(TABLE)
+      .upsert(this.toRow(run), { onConflict: 'id' })
+    if (error) throw error
+  }
+
+  async findLatest(): Promise<ScanRun | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .order('started_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as ScanRunRow) : null
+  }
+
+  async findLatestCompleted(): Promise<ScanRun | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('status', 'completed')
+      .order('completed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as ScanRunRow) : null
+  }
+
+  async countByStatus(status: ScanRunStatus): Promise<number> {
+    const { error, count } = await this.db
+      .from(TABLE)
+      .select('*', { count: 'exact', head: true })
+      .eq('status', status)
+    if (error) throw error
+    return count ?? 0
+  }
+
+  private toRow(run: ScanRun): ScanRunRow {
+    return {
+      id: run.id,
+      started_at: run.startedAt.toISOString(),
+      completed_at: run.completedAt ? run.completedAt.toISOString() : null,
+      companies_scanned: run.companiesScanned,
+      clusters_generated: run.clustersGenerated,
+      recommendations_generated: run.recommendationsGenerated,
+      events_emitted: run.eventsEmitted,
+      status: run.status,
+      trigger: run.trigger,
+      error_message: run.errorMessage,
+      duration_ms: run.durationMs,
+    }
+  }
+
+  private toEntity(row: ScanRunRow): ScanRun {
+    if (!STATUSES.includes(row.status as ScanRunStatus)) {
+      throw new Error(`Unknown ScanRun status from DB: ${row.status}`)
+    }
+    if (!TRIGGERS.includes(row.trigger as ScanRunTrigger)) {
+      throw new Error(`Unknown ScanRun trigger from DB: ${row.trigger}`)
+    }
+    return ScanRun.hydrate({
+      id: row.id,
+      startedAt: new Date(row.started_at),
+      completedAt: row.completed_at ? new Date(row.completed_at) : null,
+      companiesScanned: row.companies_scanned,
+      clustersGenerated: row.clusters_generated,
+      recommendationsGenerated: row.recommendations_generated,
+      eventsEmitted: row.events_emitted,
+      status: row.status as ScanRunStatus,
+      trigger: row.trigger as ScanRunTrigger,
+      errorMessage: row.error_message,
+    })
+  }
+}

--- a/src/brain/src/agent/infrastructure/scheduler/AgentScheduler.ts
+++ b/src/brain/src/agent/infrastructure/scheduler/AgentScheduler.ts
@@ -1,0 +1,39 @@
+// NestJS reads constructor paramtypes via emitDecoratorMetadata at runtime.
+// Class deps without @Inject() must keep their value-imports — `import type`
+// would erase the binding and break DI.
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import { Injectable, Logger } from '@nestjs/common'
+import { Cron } from '@nestjs/schedule'
+import { RunIncrementalScan } from '@/agent/application/use-cases/RunIncrementalScan'
+import { env } from '@/shared/infrastructure/env'
+
+@Injectable()
+export class AgentScheduler {
+  private readonly logger = new Logger(AgentScheduler.name)
+  private isRunning = false
+
+  constructor(private readonly runScan: RunIncrementalScan) {}
+
+  @Cron(env.AGENT_CRON_SCHEDULE, { name: 'agent-incremental-scan' })
+  async handleScan(): Promise<void> {
+    if (env.AGENT_ENABLED === 'false') return
+    if (this.isRunning) {
+      this.logger.warn('Previous scan still running, skipping this tick')
+      return
+    }
+
+    this.isRunning = true
+    const t0 = Date.now()
+    try {
+      const result = await this.runScan.execute({ trigger: 'cron' })
+      const dt = Date.now() - t0
+      this.logger.log(`Scan completed in ${dt}ms: ${JSON.stringify(result)}`)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      const stack = e instanceof Error ? e.stack : undefined
+      this.logger.error(`Scan failed: ${message}`, stack)
+    } finally {
+      this.isRunning = false
+    }
+  }
+}

--- a/src/brain/src/app.module.ts
+++ b/src/brain/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common'
 import { ScheduleModule } from '@nestjs/schedule'
+import { AgentModule } from './agent/agent.module'
 import { SharedModule } from './shared/shared.module'
 import { CiiuTaxonomyModule } from './ciiu-taxonomy/ciiu-taxonomy.module'
 import { ClustersModule } from './clusters/clusters.module'
@@ -15,6 +16,7 @@ import { HealthController } from './shared/infrastructure/health/health.controll
     CompaniesModule,
     ClustersModule,
     RecommendationsModule,
+    AgentModule,
   ],
   controllers: [HealthController],
 })

--- a/src/brain/src/clusters/domain/repositories/ClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/domain/repositories/ClusterMembershipRepository.ts
@@ -13,4 +13,9 @@ export interface ClusterMembershipRepository {
   findCompanyIdsByCluster(clusterId: string): Promise<string[]>
   deleteAll(): Promise<void>
   count(): Promise<number>
+  /**
+   * Returns a Map of `clusterId -> companyIds` for every stored membership.
+   * Used by the agent to detect new cluster members between scans.
+   */
+  snapshot(): Promise<Map<string, string[]>>
 }

--- a/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository.ts
@@ -48,4 +48,18 @@ export class InMemoryClusterMembershipRepository implements ClusterMembershipRep
   async count(): Promise<number> {
     return this.store.size
   }
+
+  async snapshot(): Promise<Map<string, string[]>> {
+    const snap = new Map<string, Set<string>>()
+    for (const key of this.store) {
+      const m = this.parse(key)
+      if (!snap.has(m.clusterId)) snap.set(m.clusterId, new Set())
+      snap.get(m.clusterId)!.add(m.companyId)
+    }
+    const result = new Map<string, string[]>()
+    for (const [clusterId, companies] of snap) {
+      result.set(clusterId, Array.from(companies))
+    }
+    return result
+  }
 }

--- a/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterMembershipRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterMembershipRepository.ts
@@ -65,4 +65,21 @@ export class SupabaseClusterMembershipRepository implements ClusterMembershipRep
     if (error) throw error
     return count ?? 0
   }
+
+  async snapshot(): Promise<Map<string, string[]>> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('cluster_id, company_id')
+    if (error) throw error
+    const result = new Map<string, string[]>()
+    for (const row of (data ?? []) as MembershipRow[]) {
+      const list = result.get(row.cluster_id)
+      if (list) {
+        list.push(row.company_id)
+      } else {
+        result.set(row.cluster_id, [row.company_id])
+      }
+    }
+    return result
+  }
 }

--- a/src/brain/src/recommendations/domain/repositories/RecommendationRepository.ts
+++ b/src/brain/src/recommendations/domain/repositories/RecommendationRepository.ts
@@ -6,6 +6,7 @@ export const RECOMMENDATION_REPOSITORY = Symbol('RECOMMENDATION_REPOSITORY')
 export interface RecommendationRepository {
   saveAll(recs: Recommendation[]): Promise<void>
   findById(id: string): Promise<Recommendation | null>
+  findAll(): Promise<Recommendation[]>
   findBySource(sourceId: string, limit?: number): Promise<Recommendation[]>
   findBySourceAndType(
     sourceId: string,
@@ -15,4 +16,9 @@ export interface RecommendationRepository {
   updateExplanation(id: string, explanation: string): Promise<void>
   countBySource(sourceId: string): Promise<number>
   deleteAll(): Promise<void>
+  /**
+   * Returns a Set of `${sourceCompanyId}|${targetCompanyId}|${relationType}`
+   * keys for every stored recommendation. Used by the agent to diff scans.
+   */
+  snapshotKeys(): Promise<Set<string>>
 }

--- a/src/brain/src/recommendations/infrastructure/repositories/InMemoryRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/InMemoryRecommendationRepository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
 import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
 import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
 
@@ -15,6 +15,18 @@ export class InMemoryRecommendationRepository implements RecommendationRepositor
 
   async findById(id: string): Promise<Recommendation | null> {
     return this.store.get(id) ?? null
+  }
+
+  async findAll(): Promise<Recommendation[]> {
+    return Array.from(this.store.values())
+  }
+
+  async snapshotKeys(): Promise<Set<string>> {
+    const keys = new Set<string>()
+    for (const r of this.store.values()) {
+      keys.add(`${r.sourceCompanyId}|${r.targetCompanyId}|${r.relationType}`)
+    }
+    return keys
   }
 
   async findBySource(

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
@@ -60,6 +60,30 @@ export class SupabaseRecommendationRepository implements RecommendationRepositor
     return data ? this.toEntity(data as RecommendationRow) : null
   }
 
+  async findAll(): Promise<Recommendation[]> {
+    const { data, error } = await this.db.from(TABLE).select('*')
+    if (error) throw error
+    return ((data ?? []) as RecommendationRow[]).map((r) => this.toEntity(r))
+  }
+
+  async snapshotKeys(): Promise<Set<string>> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('source_company_id, target_company_id, relation_type')
+    if (error) throw error
+    const keys = new Set<string>()
+    for (const row of (data ?? []) as Array<{
+      source_company_id: string
+      target_company_id: string
+      relation_type: string
+    }>) {
+      keys.add(
+        `${row.source_company_id}|${row.target_company_id}|${row.relation_type}`,
+      )
+    }
+    return keys
+  }
+
   async findBySource(
     sourceId: string,
     limit?: number,


### PR DESCRIPTION
## Summary

Implements **Phase 6** of the brain clustering plan (`docs/2026-04-25-brain-clustering-engine-implementation.md`) — the **agent context**: cron-driven incremental scans that diff between runs and emit opportunity events.

- **Agent bounded context** (`src/brain/src/agent/`): full hexagonal layout — domain (entities, value objects, repositories), application (services, use cases), infrastructure (Supabase + InMemory adapters, HTTP controller, cron scheduler).
- **9 commits**, each one task from the plan, TDD throughout. **+186 tests**, all 542 brain tests green.
- **2 commit-zero extensions** to existing repos (in same branch, agreed with reviewer): `RecommendationRepository.snapshotKeys` + `findAll` and `ClusterMembershipRepository.snapshot` — needed for the agent to diff between scans.

## What's in this PR

| Commit | Task | Files |
|---|---|---|
| `b6d2608` | pre-task: extend `RecommendationRepository` | port + 2 adapters + 11 tests |
| `a9da4a6` | pre-task: extend `ClusterMembershipRepository` | port + 2 adapters + 6 tests |
| `fd6484f` | 6.1 — `ScanRun`, `AgentEvent`, `EventType` VO | entities + 23 tests |
| `c9a3255` | 6.2 — `ScanRunRepository` + `AgentEventRepository` | 2 ports + 4 adapters + 43 tests |
| `23526fc` | 6.3 — `OpportunityDetector` service | service + 14 tests |
| `8cf0e43` | 6.4 — `RunIncrementalScan` use case | the orchestrator + 12 E2E tests |
| `d0c681b` | 6.5 — `AgentScheduler` with `@Cron` + re-entry guard | scheduler + 6 tests |
| `7b6ff2a` | 6.6 — `GetAgentEvents` + `MarkEventAsRead` | 2 use cases + 7 tests |
| `c007d22` | 6.7 — `AgentController` + `AgentModule` wired | controller + module + 8 tests |

## Architecture decisions worth flagging

1. **Entities receive `now: Date` by parameter.** `ScanRun.start({ id, trigger, now })`, `complete(stats, now)`, `fail(message, now)`, `partial(stats, message, now)`, `AgentEvent.create({ ..., now })`. Keeps entities pure and avoids the broken `vi.setSystemTime` path in bun's vitest. Use cases pass `new Date()`.

2. **`snapshotKeys()` key format**: \`\${sourceId}|\${targetId}|\${type}\` — score is NOT in the key, so a recommendation that crosses the high-score threshold on a triplet that already existed will NOT trigger \`new_high_score_match\`. Documented in the port.

3. **\`findAll()\` returns full entities** rather than threading recommendations through \`GenerateRecommendations.execute()\` output. Keeps fidelity to the plan; reconsider if scan-time memory becomes a concern.

4. **Three-tier event detection** in \`OpportunityDetector\`:
   - score ≥ 0.75 → \`new_high_score_match\` (any relation type)
   - else if cliente|proveedor and score ≥ 0.65 → \`new_value_chain_partner\`
   - existing cluster member receives \`new_cluster_member\` for each new arrival

5. **Failure handling in \`RunIncrementalScan\`**: any throw in sync, cluster gen, or rec gen → \`run.fail(message, now)\` + rethrow. \`partial\` status is reserved for future granular degradation (e.g. AI inference fails but fallback runs); not used in the orchestrator yet.

6. **\`/* eslint-disable @typescript-eslint/consistent-type-imports */\`** in \`RunIncrementalScan.ts\`, \`AgentScheduler.ts\`, \`agent.controller.ts\`. NestJS DI reads constructor paramtypes via \`emitDecoratorMetadata\` at runtime — \`import type\` would erase the binding and break wiring. Documented inline at the top of each file. Pre-commit \`eslint --fix\` would have re-broken these without the disable.

7. **Test runner caveat**: brain tests must run with **\`bunx vitest run\`** (uses SWC for decorator metadata), NOT \`bun test\` (the native runner mishandles NestJS method decorators). \`pre-push\` already uses \`bun test:run\` which is wired to vitest, so CI is fine.

## New endpoints

- \`POST /api/agent/scan\` → trigger manual incremental scan
- \`GET /api/agent/status\` → latest run + counts by status
- \`GET /api/agent/events?companyId=X&unread=true&limit=20\` → events feed
- \`POST /api/agent/events/:id/read\` → mark event as read

## Test plan

- [ ] CI (pre-push hook) ran the full vitest suite — 542/542 passed
- [ ] Verify Supabase tables \`scan_runs\` and \`agent_events\` exist (already in baseline migration \`20260425220840_brain_init.sql\`)
- [ ] Local: \`bun --cwd src/brain run dev\` and hit \`POST /api/agent/scan\` — should complete and persist a row in \`scan_runs\`
- [ ] Local: with \`AGENT_ENABLED=true\` and a fast \`AGENT_CRON_SCHEDULE\`, watch the scheduler tick and verify re-entry guard (no overlapping runs)
- [ ] Hit \`GET /api/agent/status\` — verify shape matches \`ScanRunView\`