### PR TITLE
feat(brain): phase 7 — seeds (csvs → supabase)

### DIFF
--- a/src/brain/__tests__/seeds/buildClusterMappings.test.ts
+++ b/src/brain/__tests__/seeds/buildClusterMappings.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildClusterMappings,
+  type ActivityRow,
+  type SectoresRow,
+} from '@/seeds/seed-cluster-mappings'
+
+const sectores: SectoresRow[] = [
+  { ciiuActividadID: '483', ciiuActividadCODIGO: '5022' },
+  { ciiuActividadID: '476', ciiuActividadCODIGO: '4930' },
+  { ciiuActividadID: '11', ciiuActividadCODIGO: '0122' },
+  // Duplicate internal id with same code — should not break the map.
+  { ciiuActividadID: '11', ciiuActividadCODIGO: '0122' },
+  // Missing/blank code — should be ignored.
+  { ciiuActividadID: '999', ciiuActividadCODIGO: '' },
+  // Non 4-digit codes (DIAN ID badly formatted) — should be skipped.
+  { ciiuActividadID: '888', ciiuActividadCODIGO: '12345' },
+]
+
+describe('buildClusterMappings', () => {
+  it('joins activities to 4-digit CIIU codes via ciiuActividadID', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '7', ciiuID: '476', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '1', ciiuID: '11', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings(sectores, activities)
+    expect(skipped).toBe(0)
+    expect(mappings).toEqual([
+      { clusterId: 'pred-7', ciiuCode: '5022' },
+      { clusterId: 'pred-7', ciiuCode: '4930' },
+      { clusterId: 'pred-1', ciiuCode: '0122' },
+    ])
+  })
+
+  it('prefixes the cluster id with "pred-"', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '8', ciiuID: '476', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings } = buildClusterMappings(sectores, activities)
+    expect(mappings[0]?.clusterId).toBe('pred-8')
+  })
+
+  it('skips rows whose actividadClusterESTADO is not ACTIVO', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'INACTIVO' },
+      { clusterID: '7', ciiuID: '476', actividadClusterESTADO: 'BORRADO' },
+      { clusterID: '7', ciiuID: '476' }, // missing estado entirely
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings(sectores, activities)
+    expect(mappings).toHaveLength(1)
+    expect(skipped).toBe(3)
+  })
+
+  it('skips activities whose ciiuID does not resolve via sectores', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '99999', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings(sectores, activities)
+    expect(mappings).toEqual([{ clusterId: 'pred-7', ciiuCode: '5022' }])
+    expect(skipped).toBe(1)
+  })
+
+  it('skips rows with missing clusterID or ciiuID', () => {
+    const activities: ActivityRow[] = [
+      { ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '7', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '   ', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings(sectores, activities)
+    expect(mappings).toHaveLength(0)
+    expect(skipped).toBe(3)
+  })
+
+  it('dedups identical (cluster, ciiuCode) pairs from the activities CSV', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '7', ciiuID: '476', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings(sectores, activities)
+    expect(mappings).toEqual([
+      { clusterId: 'pred-7', ciiuCode: '5022' },
+      { clusterId: 'pred-7', ciiuCode: '4930' },
+    ])
+    // Dedup is silent — does not increment skipped (not the same as a filtered row).
+    expect(skipped).toBe(0)
+  })
+
+  it('resolves the same internal id used by different clusters independently', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+      { clusterID: '8', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings } = buildClusterMappings(sectores, activities)
+    expect(mappings).toEqual([
+      { clusterId: 'pred-7', ciiuCode: '5022' },
+      { clusterId: 'pred-8', ciiuCode: '5022' },
+    ])
+  })
+
+  it('returns empty result when sectores is empty (no resolution possible)', () => {
+    const activities: ActivityRow[] = [
+      { clusterID: '7', ciiuID: '483', actividadClusterESTADO: 'ACTIVO' },
+    ]
+    const { mappings, skipped } = buildClusterMappings([], activities)
+    expect(mappings).toHaveLength(0)
+    expect(skipped).toBe(1)
+  })
+})

--- a/src/brain/package.json
+++ b/src/brain/package.json
@@ -13,7 +13,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "seed:ciiu": "bun run src/seeds/seed-ciiu-taxonomy.ts"
+    "seed:ciiu": "bun run src/seeds/seed-ciiu-taxonomy.ts",
+    "seed:companies": "bun run src/seeds/seed-companies.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/src/brain/package.json
+++ b/src/brain/package.json
@@ -16,7 +16,8 @@
     "seed:ciiu": "bun run src/seeds/seed-ciiu-taxonomy.ts",
     "seed:companies": "bun run src/seeds/seed-companies.ts",
     "seed:clusters": "bun run src/seeds/seed-predefined-clusters.ts",
-    "seed:cluster-mappings": "bun run src/seeds/seed-cluster-mappings.ts"
+    "seed:cluster-mappings": "bun run src/seeds/seed-cluster-mappings.ts",
+    "seed": "bun run src/seeds/bootstrap-all.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/src/brain/package.json
+++ b/src/brain/package.json
@@ -14,7 +14,9 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "seed:ciiu": "bun run src/seeds/seed-ciiu-taxonomy.ts",
-    "seed:companies": "bun run src/seeds/seed-companies.ts"
+    "seed:companies": "bun run src/seeds/seed-companies.ts",
+    "seed:clusters": "bun run src/seeds/seed-predefined-clusters.ts",
+    "seed:cluster-mappings": "bun run src/seeds/seed-cluster-mappings.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/src/brain/src/seeds/bootstrap-all.ts
+++ b/src/brain/src/seeds/bootstrap-all.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+import { seedCiiuTaxonomy } from '@/seeds/seed-ciiu-taxonomy'
+import { seedCompanies } from '@/seeds/seed-companies'
+import { seedPredefinedClusters } from '@/seeds/seed-predefined-clusters'
+import { seedClusterMappings } from '@/seeds/seed-cluster-mappings'
+
+async function main(): Promise<void> {
+  console.log('🚀 Bootstrapping brain database...')
+
+  console.log('\nStep 1/4: CIIU DIAN taxonomy')
+  const ciiu = await seedCiiuTaxonomy()
+  console.log(
+    `  → ${ciiu.inserted} activities seeded (skipped ${ciiu.skipped})`,
+  )
+
+  console.log('\nStep 2/4: Companies')
+  const companies = await seedCompanies()
+  console.log(`  → ${companies.inserted} companies seeded`)
+
+  console.log('\nStep 3/4: Predefined clusters')
+  const clusters = await seedPredefinedClusters()
+  console.log(
+    `  → ${clusters.inserted} predefined clusters seeded (skipped ${clusters.skipped})`,
+  )
+
+  console.log('\nStep 4/4: Cluster CIIU mappings')
+  const mappings = await seedClusterMappings()
+  console.log(
+    `  → ${mappings.inserted} cluster→CIIU mappings seeded (skipped ${mappings.skipped})`,
+  )
+
+  console.log('\n✅ Bootstrap complete')
+}
+
+main().catch((err: unknown) => {
+  console.error('❌ Bootstrap failed:', err)
+  process.exit(1)
+})

--- a/src/brain/src/seeds/seed-cluster-mappings.ts
+++ b/src/brain/src/seeds/seed-cluster-mappings.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-console */
+import type { ClusterCiiuMapping } from '@/clusters/domain/repositories/ClusterCiiuMappingRepository'
+import { SupabaseClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/SupabaseClusterCiiuMappingRepository'
+import { CsvLoader } from '@/shared/infrastructure/csv/CsvLoader'
+import { DataPaths } from '@/shared/infrastructure/path/DataPaths'
+import { createBrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+export interface SectoresRow {
+  ciiuActividadID?: string
+  ciiuActividadCODIGO?: string
+}
+
+export interface ActivityRow {
+  clusterID?: string
+  ciiuID?: string
+  actividadClusterESTADO?: string
+}
+
+const VALID_CODE = /^\d{4}$/
+
+export interface BuildMappingsResult {
+  mappings: ClusterCiiuMapping[]
+  skipped: number
+}
+
+/**
+ * Pure join: builds `pred-<clusterID>` → 4-digit CIIU mappings by resolving
+ * `ActivityRow.ciiuID` (DIAN internal numeric id) against `SectoresRow`'s
+ * `ciiuActividadID → ciiuActividadCODIGO`. Skips inactive rows, missing keys,
+ * unresolved internal ids, and dedups identical (cluster, code) pairs.
+ */
+export function buildClusterMappings(
+  sectores: SectoresRow[],
+  activities: ActivityRow[],
+): BuildMappingsResult {
+  const idToCode = new Map<string, string>()
+  for (const row of sectores) {
+    const id = row.ciiuActividadID?.trim()
+    const code = row.ciiuActividadCODIGO?.trim()
+    if (!id || !code || !VALID_CODE.test(code)) continue
+    if (!idToCode.has(id)) idToCode.set(id, code)
+  }
+
+  let skipped = 0
+  const seen = new Set<string>()
+  const mappings: ClusterCiiuMapping[] = []
+  for (const row of activities) {
+    if (row.actividadClusterESTADO !== 'ACTIVO') {
+      skipped++
+      continue
+    }
+    const clusterId = row.clusterID?.trim()
+    const internalId = row.ciiuID?.trim()
+    if (!clusterId || !internalId) {
+      skipped++
+      continue
+    }
+    const ciiuCode = idToCode.get(internalId)
+    if (!ciiuCode) {
+      skipped++
+      continue
+    }
+    const fullClusterId = `pred-${clusterId}`
+    const dedupKey = `${fullClusterId}|${ciiuCode}`
+    if (seen.has(dedupKey)) continue
+    seen.add(dedupKey)
+    mappings.push({ clusterId: fullClusterId, ciiuCode })
+  }
+
+  return { mappings, skipped }
+}
+
+export interface SeedClusterMappingsResult {
+  inserted: number
+  skipped: number
+  repo: SupabaseClusterCiiuMappingRepository
+}
+
+export async function seedClusterMappings(): Promise<SeedClusterMappingsResult> {
+  const sectores = await CsvLoader.load<SectoresRow>(
+    DataPaths.clusterSectoresCsv,
+  )
+  const activities = await CsvLoader.load<ActivityRow>(
+    DataPaths.clusterActivitiesCsv,
+  )
+
+  const { mappings, skipped } = buildClusterMappings(sectores, activities)
+
+  const repo = new SupabaseClusterCiiuMappingRepository(
+    createBrainSupabaseClient(),
+  )
+  await repo.saveMany(mappings)
+
+  return { inserted: mappings.length, skipped, repo }
+}
+
+if (require.main === module) {
+  seedClusterMappings()
+    .then(async ({ inserted, skipped, repo }) => {
+      console.log(
+        `✅ Seeded ${inserted} cluster→CIIU mappings (skipped ${skipped} rows)`,
+      )
+      const total = await repo.count()
+      const map = await repo.getCiiuToClusterMap()
+      console.log(
+        `🔎 Round-trip OK — mapping rows: ${total}, distinct ciiu codes: ${map.size}`,
+      )
+      process.exit(inserted > 0 && total >= inserted ? 0 : 1)
+    })
+    .catch((err) => {
+      console.error('❌ Seed cluster mappings failed:', err)
+      process.exit(1)
+    })
+}

--- a/src/brain/src/seeds/seed-companies.ts
+++ b/src/brain/src/seeds/seed-companies.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+import { CsvCompanySource } from '@/companies/infrastructure/sources/CsvCompanySource'
+import { SupabaseCompanyRepository } from '@/companies/infrastructure/repositories/SupabaseCompanyRepository'
+import { createBrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+export interface SeedCompaniesResult {
+  inserted: number
+  repo: SupabaseCompanyRepository
+}
+
+export async function seedCompanies(): Promise<SeedCompaniesResult> {
+  const source = new CsvCompanySource()
+  const companies = await source.fetchAll()
+
+  const repo = new SupabaseCompanyRepository(createBrainSupabaseClient())
+  await repo.saveMany(companies)
+
+  return { inserted: companies.length, repo }
+}
+
+if (require.main === module) {
+  seedCompanies()
+    .then(async ({ inserted, repo }) => {
+      console.log(`✅ Seeded ${inserted} companies (source: CsvCompanySource)`)
+      const total = await repo.count()
+      console.log(`🔎 Round-trip OK — companies table count = ${total}`)
+      process.exit(inserted > 0 && total >= inserted ? 0 : 1)
+    })
+    .catch((err) => {
+      console.error('❌ Seed companies failed:', err)
+      process.exit(1)
+    })
+}

--- a/src/brain/src/seeds/seed-predefined-clusters.ts
+++ b/src/brain/src/seeds/seed-predefined-clusters.ts
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { SupabaseClusterRepository } from '@/clusters/infrastructure/repositories/SupabaseClusterRepository'
+import { CsvLoader } from '@/shared/infrastructure/csv/CsvLoader'
+import { DataPaths } from '@/shared/infrastructure/path/DataPaths'
+import { createBrainSupabaseClient } from '@/shared/infrastructure/supabase/SupabaseClient'
+
+interface ClusterRow {
+  clusterID: string
+  clusterCODIGO: string
+  clusterTITULO: string
+  clusterDESCRIPCION?: string
+  clusterESTADO: string
+}
+
+export interface SeedPredefinedClustersResult {
+  inserted: number
+  skipped: number
+  repo: SupabaseClusterRepository
+}
+
+export async function seedPredefinedClusters(): Promise<SeedPredefinedClustersResult> {
+  const rows = await CsvLoader.load<ClusterRow>(DataPaths.clustersCsv)
+
+  let skipped = 0
+  const clusters: Cluster[] = []
+  for (const row of rows) {
+    if (row.clusterESTADO !== 'ACTIVO') {
+      skipped++
+      continue
+    }
+    const id = row.clusterID?.trim()
+    const codigo = row.clusterCODIGO?.trim()
+    const titulo = row.clusterTITULO?.trim()
+    if (!id || !codigo || !titulo) {
+      skipped++
+      continue
+    }
+    clusters.push(
+      Cluster.create({
+        id: `pred-${id}`,
+        codigo,
+        titulo,
+        descripcion: row.clusterDESCRIPCION?.trim() || null,
+        tipo: 'predefined',
+        macroSector: null,
+        memberCount: 0,
+      }),
+    )
+  }
+
+  const repo = new SupabaseClusterRepository(createBrainSupabaseClient())
+  await repo.saveMany(clusters)
+
+  return { inserted: clusters.length, skipped, repo }
+}
+
+if (require.main === module) {
+  seedPredefinedClusters()
+    .then(async ({ inserted, skipped, repo }) => {
+      console.log(
+        `✅ Seeded ${inserted} predefined clusters (skipped ${skipped} non-active rows)`,
+      )
+      const total = await repo.findByTipo('predefined')
+      console.log(
+        `🔎 Round-trip OK — predefined clusters in DB: ${total.length} (${total.map((c) => c.codigo).join(', ')})`,
+      )
+      process.exit(inserted > 0 && total.length >= inserted ? 0 : 1)
+    })
+    .catch((err) => {
+      console.error('❌ Seed predefined clusters failed:', err)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary

Implements **Phase 7** of the brain clustering plan (`docs/2026-04-25-brain-clustering-engine-implementation.md`) — the **seeds layer**: scripts that load the four hackathon CSVs into Supabase and a single `bootstrap-all` runner that orchestrates them.

- **3 commits**, one per remaining task. **Task 7.1 was already shipped during Phase 2** (`03d5162 feat(ciiu-taxonomy): add seed script for dian csv with round-trip probe`) — Phase 7 covered 7.2, 7.3, 7.4.
- **+8 unit tests** for the only piece with real logic: the cross-CSV join in `seed-cluster-mappings`. Brain test suite: **550/550 passing** (Phase 6 baseline 542 + 8 new).
- **End-to-end run against Supabase verified**: 502 CIIU activities · 9995 companies · 8 predefined clusters · 39 cluster→CIIU mappings.

## What's in this PR

| Commit | Task | Files |
|---|---|---|
| `cf04c5a` | 7.2 — `seed-companies.ts` | thin wrapper over `CsvCompanySource` + `seed:companies` script |
| `a7b8416` | 7.3 — `seed-predefined-clusters.ts` + `seed-cluster-mappings.ts` | 2 seeds + pure `buildClusterMappings` helper + 8 unit tests + 2 scripts |
| `c7d983a` | 7.4 — `bootstrap-all.ts` runner | orchestrates the 4 seeds + `seed` script |

## Architecture / process decisions worth flagging

1. **Pragmatic TDD for thin wrappers (agreed with reviewer up front).** Strict TDD is active for the project, but `seed-companies.ts` and `bootstrap-all.ts` are thin wrappers over already-tested code (`CsvCompanySource.toCompany()` from Phase 3, all repositories from Phases 2-4). Mocking `source.fetchAll`/`repo.saveMany` to verify wiring would be test theater. Verification is the standalone probe in each `if (require.main === module)` block — same pattern as `seed-ciiu-taxonomy.ts` from Phase 2.

2. **Real logic was extracted and tested.** `seed-cluster-mappings.ts` exports `buildClusterMappings(sectores, activities)` as a pure function. 8 tests cover: the join, dedup of `(clusterId, ciiuCode)`, `actividadClusterESTADO === 'ACTIVO'` filter, missing/blank fields, unresolved internal IDs, empty inputs.

3. **CSV join: `ciiuActividadID` is the right key.** `CLUSTERS_ACTIVIDADESECONOMICAS.ciiuID` (DIAN internal numeric IDs, ranging 5–792) joins against `CLUSTERS_SECTORES_SECCIONES_ACTIVIDADES.ciiuActividadID` to resolve the 4-digit `ciiuActividadCODIGO`. Verified empirically with a discardable script: **40/40 match** against `ciiuActividadID` — 0 against `ciiuSeccionID` or `macroSectorID`. The plan's wording (cross-reference via the sectores CSV) was correct, the column names are confirmed.

4. **Predefined clusters use `id: pred-${clusterID}`.** Matches the convention used elsewhere (`PredefinedClusterMatcher` in Phase 4). Filter: `clusterESTADO === 'ACTIVO'`.

5. **Dedup matters.** `pred-8` (Turismo) has `ciiuID: "508"` twice in the activities CSV (both resolve to `5512`). Without in-memory dedup the seed would upsert the same `(cluster, code)` twice — the unique constraint absorbs it but the inserted count would lie. Dedup is silent (does not increment `skipped`).

6. **Uniform return shape.** Every seed returns `{ inserted, skipped?, repo }`. Lets `bootstrap-all.ts` print consistent stats and lets the standalone probe at the end of each file run round-trip queries (`repo.count()`, `repo.findByTipo('predefined')`, `repo.getCiiuToClusterMap()`).

## New scripts

- `bun --filter brain seed:companies`
- `bun --filter brain seed:clusters`
- `bun --filter brain seed:cluster-mappings`
- `bun --filter brain seed` → runs all four (incl. the existing `seed:ciiu` flow)

## Test plan

- [x] `bun --filter brain test:run` — 550/550 passing locally
- [x] `bun --filter brain seed` against the live Supabase project — 502 + 9995 + 8 + 39 rows confirmed end-to-end
- [ ] Verify in Supabase Dashboard that `ciiu_taxonomy`, `companies`, `clusters`, `cluster_ciiu_mapping` show the expected counts
- [ ] Spot-check a known mapping (e.g. `pred-7` → `5022, 4930, 4921, ...`) via `select * from cluster_ciiu_mapping where cluster_id = 'pred-7'`