### PR TITLE
docs: add system overview readmes and scoring deep-dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,91 @@ Ruta C Conecta hace tres cosas que no hace ningún otro sistema en el ecosistema
 
 ---
 
+## Cómo está construido
+
+Ruta C Conecta es un **monorepo** con dos servicios independientes que se comunican por HTTP, gestionado con `bun workspaces`.
+
+```
+silver-adventure/
+├── src/
+│   ├── front/      # Web Next.js 16 (App Router) — la cara del producto
+│   └── brain/      # Servicio NestJS — el motor inteligente
+├── docs/           # Documentación funcional, planeación y specs
+├── supabase/       # Schema y migraciones de la base
+└── .env            # Single source of truth (symlinks por workspace)
+```
+
+**Dos servicios, una sola lógica.**
+
+- **`src/front/`** ([README](src/front/README.md)) — Next.js 16 con App Router, React 19 y React Compiler. Es el canal del empresario formal: landing pública, login, registro guiado y la app autenticada con cinco pantallas (`Inicio`, `Recomendaciones`, `Mi Cluster`, `Mi Negocio`, `Conexiones`). Sigue arquitectura hexagonal y patrón BFF estricto: TODA llamada externa pasa por sus propios Route Handlers.
+
+- **`src/brain/`** ([README](src/brain/README.md)) — Servicio NestJS que cumple el componente "Inteligencia" del sistema. Genera clusters (predefinidos + heurísticos en cascada), produce recomendaciones AI-first con Gemini y orquesta el agente Conector que corre en cron. Arquitectura hexagonal estricta, port `CompanySource` para ser BigQuery-ready cuando lleguen las credenciales del reto.
+
+**Comunicación entre los dos.** El front NUNCA habla con Supabase ni con Gemini directamente. Sus Route Handlers consumen al brain por REST (`GET /api/recommendations/by-company/...`, `GET /api/clusters/by-company/...`, etc.). Esto preserva el patrón BFF y permite que el brain se reemplace sin tocar UI.
+
+### Stack global
+
+| Capa       | Tecnología                                                                              |
+| ---------- | --------------------------------------------------------------------------------------- |
+| Runtime    | **Bun** 1.x para dev y scripts; Node 24 para prod del brain                             |
+| Lenguaje   | **TypeScript 6** strict en ambos workspaces                                             |
+| Front      | **Next.js 16** (App Router, React 19 + React Compiler), Tailwind 4, next-intl, SWR      |
+| Brain      | **NestJS 11**, Vitest, `@google/generative-ai`, `@nestjs/schedule` (cron), Zod, OpenAPI |
+| Datos      | **Supabase / Postgres** (cloud)                                                         |
+| IA         | **Google Gemini 2.5 Flash** (chat + structured) y `text-embedding-004` (embeddings)     |
+| Validación | **Zod 4** en front, brain y env vars                                                    |
+| Tests      | **Vitest 4** en ambos workspaces (`bun test`)                                           |
+| Calidad    | ESLint 10, Prettier 3, Husky + lint-staged + commitlint, conventional commits           |
+
+### Cómo correr el monorepo
+
+```bash
+# 1. Instalar dependencias (una sola vez)
+bun install
+
+# 2. Configurar variables de entorno
+cp .env.example .env
+# Editar .env con SUPABASE_*, GEMINI_API_KEY, etc.
+
+# 3. Levantar los dos servicios (en terminales separadas)
+bun dev:front      # http://localhost:3000  (Next.js)
+bun dev:brain      # http://localhost:3001  (NestJS, OpenAPI en /docs)
+
+# 4. Tests de TODO el monorepo
+bun test           # corre vitest en front y brain
+
+# 5. Format / lint global
+bun format
+bun lint
+```
+
+Detalles específicos de cada servicio (seeds, endpoints, pantallas, providers) viven en sus README dedicados.
+
+### Variables de entorno
+
+Hay **un solo `.env` real** en la raíz del monorepo. Cada workspace lo ve a través de un **symlink relativo** (`src/front/.env -> ../../.env`, idem brain). El archivo es shared, pero cada workspace declara qué variables consume vía Zod schema independiente, que falla-rápido al startup si falta algo. Detalle completo en [`AGENTS.md`](AGENTS.md) §8.
+
+| Categoría     | Variables principales                                                   |
+| ------------- | ----------------------------------------------------------------------- |
+| Supabase      | `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SERVICE_ROLE_KEY` |
+| Gemini        | `GEMINI_API_KEY`, `GEMINI_CHAT_MODEL`, `GEMINI_EMBEDDING_MODEL`         |
+| Agente        | `AGENT_CRON_SCHEDULE`, `AGENT_ENABLED`, `AI_MATCH_INFERENCE_ENABLED`    |
+| GCP / BQ      | `GCP_PROJECT_ID`, `GCP_LOCATION`, `BIGQUERY_DATASET`                    |
+| Front público | `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_DEBUG_ENABLED`                      |
+
+---
+
 ## Estado del proyecto
 
 Este repositorio contiene el prototipo desarrollado durante el Hackathon Samatech organizado por la Cámara de Comercio de Santa Marta.
 
-- **Documentación técnica**: [`docs/documentacion.md`](docs/documentacion.md) — arquitectura, stack y cómo correr el proyecto.
+- **Convenciones del repo y reglas para agentes IA**: [`AGENTS.md`](AGENTS.md) — arquitectura hexagonal, BFF, hooks de Git, TDD, path aliases.
+- **Documentación técnica del entregable**: [`docs/documentacion.md`](docs/documentacion.md) — flujos, stack y cómo correr.
+- **Sistema de scoring de recomendaciones**: [`docs/scoring.md`](docs/scoring.md) — fórmulas, pesos, thresholds, ejemplos y trazabilidad.
 - **Planeación del equipo**: [`docs/planeacion/`](docs/planeacion/) — alcance del MVP, roles, personas, motor de recomendaciones, cronograma y riesgos.
+- **Specs por bounded context**: [`docs/specs/`](docs/specs/) — requirements y scenarios de cada contexto del brain.
 - **Reto y datos de partida**: [`docs/hackathon/`](docs/hackathon/) — bases del reto, dataset y documentación de clustering provista por la Cámara.
+- **Plan de implementación del motor**: [`docs/2026-04-25-brain-clustering-engine-implementation.md`](docs/2026-04-25-brain-clustering-engine-implementation.md) — fases, tasks y división de trabajo.
 
 ---
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,542 @@
+# Sistema de scoring — Cómo le damos peso a cada recomendación
+
+> Documento técnico-pedagógico que explica **cómo el brain calcula el score de cada recomendación, qué significa cada número, y por qué los pesos son los que son**.
+>
+> Este doc es la fuente única de verdad sobre scoring. La lógica que se documenta acá es **lo que el código hace de verdad** (`src/brain/src/recommendations/`), no lo que el spec ideal proponía. Donde haya divergencia con el spec original (`docs/specs/05-recommendations/requirements.md`), está marcado explícitamente al final del doc.
+>
+> Audiencia: jurado del hackathon, devs que tocan el motor, product managers que necesitan entender por qué tal recomendación apareció en tal puesto.
+
+---
+
+## 1. Qué es el score y para qué sirve
+
+Cada recomendación que el brain emite lleva un número en `[0, 1]` llamado **`score`**.
+
+- `score = 0.0` → no hay relación.
+- `score = 1.0` → relación máxima, mismas variables alineadas perfectamente (caso teórico).
+- En la práctica los scores útiles caen en `[0.5, 0.95]`. Cualquier cosa por debajo de `0.5` se filtra antes de persistir (ver §8).
+
+El score cumple **tres funciones** en el sistema:
+
+1. **Ordenar** — el front muestra primero las de mayor score (`findBySource` ordena desc por score).
+2. **Filtrar** — los thresholds operativos (`HIGH_SCORE_THRESHOLD = 0.8`, etc.) deciden cuándo el agente Conector emite eventos.
+3. **Empatar / desempatar** — cuando dos matchers generan la misma terna `(source, target, type)`, gana la de mayor score (dedupe).
+
+El score **NO es una probabilidad bayesiana ni un porcentaje**. Es una métrica heurística normalizada que combina señal semántica (Gemini) con señal estructural (proximidad de las dos empresas). Su uso correcto es **comparativo dentro del mismo `sourceCompanyId`**, no absoluto entre empresas distintas.
+
+---
+
+## 2. Anatomía del score — qué hay adentro
+
+Una recomendación se construye así:
+
+```
+score = f(matcher_que_la_generó, par_de_empresas, par_de_CIIUs)
+```
+
+El brain usa **cuatro matchers**, cada uno con su propia fórmula:
+
+| Matcher             | Tipo de relación que emite | Fuente del score                                  | `source` field  |
+| ------------------- | -------------------------- | ------------------------------------------------- | --------------- |
+| `AiMatchEngine`     | cualquiera de las 4        | Gemini × proximidad de las empresas concretas     | `'ai-inferred'` |
+| `PeerMatcher`       | `referente`                | Solo proximidad (mismo `ciiu_division` requerido) | `'cosine'`      |
+| `ValueChainMatcher` | `cliente` / `proveedor`    | Peso de la regla × penalización por municipio     | `'rule'`        |
+| `AllianceMatcher`   | `aliado`                   | Score plano según municipio                       | `'ecosystem'`   |
+
+**El matcher principal es `AiMatchEngine`.** Los otros tres son **fallback** — corren si Gemini falla, si `AI_MATCH_INFERENCE_ENABLED=false`, o si un par CIIU no tiene cache hit.
+
+Cada `Recommendation` además lleva:
+
+- `reasons: Reason[]` — array JSONB **estructurado** con las features que aportaron al score (no texto libre). Cada `Reason` tiene `{ feature, weight, value?, description? }`.
+- `explanation: string | null` — texto natural lazy generado por Gemini bajo demanda y cacheado.
+
+Esto garantiza **trazabilidad total**: cualquier rec puede responder "¿de dónde salió este score?" sin abrir el código.
+
+---
+
+## 3. La fórmula AI — el corazón del motor
+
+Cuando el matcher es `AiMatchEngine` (el caso del 90%+ de las recs en producción):
+
+```
+score = min(1, ai_confidence × (AI_WEIGHT + PROXIMITY_WEIGHT × proximity))
+
+donde:
+  AI_WEIGHT        = 0.6   (constante en GenerateRecommendations)
+  PROXIMITY_WEIGHT = 0.4
+  ai_confidence    ∈ [0, 1]   ← lo que devuelve Gemini para el par CIIU
+  proximity        ∈ [0, 1]   ← qué tan cerca están las dos empresas concretas
+```
+
+Implementación: `src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts:144-147`.
+
+### Cómo leer el split 60/40
+
+- **El 60% del score es semántico.** Lo que Gemini "sabe" sobre el par CIIU `(origen, destino)`: ¿existe una relación de negocio?, ¿de qué tipo?, ¿con qué confianza? Eso se cachea en `ai_match_cache` por par de CIIUs y dura entre scans.
+- **El 40% del score es estructural.** Modula por proximidad de las dos empresas concretas. Misma señal semántica, pero gana la empresa más cerca en municipio + etapa + tamaño.
+
+### Por qué este split y no otro
+
+| Si fuera... | Qué pasaría                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------- |
+| 100% AI     | Dos empresas con el mismo par CIIU empatarían siempre. La AI no puede distinguir empresas — solo CIIUs.       |
+| 50/50       | El score sería mitad-mitad. Funcionaría, pero los heurísticos contaminarían demasiado al matcher principal.   |
+| 80/20       | Empresas en distinta provincia con el mismo par CIIU casi empatarían. Mata el valor de "recomendación local". |
+| **60/40**   | Garantiza diferenciación por proximidad sin diluir la señal semántica. **Decisión adoptada.**                 |
+
+### Garantía formal del split
+
+> **Dos targets con el mismo par CIIU (mismo `ai_confidence`) pero distinta `proximity` siempre producen scores distintos.**
+
+Demostración rápida con `ai_confidence = 0.8`:
+
+```
+target A en mismo municipio, misma etapa, tamaño parecido → proximity ≈ 0.95
+  score_A = 0.8 × (0.6 + 0.4 × 0.95) = 0.8 × 0.98  = 0.784
+
+target B en municipio distinto, etapa distinta, tamaño distinto → proximity ≈ 0.05
+  score_B = 0.8 × (0.6 + 0.4 × 0.05) = 0.8 × 0.62  = 0.496
+
+Δ = 0.288 → A va MUY arriba en la lista, B se descarta por MIN_CONFIDENCE.
+```
+
+---
+
+## 4. Cómo se calcula `proximity` (el 40% estructural)
+
+`proximity` es un número en `[0, 1]` que mide qué tan parecidas son **dos empresas concretas** (no dos CIIUs). Lo calcula `FeatureVectorBuilder.proximity(a, b)` en `src/brain/src/recommendations/application/services/FeatureVectorBuilder.ts:32-39`.
+
+### Fórmula real (lo que el código hace hoy)
+
+```
+proximity = w_municipio + w_etapa + w_personal + w_ingreso
+
+  w_municipio = 0.4   si  source.municipio === target.municipio
+              = 0.0   si no
+
+  w_etapa     = 0.3   si  source.etapaOrdinal === target.etapaOrdinal
+              = 0.0   si no
+
+  w_personal  = 0.2 × (1 - |personalLog_source − personalLog_target|)
+              ∈ [0, 0.2]
+
+  w_ingreso   = 0.1 × (1 - |ingresoLog_source − ingresoLog_target|)
+              ∈ [0, 0.1]
+
+proximity = min(1, w_municipio + w_etapa + w_personal + w_ingreso)
+```
+
+### Por qué los pesos son 40 / 30 / 20 / 10
+
+| Feature       | Peso | Razón                                                                                                                                                                                                                                                            |
+| ------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Municipio** | 0.4  | El criterio más fuerte. Una recomendación local tiene valor de negocio inmediato (visita en persona, logística baja, confianza por proximidad). Si el matching ignora geografía, recomendamos una lavandería de Santa Marta a un hotel de Cartagena. Inservible. |
+| **Etapa**     | 0.3  | Importa porque "cliente potencial" entre dos startups en `nacimiento` es muy distinto a entre una `madurez` y una en `nacimiento`. Empareja maturity de negocio.                                                                                                 |
+| **Personal**  | 0.2  | Tamaño por cantidad de empleados. Una empresa de 3 personas no es proveedor realista de una corporación de 800. Log-scale para que la diferencia entre 1 y 10 pese más que entre 100 y 200.                                                                      |
+| **Ingreso**   | 0.1  | Tamaño por revenue. Reforzante de `personal`. Peso menor porque el ingreso es más volátil que la nómina.                                                                                                                                                         |
+
+**Suma máxima = 1.0** (todos coinciden). **Suma mínima = 0.0** (todos distintos y muy lejanos).
+
+### Detalle log-scale
+
+`personal` e `ingreso` se normalizan en `FeatureVectorBuilder.build()`:
+
+```typescript
+const PERSONAL_LOG_MAX = log10(10_000 + 1)        // ≈ 4.0
+const INGRESO_LOG_MAX  = log10(10_000_000_000 + 1) // ≈ 10.0
+
+personalLog = log10(personal + 1) / PERSONAL_LOG_MAX  → [0, 1]
+ingresoLog  = log10(ingreso + 1)  / INGRESO_LOG_MAX   → [0, 1]
+```
+
+Después se compara con `(1 - |a − b|)`. Dos empresas con personal idéntico → `w_personal = 0.2`. Dos empresas en extremos opuestos del rango (1 vs 10.000 empleados) → `w_personal ≈ 0`.
+
+### Etapas
+
+`etapaOrdinal` viene de `ETAPAS = ['nacimiento', 'crecimiento', 'consolidacion', 'madurez']`. Es un índice 1-4. Hoy la comparación es **binaria** (igual o no). Una mejora futura es dar bonus parcial a etapas adyacentes — está propuesta en el spec pero no implementada en código.
+
+---
+
+## 5. Las fórmulas de los fallbacks
+
+Si Gemini falla, si `AI_MATCH_INFERENCE_ENABLED=false`, o si un par CIIU no tiene cache hit, los tres matchers heurísticos corren en paralelo.
+
+### 5.1. `PeerMatcher` → emite `referente`
+
+Implementación: `src/brain/src/recommendations/application/services/PeerMatcher.ts`.
+
+**Estrategia.** Para cada `source`, busca otras empresas en la **misma `ciiu_division`** (filtro previo barato), calcula `proximity()` contra cada una, ordena desc, toma top-N (default 10), descarta los que dan proximity = 0.
+
+```
+score = proximity(source_vector, target_vector)
+```
+
+Usa **la misma función `proximity()`** que la AI, no cosine puro. La razón: `cosine_similarity` sobre vectores one-hot daba scores menos discriminativos que `proximity()`. El nombre del campo `source: 'cosine'` quedó por compatibilidad con el spec original.
+
+**Razones que se agregan:**
+
+| Cuando…                                                             | Reason emitida                 | weight |
+| ------------------------------------------------------------------- | ------------------------------ | ------ |
+| `source.ciiu === target.ciiu`                                       | `mismo_ciiu_clase` (4 dígitos) | 0.4    |
+| `source.ciiuDivision === target.ciiuDivision` (pero distinta clase) | `mismo_ciiu_division`          | 0.25   |
+| `source.municipio === target.municipio`                             | `mismo_municipio`              | 0.3    |
+| `source.etapa === target.etapa`                                     | `misma_etapa`                  | 0.2    |
+
+**Importante:** los `weight` de las `reasons` son **descriptivos** (cuánto contribuye cada feature a la justificación), no se suman para formar el score. El score viene SOLO de `proximity()`.
+
+### 5.2. `ValueChainMatcher` → emite `cliente` y `proveedor`
+
+Implementación: `src/brain/src/recommendations/application/services/ValueChainMatcher.ts`.
+
+**Estrategia.** Recorre las **27 reglas hardcoded de cadena de valor** (`VALUE_CHAIN_RULES` en `ValueChainRules.ts`). Cada regla tiene la forma:
+
+```typescript
+{
+  ciiuOrigen:  '0122',
+  ciiuDestino: '4631',  // o '*' (wildcard — cualquier CIIU distinto del origen)
+  weight:       0.85,
+  description: 'Banano hacia mayoristas de alimentos'
+}
+```
+
+Para cada `(rule, source con ciiu=origen, target con ciiu=destino)`:
+
+```
+factor = 1.0   si source.municipio === target.municipio    (SAME_MUNICIPIO_BOOST)
+       = 0.85  si no                                       (DIFF_MUNICIPIO_FACTOR)
+
+score = min(1, rule.weight × factor)
+```
+
+**Emite DOS recs por par** (bidireccional):
+
+- Una desde el origen como `'cliente'` (el destino es su cliente potencial).
+- Una desde el destino como `'proveedor'` (el origen es su proveedor potencial).
+
+Ambas con el mismo score y razones simétricas (`cadena_valor_directa` y `cadena_valor_inversa`).
+
+### 5.3. `AllianceMatcher` → emite `aliado`
+
+Implementación: `src/brain/src/recommendations/application/services/AllianceMatcher.ts`.
+
+**Estrategia.** Recorre los **6 ecosistemas predefinidos** (`ECOSYSTEMS` en `ValueChainRules.ts`):
+
+| Ecosistema                | CIIU codes incluidos                 |
+| ------------------------- | ------------------------------------ |
+| `turismo`                 | `5511, 5519, 5611, 5630, 4921, 6810` |
+| `construccion`            | `4290, 4111, 7112, 4752, 6910, 4923` |
+| `servicios-profesionales` | `6910, 7020, 7490, 7310`             |
+| `agro-exportador`         | `0122, 0126, 0121, 4631, 4923`       |
+| `salud`                   | `8610, 8621, 8692, 7912`             |
+| `educacion`               | `8512, 8551, 8559`                   |
+
+Para cada par de empresas en el mismo ecosistema (con CIIU distinto):
+
+```
+score = 0.75   si mismo municipio   (SAME_MUNICIPIO_SCORE)
+      = 0.55   si distinto municipio  (DIFF_MUNICIPIO_SCORE)
+```
+
+**Score plano.** No depende de proximity. La señal "están en el mismo ecosistema estratégico" ya es fuerte por sí sola.
+
+**Dedupe interno.** Un par `(a, b)` se procesa una sola vez gracias a un set de keys ordenadas (`a.id < b.id ? a|b : b|a`). Después se emiten 2 recs simétricas (a→b y b→a).
+
+---
+
+## 6. El pipeline completo — de fuente a persistencia
+
+Cómo se combina todo. Esto corre dentro de `GenerateRecommendations.execute()`.
+
+```
+                    ┌──────────────────────────────────────┐
+                    │   companies (estado='ACTIVO' en BD)  │
+                    └────────────────┬─────────────────────┘
+                                     ▼
+                  ┌──────────────────────────────────────────┐
+                  │   AI_MATCH_INFERENCE_ENABLED === 'true'? │
+                  └────┬─────────────────────────────────┬───┘
+                       ▼                                 ▼
+                    SÍ ─────────────────────┐         NO
+                    │                       │         │
+   ┌────────────────▼───────────┐           │         ▼
+   │  CandidateSelector         │           │   runFallback(companies):
+   │   .selectCiiuPairs()       │           │     PeerMatcher.match
+   │  → set de pares CIIU       │           │     ValueChainMatcher.match
+   │    relevantes              │           │     AllianceMatcher.match
+   └────────────────┬───────────┘           │
+                    ▼                       │
+   ┌─────────────────────────────────┐      │
+   │  CiiuPairEvaluator              │      │
+   │   .evaluateAll(pairs, conc=4)   │      │  Si esta orquestación
+   │   → llama Gemini para cada par  │      │  EXPLOTA por cualquier
+   │     con cache miss              │      │  motivo, cae al fallback
+   │   → guarda en ai_match_cache    │      │  con catch (error) →
+   └────────────────┬────────────────┘      │  runFallback().
+                    ▼                       │
+   ┌─────────────────────────────────┐      │
+   │  expandFromCache(companies):    │      │
+   │   filtra cache por              │      │
+   │     hasMatch === true Y         │      │
+   │     confidence ≥ 0.5            │      │
+   │   por cada (source, target):    │      │
+   │     score = ai_confidence ×     │      │
+   │             (0.6 + 0.4 × prox)  │      │
+   │     emite Recommendation con    │      │
+   │       source: 'ai-inferred'     │      │
+   └────────────────┬────────────────┘      │
+                    │                       │
+                    └───────────┬───────────┘
+                                ▼
+                  ┌─────────────────────────┐
+                  │  dedupe(recsBySource)   │
+                  │   key = `${target}|     │
+                  │          ${relType}`    │
+                  │   → gana max(score)     │
+                  └────────────┬────────────┘
+                               ▼
+                  ┌─────────────────────────┐
+                  │  limit(recsBySource)    │
+                  │   TOP_PER_TYPE = 5      │
+                  │   TOP_TOTAL    = 20     │
+                  └────────────┬────────────┘
+                               ▼
+                  ┌─────────────────────────┐
+                  │  recRepo.deleteAll()    │
+                  │  recRepo.saveAll(...)   │
+                  └─────────────────────────┘
+```
+
+### Pasos clave del pipeline
+
+1. **Filtrado por estado.** Solo empresas `estado='ACTIVO'` participan.
+2. **Selección de pares CIIU.** `CandidateSelector` reduce el universo de pares antes de gastar llamadas a Gemini.
+3. **Pre-warm del cache.** `CiiuPairEvaluator.evaluateAll()` corre con `concurrency=4` (4 llamadas a Gemini en paralelo). Resultados van a `ai_match_cache`.
+4. **Expansión desde cache.** Por cada par de empresas concretas, lee el cache para su par CIIU y materializa una `Recommendation` aplicando la fórmula.
+5. **Inversión de relación.** Si `source.ciiu > target.ciiu`, se invierte el `relationType` con `inverseRelation()` (cliente↔proveedor). Esto garantiza simetría: el cache solo guarda una dirección por par CIIU.
+6. **Razón "mismo_municipio" extra.** Si las dos empresas están en el mismo municipio, se agrega una `Reason` con `weight=0.2` y `feature='mismo_municipio'`. **Es razón estructurada, no afecta el score** (el score ya pesó municipio dentro de proximity).
+7. **Dedupe.** Si AI y un fallback (o dos fallbacks) generan la misma terna `(source, target, type)`, **gana la rec con mayor score**. Las `reasons` son del matcher ganador (no se mergean para evitar double-counting).
+8. **Tope.** `TOP_PER_TYPE = 5` (máximo 5 por tipo de relación) y `TOP_TOTAL = 20` (máximo 20 por empresa).
+9. **Persistencia.** `deleteAll()` + `saveAll()` — regeneración limpia para evitar recs huérfanas. El constraint `unique(source_company_id, target_company_id, relation_type)` en BD blinda contra duplicados.
+
+---
+
+## 7. Razones estructuradas — `Reason[]`
+
+Cada recomendación lleva un array de `Reason` en JSONB. **No es texto libre.** Cada Reason es:
+
+```typescript
+{
+  feature:     string         // del catálogo cerrado
+  weight:      number         // [0, 1]
+  value?:      unknown        // valor concreto que disparó la razón (ej. el municipio)
+  description?: string         // texto corto humano-legible
+  confidence?: number         // solo presente si feature === 'ai_inferido'
+}
+```
+
+### Catálogo cerrado de `feature`
+
+| Feature                 | Cuándo se emite                                          | Matcher             |
+| ----------------------- | -------------------------------------------------------- | ------------------- |
+| `ai_inferido`           | AI infirió match con `confidence >= 0.5`                 | `AiMatchEngine`     |
+| `mismo_municipio`       | `source.municipio === target.municipio` (todas las recs) | todos               |
+| `mismo_ciiu_clase`      | mismo CIIU 4 dígitos                                     | `PeerMatcher`       |
+| `mismo_ciiu_division`   | misma división 2 dígitos (pero distinta clase)           | `PeerMatcher`       |
+| `misma_etapa`           | misma etapa de crecimiento                               | `PeerMatcher`       |
+| `cadena_valor_directa`  | matchea regla con `source.ciiu === rule.ciiuOrigen`      | `ValueChainMatcher` |
+| `cadena_valor_inversa`  | matchea regla con `source.ciiu === rule.ciiuDestino`     | `ValueChainMatcher` |
+| `ecosistema_compartido` | ambas empresas en el mismo ecosistema                    | `AllianceMatcher`   |
+
+### Por qué razones estructuradas y no texto libre
+
+- **El front puede procesar features individuales** y mostrarlas como pills: `[Mismo municipio: Santa Marta] [Misma etapa: crecimiento]`.
+- **El motor puede razonar sobre ellas** — agregar nuevas features no rompe el front.
+- **Auditabilidad** — el jurado puede mirar el JSONB y ver exactamente qué features dispararon la rec.
+- **Internacionalización** — el `description` se puede traducir o reformatear sin tocar la lógica.
+
+---
+
+## 8. Thresholds operativos
+
+Constantes que controlan decisiones de filtrado, persistencia y notificación.
+
+| Constante               | Valor  | Dónde vive                       | Para qué                                                                                         |
+| ----------------------- | ------ | -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `MIN_CONFIDENCE`        | `0.5`  | `GenerateRecommendations.ts:42`  | Filtra entradas del cache antes de materializar Recommendation. Por debajo → la rec no se emite. |
+| `TOP_PER_TYPE`          | `5`    | `GenerateRecommendations.ts:43`  | Cap por tipo de relación por empresa.                                                            |
+| `TOP_TOTAL`             | `20`   | `GenerateRecommendations.ts:44`  | Cap global por empresa.                                                                          |
+| `AI_WEIGHT`             | `0.6`  | `GenerateRecommendations.ts:45`  | Peso semántico de la fórmula AI.                                                                 |
+| `PROXIMITY_WEIGHT`      | `0.4`  | `GenerateRecommendations.ts:46`  | Peso estructural de la fórmula AI.                                                               |
+| `SAME_MUNICIPIO_BOOST`  | `1.0`  | `ValueChainMatcher.ts:8`         | Sin penalización si mismo municipio.                                                             |
+| `DIFF_MUNICIPIO_FACTOR` | `0.85` | `ValueChainMatcher.ts:9`         | 15% de castigo si distinto municipio.                                                            |
+| `SAME_MUNICIPIO_SCORE`  | `0.75` | `AllianceMatcher.ts:8`           | Score plano para aliados en mismo municipio.                                                     |
+| `DIFF_MUNICIPIO_SCORE`  | `0.55` | `AllianceMatcher.ts:9`           | Score plano para aliados en distinto municipio.                                                  |
+| `HIGH_SCORE_THRESHOLD`  | `0.8`  | `OpportunityDetector` (planeado) | Trigger del evento `new_high_score_match` del agente.                                            |
+
+---
+
+## 9. Trazabilidad — cómo responder "¿por qué este score?"
+
+Tres campos persistidos en cada `Recommendation` permiten reconstruir el cálculo:
+
+| Campo         | Qué cuenta                                                                    |
+| ------------- | ----------------------------------------------------------------------------- |
+| `source`      | Qué matcher la generó (`'ai-inferred' \| 'cosine' \| 'rule' \| 'ecosystem'`). |
+| `reasons`     | Las features que entraron, con sus weights individuales.                      |
+| `explanation` | Texto natural lazy generado por Gemini bajo demanda y cacheado.               |
+
+### Lazy explanation
+
+Generar 10k explicaciones por scan sería caro y la mayoría no se ven. El use case `ExplainRecommendation` corre solo cuando el usuario hace click en una rec en el front:
+
+1. Si `recommendation.explanation != null` → devolver cached.
+2. Sino → invocar Gemini con `(source, target, relationType, reasons)` → texto natural en español.
+3. Persistir en `recommendations.explanation` y `explanation_cached_at`.
+4. Devolver texto.
+
+**Una explicación por rec, una sola llamada a Gemini, cacheada para siempre.** Si la rec se regenera (deleteAll + saveAll), la explicación se pierde y se regenera al primer click.
+
+---
+
+## 10. Tres ejemplos numéricos
+
+### Ejemplo 1 — Caso ideal AI: dos empresas alineadas
+
+- **Source:** Hotel boutique en `EL_RODADERO`, etapa `crecimiento`, 12 empleados, ingresos $400M.
+- **Target:** Lavandería industrial en `EL_RODADERO`, etapa `crecimiento`, 8 empleados, ingresos $250M.
+- **Par CIIU:** `(5511, 9601)` → Gemini dice `relationType='proveedor'`, `confidence=0.85`.
+
+```
+Cálculo de proximity:
+  w_municipio  = 0.4   (mismo)
+  w_etapa      = 0.3   (mismo)
+  personalLog_a = log10(13)/4   ≈ 0.279
+  personalLog_b = log10(9)/4    ≈ 0.239
+  w_personal   = 0.2 × (1 - |0.279 - 0.239|) = 0.2 × 0.96 = 0.192
+  ingresoLog_a ≈ log10(4e8)/10 ≈ 0.860
+  ingresoLog_b ≈ log10(2.5e8)/10≈ 0.840
+  w_ingreso    = 0.1 × (1 - |0.860 - 0.840|) = 0.1 × 0.98 = 0.098
+
+  proximity = 0.4 + 0.3 + 0.192 + 0.098 = 0.99
+
+Score AI:
+  score = 0.85 × (0.6 + 0.4 × 0.99) = 0.85 × 0.996 = 0.8466
+```
+
+→ La lavandería aparece **MUY arriba** en la lista de proveedores del hotel.
+
+### Ejemplo 2 — Mismo par CIIU, otra ciudad
+
+- **Source:** Mismo hotel boutique en `EL_RODADERO`.
+- **Target:** Otra lavandería industrial, en `BARRANQUILLA`, etapa `madurez`, 80 empleados, ingresos $4.000M.
+- **Mismo par CIIU `(5511, 9601)`** → mismo `confidence=0.85` del cache.
+
+```
+Cálculo de proximity:
+  w_municipio  = 0.0   (distinto)
+  w_etapa      = 0.0   (crecimiento vs madurez)
+  personalLog_a = 0.279
+  personalLog_b = log10(81)/4 ≈ 0.477
+  w_personal   = 0.2 × (1 - 0.198) = 0.2 × 0.802 = 0.160
+  ingresoLog_a = 0.860
+  ingresoLog_b = log10(4e9)/10 ≈ 0.961
+  w_ingreso    = 0.1 × (1 - 0.101) = 0.0899
+
+  proximity = 0.0 + 0.0 + 0.160 + 0.0899 = 0.250
+
+Score AI:
+  score = 0.85 × (0.6 + 0.4 × 0.250) = 0.85 × 0.700 = 0.595
+```
+
+→ Misma señal semántica, pero **0.85 vs 0.60**. La lavandería local le gana fácil al hotel boutique.
+
+### Ejemplo 3 — Dedupe entre AI y fallback
+
+Imaginemos que para el mismo par `(hotel, lavandería_local)`:
+
+- **AI** emitió: `relationType='proveedor'`, `score=0.8466`, `source='ai-inferred'`.
+- **ValueChainMatcher** (con la regla "5611 → 9601 weight=0.6") emitió la misma terna: `score = min(1, 0.6 × 1.0) = 0.6`, `source='rule'`.
+
+Tras `dedupe()`:
+
+```
+key = "lavandería_id|proveedor"
+  → AI:        score=0.8466
+  → ValueChain: score=0.6
+  → gana AI. La rec final tiene source='ai-inferred', reasons=[ai_inferido, mismo_municipio].
+```
+
+La razón estructurada del fallback se descarta — **NO se mergea** para evitar double-counting.
+
+---
+
+## 11. Por qué los pesos son los que son — la decisión completa
+
+Resumen de las decisiones de diseño y por qué se tomaron:
+
+| Decisión                                 | Valor       | Por qué                                                                                                    |
+| ---------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `AI_WEIGHT / PROXIMITY_WEIGHT`           | 60% / 40%   | Garantiza diferenciación por proximidad sin diluir la señal semántica de Gemini.                           |
+| Proximity municipio                      | 40%         | Recomendación local = valor de negocio inmediato. Sin esto, recomendamos lavanderías en otra ciudad.       |
+| Proximity etapa                          | 30%         | Empareja maturity de negocio. Una startup con una multinacional no es match realista.                      |
+| Proximity tamaño (personal)              | 20%         | Emparejar tamaño en empleados. Log-scale para que la diferencia entre 1 y 10 pese más que entre 100 y 200. |
+| Proximity tamaño (ingreso)               | 10%         | Reforzante de personal. Peso menor porque ingreso es más volátil.                                          |
+| `MIN_CONFIDENCE`                         | 0.5         | Punto donde Gemini deja de tener señal útil — debajo de eso es ruido.                                      |
+| `TOP_PER_TYPE / TOP_TOTAL`               | 5 / 20      | El front muestra 3-5 cards por tipo. Persistir más es desperdicio.                                         |
+| `DIFF_MUNICIPIO_FACTOR` (rules)          | 0.85        | 15% de castigo. Suficiente para diferenciar, no tanto como para descartar la rec.                          |
+| `SAME / DIFF_MUNICIPIO_SCORE` (alliance) | 0.75 / 0.55 | Por debajo del threshold de high score (0.8). Las alianzas son señal media, no alta.                       |
+
+---
+
+## 12. Configurabilidad y futuro
+
+### Hoy es configurable
+
+- `AI_MATCH_INFERENCE_ENABLED` (env): apaga Gemini, fuerza fallback total.
+- `AGENT_ENABLED` (env): apaga el cron del agente (no afecta scoring, sí afecta cuándo se regenera).
+- `enableAi: boolean` en input de `GenerateRecommendations.execute()`: override por llamada (útil para tests).
+
+### Hoy NO es configurable (constantes hardcoded)
+
+- Pesos de la fórmula AI (`AI_WEIGHT`, `PROXIMITY_WEIGHT`).
+- Pesos de proximity (40/30/20/10).
+- Thresholds (`MIN_CONFIDENCE`, `TOP_*`).
+- Factores de penalización por municipio.
+
+**Cuándo conviene exponerlas como env.** Cuando empecemos a A/B testear pesos o cuando el reto pida tuning por territorio (ej. en municipios pequeños el peso de "mismo municipio" debería ser menor porque hay menos opciones).
+
+### Mejoras propuestas pero no implementadas
+
+1. **Bonus parcial para etapas adyacentes** (`nacimiento↔crecimiento`, `crecimiento↔consolidacion`, `consolidacion↔madurez` → `0.15` en vez de `0.0`). Está en el spec REC-REQ-018, no en código.
+2. **Boost por membresía a cluster `grp-`** (más fino que `div-`). Hoy clusters no afectan score directamente.
+3. **Penalty por overconcentración** — si una empresa ya recibió 5 recs del mismo target en runs anteriores, bajar score progresivamente.
+4. **Score temporal** — recs nuevas tienen un boost decay durante 7 días para que el agente las priorice como "oportunidades frescas".
+
+---
+
+## 13. Divergencias con el spec original
+
+`docs/specs/05-recommendations/requirements.md` (REC-REQ-017 y REC-REQ-018) propuso un diseño que el código implementó **con tres ajustes** durante el desarrollo. Documentadas acá para que no haya confusión:
+
+| Tema                                | Spec REC-REQ-018                                        | Código real                                                                          | Por qué se cambió                                                                                                 |
+| ----------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Pesos de proximity                  | 40 / 30 / 30 (`tamaño` combinado de personal + ingreso) | 40 / 30 / 20 / 10 (separa `personal` 20 e `ingreso` 10)                              | Separar las dos señales le dio más estabilidad — el ingreso es más volátil que la nómina.                         |
+| Adyacencia de etapas                | Bonus parcial 0.15 para etapas adyacentes               | Comparación binaria (igual o no)                                                     | Quedó pendiente como mejora. Ver §12.                                                                             |
+| Servicio dedicado                   | `ProximityCalculator` en `application/services/`        | Implementado como método de `FeatureVectorBuilder.proximity()`                       | Reuso directo del builder evita duplicar la construcción del vector.                                              |
+| `PeerMatcher` score                 | `cosine_similarity` puro, threshold ≥ 0.7               | `proximity()` (la misma de la AI). Sin threshold (se descarta solo si es 0).         | `proximity()` discrimina mejor que cosine sobre vectores one-hot. El `source: 'cosine'` quedó por compatibilidad. |
+| Cantidad de reglas                  | 24 reglas hardcoded                                     | **27 reglas** + soporte para wildcard `ciiuDestino: '*'`                             | Aparecieron casos de uso adicionales durante el desarrollo.                                                       |
+| Razón extra `mismo_municipio` en AI | No mencionado                                           | Se agrega como `Reason` con weight 0.2 si match (no afecta score, solo trazabilidad) | Para que el front pueda mostrar el pill "Mismo municipio" sin recalcular.                                         |
+
+**Decisión.** El código es la fuente de verdad. El spec se actualizará en el próximo refactor para reflejar §11 de este doc.
+
+---
+
+## 14. Referencias
+
+- **Implementación principal:** [`src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts`](../src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts)
+- **Cálculo de proximity:** [`src/brain/src/recommendations/application/services/FeatureVectorBuilder.ts`](../src/brain/src/recommendations/application/services/FeatureVectorBuilder.ts)
+- **Matchers fallback:** `PeerMatcher.ts`, `ValueChainMatcher.ts`, `AllianceMatcher.ts` en `src/brain/src/recommendations/application/services/`
+- **Reglas y ecosistemas:** [`src/brain/src/recommendations/application/services/ValueChainRules.ts`](../src/brain/src/recommendations/application/services/ValueChainRules.ts)
+- **Spec original:** [`docs/specs/05-recommendations/requirements.md`](specs/05-recommendations/requirements.md) (REC-REQ-017, REC-REQ-018)
+- **Decisión arquitectural:** [`docs/specs/00-arquitectura.md`](specs/00-arquitectura.md) ARQ-004 (matching AI-first)
+- **Doc del brain:** [`src/brain/README.md`](../src/brain/README.md) §2.3, §3

--- a/src/brain/README.md
+++ b/src/brain/README.md
@@ -1,55 +1,496 @@
-# Brain — Motor inteligente
+# Brain — Motor inteligente de Ruta C Conecta
 
-Servicio NestJS que expone el motor de clusters, recomendaciones y agente vía REST.
+> Servicio NestJS que cumple el componente **"Inteligencia"** del sistema. Genera clusters de empresas, produce recomendaciones de relaciones de negocio (cliente, proveedor, aliado, referente) y orquesta un agente autónomo que corre en cron sin intervención humana.
+>
+> Este README explica **qué hace el brain, cómo funciona, qué rol cumple la IA y cómo está construido**. Para el contexto narrativo del producto completo ver el [README raíz](../../README.md). Para la planeación funcional ver [`docs/planeacion/`](../../docs/planeacion/). Para los specs por bounded context ver [`docs/specs/`](../../docs/specs/).
 
-## Stack
+---
 
-- **NestJS 11** + **Bun** runtime
-- **Vitest** (no Jest) — consistencia con el front
-- **Hexagonal**: domain puro TS, NestJS solo en `infrastructure/` como composition root
-- **Zod** para validación + **OpenAPI** auto-generado vía `@nestjs/swagger`
+## 1. Qué es el brain
 
-## Estructura
+El brain es el **cerebro del sistema**. Es un servicio HTTP (NestJS sobre Bun/Node) que expone una API REST con cuatro responsabilidades centrales:
+
+1. **Sincronizar empresas** desde una fuente externa (hoy CSV, mañana BigQuery).
+2. **Generar clusters** de empresas en dos capas: predefinidos (estratégicos de la Cámara) y heurísticos en cascada por CIIU + municipio.
+3. **Generar recomendaciones** de relaciones entre empresas usando Gemini como matcher principal con tres fallbacks heurísticos.
+4. **Operar autónomamente** vía un agente con `@Cron` que corre cada 60 segundos, detecta cambios y emite eventos consumibles por el front.
+
+El front Next.js NO habla con Supabase ni con Gemini directamente. Habla con el brain. **El brain es el único punto de acceso a la base y a la IA.** Esto cumple el patrón BFF estricto del monorepo.
+
+> El reto del Hackathon Samatech pide explícitamente un componente "agéntico" y un "motor de clusters" con explicaciones. El brain entrega los dos: el agente Conector y el motor AI-first con razones estructuradas + texto natural cacheado.
+
+---
+
+## 2. Qué hace — las cuatro capacidades del motor
+
+### 2.1. Sincronización de empresas (BigQuery-ready)
+
+El bounded context `companies` define un **port abstracto** `CompanySource` con dos métodos:
+
+```typescript
+interface CompanySource {
+  fetchAll(): Promise<Company[]>
+  fetchUpdatedSince(since: Date): Promise<Company[]>
+}
+```
+
+- **Hoy:** `CsvCompanySource` lee `docs/hackathon/DATA/REGISTRADOS_SII.csv` y mapea cada fila a una entity `Company` validada. La derivación de campos (limpieza de prefijo CIIU, división, grupo, sección, etapa de crecimiento) ocurre **en el adapter, no en el seed**.
+- **Mañana:** cuando lleguen las credenciales de BigQuery del reto, se crea `BigQueryCompanySource` y el switch es **una sola línea** en `companies.module.ts`. Cero impacto en el resto del sistema.
+
+El use case `SyncCompaniesFromSource` es el mismo para el seed inicial y para el agente periódico (`since` opcional).
+
+### 2.2. Generación de clusters
+
+Dos estrategias ortogonales corren en cada generación. Una empresa puede pertenecer a **varios clusters al mismo tiempo** (relación N:M en `cluster_members`).
+
+**Capa A — Predefinidos (8 estratégicos de la Cámara).** Vienen del CSV oficial de la Cámara: BANANO, MANGO, YUCA, CACAO, PALMA, CAFÉ, LOGÍSTICA, TURISMO. El servicio `PredefinedClusterMatcher` lee la tabla `cluster_ciiu_mapping` y, por cada empresa, la asigna a todos los clusters cuyo CIIU corresponde al CIIU de la empresa.
+
+**Capa B — Heurísticos en cascada de 2 niveles** (`HeuristicClusterer`):
+
+| Pase | Granularidad                      | Umbral mínimo    | ID resultante             |
+| ---- | --------------------------------- | ---------------- | ------------------------- |
+| 1    | `(ciiu_division, municipio)` (2d) | `>= 5` empresas  | `div-{div}-{municipio}`   |
+| 2    | `(ciiu_grupo, municipio)` (3d)    | `>= 10` empresas | `grp-{grupo}-{municipio}` |
+
+Los pases son **ortogonales**: el grupo no necesita que la división califique. Por qué umbrales distintos: a nivel grupo hay más particiones posibles, así que pedimos más masa crítica para que el cluster valga algo. Por qué no por sección (1 letra): demasiado genérico (un cluster de 4000 empresas no recomienda nada útil). Por qué no por CIIU completo (4 dígitos): demasiado fino (clusters de 3 empresas).
+
+Decisión documentada en [`docs/specs/00-arquitectura.md` ARQ-005](../../docs/specs/00-arquitectura.md).
+
+### 2.3. Generación de recomendaciones — AI primero
+
+Este es el **corazón del motor**. Cada recomendación tiene cuatro campos no negociables:
+
+- `relationType`: uno de `'referente' | 'cliente' | 'proveedor' | 'aliado'` (cerrado en compile-time).
+- `score`: número en `[0, 1]` validado en el factory (`Recommendation.create()`).
+- `reasons[]`: array de objetos JSONB **estructurados** (no texto libre): `{ feature, weight, value?, confidence? }`.
+- `source`: `'ai-inferred' | 'cosine' | 'rule' | 'ecosystem'` — qué matcher la generó.
+
+**Estrategia en cascada (en orden):**
+
+1. **AI (PRINCIPAL) — `AiMatchEngine` con Gemini.** Para cada par `(ciiu_origen, ciiu_destino)` Gemini decide si hay relación de negocio, qué tipo, y con qué confianza. Resultado se cachea estructuralmente en `ai_match_cache`.
+2. **Fallback 1 — `PeerMatcher`** (cosine similarity sobre feature vectors): emite recs `'referente'` si cosine ≥ 0.7.
+3. **Fallback 2 — `ValueChainMatcher`** (24 reglas hardcoded de cadena de valor): emite recs `'cliente'` o `'proveedor'`.
+4. **Fallback 3 — `AllianceMatcher`** (6 ecosistemas predefinidos): emite recs `'aliado'`.
+
+**Fórmula de scoring (matcher AI):**
 
 ```
-src/brain/
-├── src/
-│   ├── main.ts                 # Bootstrap (composition root)
-│   ├── app.module.ts           # Root module
-│   └── shared/
-│       ├── domain/             # Entity, ValueObject, UseCase, Repository, Logger (puro TS)
-│       └── infrastructure/
-│           ├── env.ts          # Zod-validated env vars
-│           └── health/
-│               └── health.controller.ts
-└── __tests__/                  # Espejo de src/
+score = ai_confidence × (0.6 + 0.4 × proximity)
 ```
 
-## Cómo correr (desde root)
+- `ai_confidence ∈ [0, 1]` — lo que devuelve Gemini para el par CIIU.
+- `proximity ∈ [0, 1]` — refinamiento por las dos empresas concretas. Calculado por `ProximityCalculator`:
+  - 40% mismo municipio
+  - 30% misma etapa (con bonus parcial para etapas adyacentes)
+  - 30% similitud log-scale de tamaño (`personal × ingreso`)
+
+**Por qué este split.** El 60% del score es semántico (lo que la AI dice del par CIIU). El 40% modula por proximidad para que dos targets con el mismo par CIIU pero distinta cercanía produzcan scores distintos. Garantía: dos targets nunca empatan al azar.
+
+**Dedupe.** Si AI y un fallback (o dos fallbacks) generan la misma terna `(source, target, type)`, **gana la rec con mayor score**. Las `reasons` son las del matcher ganador (no se mergean).
+
+> **Profundo y a detalle:** la explicación completa del scoring (cada peso, cada threshold, ejemplos numéricos, divergencias con el spec) vive en [`docs/scoring.md`](../../docs/scoring.md).
+
+### 2.4. Agente Conector autónomo
+
+El componente agéntico exigido por el reto. Vive en el bounded context `agent`.
+
+**`AgentScheduler` con `@Cron(env.AGENT_CRON_SCHEDULE)`** (default `*/60 * * * * *`):
+
+1. Crea un `ScanRun` con `trigger: 'cron'`, lo persiste en `scan_runs`.
+2. Calcula `since = lastCompletedRun?.completedAt ?? new Date(0)`.
+3. **Sync** desde `CompanySource` (CSV/BQ — vía port).
+4. Si no hay empresas updated y NO es el primer run → completar scan vacío y salir.
+5. Snapshot del estado anterior (`recRepo.snapshotKeys()`, `membershipRepo.snapshot()`).
+6. Regenera clusters (`GenerateClusters.execute()`).
+7. Regenera recomendaciones (`GenerateRecommendations.execute()`).
+8. **Detecta oportunidades** vía `OpportunityDetector` comparando snapshots:
+   - `new_high_score_match` → rec con `score >= 0.8` que NO existía antes.
+   - `new_value_chain_partner` → rec con `relationType ∈ {cliente, proveedor}` nueva.
+   - `new_cluster_member` → empresa que entró a un cluster en el que no estaba.
+9. Persiste eventos en `agent_events` (consumibles por el front).
+10. Marca `ScanRun.complete(stats)`.
+
+**Concurrencia:** si un scan está corriendo, el siguiente tick lo skippea (no se solapan). `AGENT_ENABLED='false'` apaga el cron sin tocar código. Manual trigger vía `POST /api/agent/scan/trigger` para demos.
+
+---
+
+## 3. Rol de la IA (Gemini)
+
+Esto es lo más importante del documento. La IA no es un "feature opcional" del brain — **es el matcher principal**. Los heurísticos son fallback.
+
+### 3.1. Qué decide la IA
+
+Por cada **par de CIIUs** `(origen, destino)` del universo presente en `companies`, Gemini decide:
+
+- ¿Existe una relación de negocio entre una empresa con CIIU X y una con CIIU Y?
+- Si existe, ¿de qué tipo? (`referente`, `cliente`, `proveedor`, `aliado`).
+- ¿Con qué confianza? (`[0, 1]`).
+- ¿Qué razón corta lo justifica? (string semántico).
+
+Output validado con **Zod schema** dentro de `GeminiAdapter.inferStructured()`. Si Gemini devuelve algo que no parsea como JSON o no cumple el schema, se trata como cache miss y se aplican fallbacks.
+
+### 3.2. Cómo se usa — AI primero + cache estructural
+
+**`ai_match_cache` es estructural, no es una optimización.** Hay ~159 CIIUs reales en el dataset → máximo `159 × 159 ≈ 25k` pares únicos. Pre-evaluar el universo entero contra Gemini al primer arranque y persistir cada resultado en cache es la base del sistema, no un atajo.
+
+**Flujo:**
+
+1. **`CiiuPairEvaluator.evaluateAll()`** corre al primer arranque (o cuando el cache está stale). Para cada par CIIU `(origen, destino)`:
+   - Si ya está en cache → skip.
+   - Sino → llamar `AiMatchEngine.inferMatch(origen, destino)`, guardar el `AiMatchCacheEntry` con `{ hasMatch, relationType, confidence, reason }`.
+2. **`CandidateSelector.selectCandidates(source, all)`** reduce el universo de pares ANTES de generar recs (evita evaluar 10k × 10k = 100M pares en runtime). Reglas:
+   - Excluir la propia empresa.
+   - Solo empresas cuyo `(source.ciiu, candidate.ciiu)` esté en cache con `hasMatch=true`.
+   - Cold start (sin cache aún): mismas división o municipio.
+3. **`GenerateRecommendations`** materializa: por cada empresa source, lee del cache, calcula `proximity`, aplica la fórmula de scoring, emite top-N recs con `source: 'ai-inferred'`.
+
+**Costo del primer scan.** ~25k pares × `gemini-2.5-flash` = $1–3 USD según length de prompts. Las siguientes corridas son casi gratis: cache hit en el 99%+ de los casos. Para tests E2E que no quieren tocar Gemini → `AI_MATCH_INFERENCE_ENABLED=false`.
+
+### 3.3. Contexto que recibe Gemini
+
+El prompt **no es un "qué crees vos"**. Recibe contexto de dominio:
+
+- **24 reglas de cadena de valor** hardcoded por la Cámara (ej. supermercado ← productor de carne) vía `ValueChainRules.getRulesAsPromptContext()`.
+- **6 ecosistemas predefinidos** (ej. `agro-banano` con miembros CIIU `['0123', '1030', '4630']`) vía `getEcosystemsAsPromptContext()`.
+- Pregunta concreta sobre el par CIIU.
+- **Schema Zod del output esperado** (Gemini está forzado a devolver JSON validable).
+
+Las reglas hardcoded **NO compiten con la AI** — son su contexto. La AI generaliza más allá de las 24 reglas.
+
+### 3.4. Fallbacks cuando la AI no aplica
+
+Cuando `AI_MATCH_INFERENCE_ENABLED=false`, o cuando Gemini falla, o cuando un par CIIU no tiene cache hit, los tres matchers heurísticos corren en paralelo:
+
+| Matcher             | Tipo de relación que emite | Fórmula                                                | Notas                                         |
+| ------------------- | -------------------------- | ------------------------------------------------------ | --------------------------------------------- |
+| `PeerMatcher`       | `referente`                | `score = cosine_similarity` (sobre feature vectors)    | Solo si cosine ≥ 0.7                          |
+| `ValueChainMatcher` | `cliente` / `proveedor`    | `score = rule.weight × (mismo_municipio ? 1.0 : 0.85)` | Castigo de 15% si distinto municipio          |
+| `AllianceMatcher`   | `aliado`                   | `score = mismo_municipio ? 0.75 : 0.55`                | Score plano por presencia en mismo ecosistema |
+
+`FeatureVectorBuilder` construye vectores con: `ciiuDivision` (one-hot), `municipio` (one-hot), `etapa` (one-hot), `personal` log-scale, `ingreso` log-scale.
+
+### 3.5. Lazy enrichment — explicaciones en lenguaje natural
+
+Cuando el usuario hace click en una recomendación en el front, el use case `ExplainRecommendation` ejecuta:
+
+1. Si `recommendation.explanation != null` → devolver cached.
+2. Sino → invocar Gemini con contexto (source, target, relationType, reasons) → texto natural.
+3. Persistir en `recommendations.explanation` y `explanation_cached_at`.
+4. Devolver texto.
+
+**Lazy** porque generar 10k explicaciones por scan sería caro y la mayoría no se ven. **Cached** porque una vez generada, no cambia mientras la rec exista.
+
+### 3.6. Resumen del rol de la IA
+
+| ¿Para qué se usa Gemini?                   | ¿Cuándo?                     | ¿Cacheado en?                 |
+| ------------------------------------------ | ---------------------------- | ----------------------------- |
+| Inferir match entre par CIIU               | Pre-warm al primer arranque  | `ai_match_cache`              |
+| Generar texto natural de la recomendación  | On-demand (click usuario)    | `recommendations.explanation` |
+| Enriquecer explicación de cluster (futuro) | On-demand (`ExplainCluster`) | TBD                           |
+
+**No se usa Gemini para:** consultas en runtime sobre la BD, generación de los heurísticos, scoring final, dedupe ni emisión de eventos. Esas son responsabilidades del código TypeScript del brain.
+
+---
+
+## 4. Arquitectura
+
+### 4.1. Hexagonal estricta (Ports & Adapters)
+
+Cada bounded context tiene tres capas. **La regla de dependencia nunca se rompe:**
+
+```
+infrastructure → application → domain
+```
+
+| Capa              | Qué vive                                                                 | Qué puede importar                                       |
+| ----------------- | ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `domain/`         | Entities, value objects, ports (interfaces), domain services             | NADA externo. **TypeScript puro**, ni NestJS ni Supabase |
+| `application/`    | Use cases, application services                                          | Solo `domain/`                                           |
+| `infrastructure/` | Adapters (Supabase, Gemini, CSV), controllers, modules NestJS, scheduler | `domain/` + `application/`                               |
+
+Los `*.module.ts` de NestJS son **el composition root** — el único lugar donde se cablea qué adapter implementa qué port. Si querés cambiar de Supabase a otra base, o de Gemini a OpenAI, tocás un module y el resto del código no se entera.
+
+Decisión completa en [`docs/specs/00-arquitectura.md` ARQ-001](../../docs/specs/00-arquitectura.md).
+
+### 4.2. BigQuery-readiness vía port `CompanySource`
+
+El reto promete acceso a BigQuery con el dataset real, "en sobre cerrado al inicio del hackathon". Hoy no tenemos credenciales. Trabajamos con el CSV `REGISTRADOS_SII.csv` como mock.
+
+**El port `CompanySource` permite que el día que lleguen las creds, el switch sea esta sola línea en `companies.module.ts`:**
+
+```typescript
+{ provide: COMPANY_SOURCE, useClass: CsvCompanySource }      // hoy
+{ provide: COMPANY_SOURCE, useClass: BigQueryCompanySource } // mañana
+```
+
+Cero impacto en domain, use cases, agent, recommendations, clusters. Esto es lo que el jurado tiene que ver.
+
+### 4.3. Persistencia — Supabase
+
+Todas las tablas operativas viven en Supabase (Postgres administrado) con `service_role` key (escribe + bypassea RLS):
+
+| Bounded context   | Tablas                                                |
+| ----------------- | ----------------------------------------------------- |
+| `ciiu-taxonomy`   | `ciiu_taxonomy`                                       |
+| `companies`       | `companies`                                           |
+| `clusters`        | `clusters`, `cluster_members`, `cluster_ciiu_mapping` |
+| `recommendations` | `recommendations`, `ai_match_cache`                   |
+| `agent`           | `scan_runs`, `agent_events`                           |
+
+Tipos auto-generados via `bun supabase:types` (en el front; el brain lee el archivo vía symlink).
+
+---
+
+## 5. Bounded contexts
+
+Seis contextos, cada uno con su propia carpeta `domain / application / infrastructure` y su propio `*.module.ts`.
+
+```
+src/brain/src/
+├── shared/                # Ports y adapters cross-cutting (Logger, GeminiPort, SupabaseClient, env, CsvLoader, DataPaths)
+├── ciiu-taxonomy/         # Taxonomía oficial DIAN CIIU rev 4 — base de la jerarquía sección/división/grupo
+├── companies/             # Empresas (entity + repo + CompanySource port + CsvCompanySource)
+├── clusters/              # Generación de clusters (predefinidos + heurísticos en cascada)
+├── recommendations/       # Motor AI-first: AiMatchEngine, CandidateSelector, fallbacks, scoring, lazy explain
+└── agent/                 # ScanRun, AgentEvent, OpportunityDetector, RunIncrementalScan, AgentScheduler @Cron
+```
+
+| Contexto          | Spec                                                                     | Highlight                                                                      |
+| ----------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `shared`          | [`docs/specs/01-shared/`](../../docs/specs/01-shared/)                   | `GeminiPort`, `Logger` port (Console/Null), `SupabaseClient`, `env.ts` con Zod |
+| `ciiu-taxonomy`   | [`docs/specs/02-ciiu-taxonomy/`](../../docs/specs/02-ciiu-taxonomy/)     | `findByDivision/findByGrupo` para el clusterer                                 |
+| `companies`       | [`docs/specs/03-companies/`](../../docs/specs/03-companies/)             | `CompanySource` port (BQ-ready), `EtapaCalculator`                             |
+| `clusters`        | [`docs/specs/04-clusters/`](../../docs/specs/04-clusters/)               | Cascada 2 niveles, una empresa en N clusters                                   |
+| `recommendations` | [`docs/specs/05-recommendations/`](../../docs/specs/05-recommendations/) | 18 archivos, AI engine + 3 fallbacks + cache + dedupe + scoring                |
+| `agent`           | [`docs/specs/06-agent/`](../../docs/specs/06-agent/)                     | Cron 60s, snapshot diff, eventos `new_high_score_match`, etc.                  |
+
+---
+
+## 6. Flujo end-to-end de un scan
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     AgentScheduler @Cron (cada 60s)                     │
+└──────────────────────────────────────────┬──────────────────────────────┘
+                                           ▼
+                            RunIncrementalScan.execute()
+                                           │
+   ┌───────────────────────────────────────┼───────────────────────────────┐
+   │ 1. ScanRun.start() → scan_runs        │                               │
+   │ 2. since = lastCompletedRun?.completedAt                              │
+   │ 3. SyncCompaniesFromSource ────────► CompanySource.fetchUpdatedSince  │
+   │                                         (CsvCompanySource hoy)        │
+   │                                         (BigQueryCompanySource mañana)│
+   │ 4. Empty diff? → return                                               │
+   │ 5. Snapshot prevRecKeys / prevMemberships                             │
+   │ 6. GenerateClusters.execute()                                         │
+   │      ├── PredefinedClusterMatcher                                     │
+   │      └── HeuristicClusterer (división MIN=5 + grupo MIN=10)           │
+   │ 7. GenerateRecommendations.execute()                                  │
+   │      ├── CiiuPairEvaluator.evaluateAll() ──► Gemini ──► ai_match_cache│
+   │      ├── CandidateSelector.selectCandidates()                         │
+   │      └── per pair: AiMatch || (Peer + ValueChain + Alliance)          │
+   │           └── dedupe by (source, target, type), keep max score        │
+   │ 8. OpportunityDetector.detect(new vs prev)                            │
+   │      ├── new_high_score_match (score ≥ 0.8 nuevo)                     │
+   │      ├── new_value_chain_partner (cliente/proveedor nuevo)            │
+   │      └── new_cluster_member (empresa entró a cluster nuevo)           │
+   │ 9. AgentEventRepository.saveAll(events)                               │
+   │ 10. ScanRun.complete(stats)                                           │
+   └───────────────────────────────────────────────────────────────────────┘
+                                           │
+                                           ▼
+                          Front (SWR poll) → /api/agent/events/:companyId
+```
+
+---
+
+## 7. Endpoints REST
+
+OpenAPI auto-generado vía `@nestjs/swagger`. Disponible en `http://localhost:3001/docs` cuando el server está arriba.
+
+### Health
+
+- `GET /api/health` — health check.
+
+### Companies
+
+- `GET /api/companies?limit=50` — lista con DTO sanitizado.
+- `GET /api/companies/:id` — detalle (404 si no existe).
+
+### Clusters
+
+- `GET /api/clusters?tipo=...` — lista filtrable.
+- `GET /api/clusters/:id` — detalle + miembros.
+- `GET /api/clusters/by-company/:companyId` — clusters de una empresa.
+- `POST /api/clusters/generate` — dispara `GenerateClusters` (admin).
+
+### Recommendations
+
+- `GET /api/recommendations/by-company/:companyId?type=...&limit=...` — recs ordenadas por score.
+- `GET /api/recommendations/:id/explanation` — texto natural lazy (Gemini + cached).
+- `POST /api/recommendations/generate` — dispara `GenerateRecommendations` (admin).
+
+### Agent
+
+- `GET /api/agent/events/:companyId?unread=true` — eventos para el usuario.
+- `POST /api/agent/events/:eventId/read` — marca como leído.
+- `POST /api/agent/scan/trigger` — fuerza un `RunIncrementalScan({ trigger: 'manual' })`.
+- `GET /api/agent/scans/recent?limit=10` — últimos runs (observabilidad).
+
+---
+
+## 8. Stack y dependencias clave
+
+| Bloque     | Pieza                                                        | Qué hace                                             |
+| ---------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| Framework  | `@nestjs/common`, `@nestjs/core`, `@nestjs/platform-express` | DI, controllers, lifecycle                           |
+| Cron       | `@nestjs/schedule`                                           | `@Cron(env.AGENT_CRON_SCHEDULE)` para el agente      |
+| OpenAPI    | `@nestjs/swagger`                                            | Docs auto-generadas en `/docs`                       |
+| IA         | `@google/generative-ai`                                      | Cliente oficial de Gemini (chat + structured output) |
+| BD         | `@supabase/postgrest-js`                                     | Cliente liviano (queries directas, sin auth)         |
+| CSV        | `papaparse`                                                  | Parsing del dataset Ruta C                           |
+| Validación | `zod`, `class-validator`, `class-transformer`                | Schemas de env, DTOs, output de Gemini               |
+| Tests      | `vitest`, `@vitest/coverage-v8`, `supertest`                 | Unit + integration. Coverage objetivo > 80%          |
+
+---
+
+## 9. Variables de entorno
+
+Validadas con Zod en `src/shared/infrastructure/env.ts`. **Falla rápido al startup si falta una requerida.**
+
+| Variable                     | Tipo    | Default              | Descripción                                                     |
+| ---------------------------- | ------- | -------------------- | --------------------------------------------------------------- |
+| `PORT`                       | number  | `3001`               | Puerto HTTP                                                     |
+| `SUPABASE_URL`               | url     | — (requerida)        | URL del proyecto Supabase                                       |
+| `SUPABASE_SERVICE_ROLE_KEY`  | string  | — (requerida)        | Service role key (escribe + bypass RLS)                         |
+| `GEMINI_API_KEY`             | string  | — (requerida)        | API key de Google AI Studio / Vertex                            |
+| `GEMINI_CHAT_MODEL`          | string  | `gemini-2.5-flash`   | Modelo para inference + texto natural                           |
+| `GEMINI_EMBEDDING_MODEL`     | string  | `text-embedding-004` | Modelo de embeddings (uso futuro)                               |
+| `AGENT_CRON_SCHEDULE`        | cron    | `*/60 * * * * *`     | Ritmo del agente (cada 60s por default; bajar a `*/30` en demo) |
+| `AGENT_ENABLED`              | enum    | `true`               | `false` apaga el cron sin tocar código                          |
+| `AI_MATCH_INFERENCE_ENABLED` | enum    | `true`               | `false` desactiva Gemini → solo fallbacks                       |
+| `GCP_PROJECT_ID`             | string? | —                    | Para BigQuery (cuando lleguen creds)                            |
+| `GCP_LOCATION`               | string  | `us-central1`        | Región GCP                                                      |
+| `BIGQUERY_DATASET`           | string  | `ruta_c`             | Nombre del dataset                                              |
+| `DEBUG_ENABLED`              | enum    | `false`              | `true` activa el `ConsoleLogger`; `false` usa `NullLogger`      |
+
+---
+
+## 10. Cómo correr
+
+### Desde la raíz del monorepo
 
 ```bash
-bun --filter brain start:dev      # dev mode con HMR
-bun --filter brain test:run       # tests
-bun --filter brain build          # build a dist/
+bun install                       # instala todo el monorepo
+cp .env.example .env              # configurar credenciales
+bun dev:brain                     # levanta el brain con HMR en :3001
 ```
 
-## Endpoints planeados
+### Desde la carpeta del brain
 
-- `GET /api/health` — health check (✅ ya existe)
-- `POST /api/clusters/generate` — genera clusters dinámicos
-- `GET /api/companies/:id/recommendations` — recomendaciones para una empresa
-- `GET /api/clusters/:id/explain` — explicación del cluster
-- `POST /api/agent/scan` — trigger del agente
+```bash
+cd src/brain
+bun start:dev                     # dev con watch
+bun start:debug                   # dev con --inspect
+bun build                         # compila a dist/
+bun start:prod                    # corre dist/main
+bun test                          # vitest watch
+bun test:run                      # vitest single run
+bun test:coverage                 # coverage report (>80% objetivo)
+bun lint
+bun typecheck
+```
 
-OpenAPI disponible en `http://localhost:3001/docs` cuando el server está arriba.
+### Filtrado desde la raíz (sin cambiar de directorio)
 
-## Cómo agregar un bounded context
+```bash
+bun --filter brain start:dev
+bun --filter brain test:run
+bun --filter brain build
+```
 
-1. **Domain** (`src/<context>/domain/`): entities, value objects, repository ports
-2. **Application** (`src/<context>/application/`): use cases (TS puro, sin NestJS)
+OpenAPI: `http://localhost:3001/docs` cuando el server está arriba.
+
+---
+
+## 11. Seeds — cargar datos iniciales
+
+Los seeds son scripts independientes en `src/seeds/` que llaman use cases reales (no duplican lógica de mapeo). Son **idempotentes** (upsert por id).
+
+```bash
+# Bootstrap todo en orden correcto
+bun --filter brain seed
+
+# O paso a paso
+bun --filter brain seed:ciiu              # taxonomía DIAN (CIIU_DIAN.csv)
+bun --filter brain seed:companies         # empresas (REGISTRADOS_SII.csv)
+bun --filter brain seed:clusters          # 8 clusters predefinidos (CLUSTERS.csv)
+bun --filter brain seed:cluster-mappings  # mapeo cluster → CIIU
+```
+
+Los CSVs viven en [`docs/hackathon/DATA/`](../../docs/hackathon/DATA/) y se acceden vía `DataPaths` (port para que en prod se cambie a otra fuente sin tocar código).
+
+**Nota costo IA:** después de seedear companies + ciiu, el primer arranque del agente disparará `CiiuPairEvaluator.evaluateAll()`, que llena `ai_match_cache` con ~25k pares (~$1–3 USD con `gemini-2.5-flash`). Las siguientes corridas son casi gratis. Para evitarlo en CI/E2E → `AI_MATCH_INFERENCE_ENABLED=false`.
+
+---
+
+## 12. Tests — TDD estricto
+
+`ARQ-007` del repo: **RED → GREEN → REFACTOR**, sin excepciones. Coverage > 80% en `src/`.
+
+- **Domain tests** (Entity, ValueObject): puro unit. Sin mocks.
+- **Use case tests:** inyectar `InMemory*Repository`. Sin Supabase ni Gemini.
+- **Adapter tests:** mockear el cliente externo (`SupabaseClient`, `GeminiAdapter`), validar mapeo.
+- **Controller tests:** `supertest` contra módulo aislado.
+- **Stub para Gemini:** `StubGeminiAdapter` para tests del motor sin tocar la AI real.
+
+Estructura de tests refleja la de `src/`:
+
+```
+src/brain/__tests__/
+├── shared/...
+├── ciiu-taxonomy/...
+├── companies/...
+├── clusters/...
+├── recommendations/...
+└── agent/...
+```
+
+Pre-push hook corre `bun test:run` en todo el monorepo. Si rompe, push rechazado.
+
+---
+
+## 13. Cómo agregar un bounded context nuevo
+
+1. **Domain** (`src/<context>/domain/`): entities, value objects, repository ports, domain services. **Cero imports externos.** Escribir el test de la entity primero.
+2. **Application** (`src/<context>/application/`): use cases (TypeScript puro, sin NestJS). Inyectar ports por constructor. Escribir test con `InMemory*Repository`.
 3. **Infrastructure** (`src/<context>/infrastructure/`):
-   - Adapters (repositorios, gateways, etc.)
-   - Controllers (`*.controller.ts`)
-   - Module (`*.module.ts`) que cablea DI
-4. Importar el módulo en `app.module.ts`
-5. Tests en `__tests__/<context>/...` espejando la estructura
+   - Adapters de los ports (Supabase, Gemini, gateway HTTP).
+   - Controllers (`*.controller.ts`).
+   - `*.module.ts` que cablea DI (`{ provide: TOKEN, useClass: ... }`).
+4. Importar el módulo en `src/app.module.ts`.
+5. Tests en `__tests__/<context>/...` espejando `src/`.
+6. Spec en `docs/specs/0X-<context>/requirements.md` y `scenarios.md` siguiendo la plantilla de los existentes.
+
+---
+
+## 14. Convenciones del repo
+
+Ver [`AGENTS.md`](../../AGENTS.md) (raíz) para el detalle. Resumen de lo que aplica al brain:
+
+- **Path aliases:** siempre `@/...` (no `../../...`). El alias `@/*` mapea a `src/brain/src/*`.
+- **Logger:** nunca `console.*` directo (ESLint lo prohíbe). Inyectar el `Logger` port.
+- **Conventional commits.** `feat | fix | docs | style | refactor | perf | test | chore | ci | revert`. Subject lowercase, sin punto final, ≤ 100 chars.
+- **Sin atribución a IA en commits.** Nunca `Co-Authored-By` ni equivalentes.
+- **Pre-commit:** lint-staged + commitlint. **Pre-push:** `bun test:run`.
+
+---
+
+## 15. Referencias
+
+- **Plan de implementación:** [`docs/2026-04-25-brain-clustering-engine-implementation.md`](../../docs/2026-04-25-brain-clustering-engine-implementation.md) — 7 fases, ~50 tasks, división Dev A / Dev B.
+- **Decisiones cross-cutting:** [`docs/specs/00-arquitectura.md`](../../docs/specs/00-arquitectura.md) — ARQ-001 a ARQ-010.
+- **Specs por contexto:** [`docs/specs/`](../../docs/specs/).
+- **Reto original:** [`docs/hackathon/`](../../docs/hackathon/) — README, RETO.pdf, dataset.
+- **Convenciones del monorepo:** [`AGENTS.md`](../../AGENTS.md).

--- a/src/front/README.md
+++ b/src/front/README.md
@@ -1,0 +1,342 @@
+# Front — Web de Ruta C Conecta
+
+> Aplicación Next.js 16 que cumple el componente **"Entrega"** del sistema para el empresario formal. Es la cara pública del producto: landing, registro guiado, login y la app autenticada con cinco pantallas que consumen las recomendaciones, clusters y eventos del [brain](../brain/README.md).
+>
+> Para el contexto narrativo del producto completo ver el [README raíz](../../README.md). Para reglas y convenciones del monorepo ver [`AGENTS.md`](../../AGENTS.md).
+
+---
+
+## 1. Qué es el front
+
+Es la **puerta de entrada del comerciante formal**. Pieza visible del sistema. Cumple cuatro funciones:
+
+1. **Landing pública** que explica la propuesta de valor del programa Ruta C Conecta y dirige al registro.
+2. **Registro guiado** con wizard de varios pasos (datos del negocio, contacto, confirmación).
+3. **Login** mockeado hoy, con `Sign in with Vercel` o el provider de Supabase Auth en producción.
+4. **App autenticada** con cinco pantallas que consumen al brain para mostrar recomendaciones, clusters, conexiones y la actividad del agente Conector.
+
+Lo que el front **NO hace**: nunca llama directamente a Supabase, ni a Gemini, ni a BigQuery. Toda llamada externa pasa por sus propios Route Handlers (`app/api/*`) o por el brain (`http://localhost:3001/api/...`). Esto es el patrón **BFF estricto** del monorepo.
+
+---
+
+## 2. Pantallas
+
+```
+src/front/app/
+├── layout.tsx                   # Root layout — fonts, CSS, <html>/<body>
+├── globals.css                  # Tailwind 4 + design tokens
+├── api/
+│   └── users/route.ts           # Route Handler de ejemplo (composition root)
+└── [locale]/                    # Locale-scoped (es default; en cuando habilitado)
+    ├── layout.tsx               # Provider stack: i18n → theme → SWR
+    ├── page.tsx                 # Landing pública
+    ├── _components/landing/     # Hero, segments, steps, CTAs, footer
+    ├── login/
+    │   ├── page.tsx
+    │   └── _components/login-form.tsx
+    ├── registro/
+    │   ├── page.tsx             # Wizard de registro
+    │   └── _components/         # Steps, schema (Zod), success
+    ├── dev/page.tsx             # Pantalla de utilidades para devs
+    └── app/                     # Área autenticada
+        ├── layout.tsx           # AppHeader + main
+        ├── page.tsx             # Redirige a /inicio
+        ├── _components/         # Componentes de las 5 pantallas
+        ├── _data/               # Mocks (mock-cluster, mock-recomendaciones, etc.)
+        ├── inicio/page.tsx
+        ├── recomendaciones/page.tsx
+        ├── mi-cluster/page.tsx
+        ├── mi-negocio/page.tsx
+        └── conexiones/page.tsx
+```
+
+### Las cinco pantallas de la app autenticada
+
+| Ruta                   | Qué muestra                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `/app/inicio`          | Saludo, KPIs del día, hero del agente Conector, mini-cluster, timeline de actividad, quick actions.               |
+| `/app/recomendaciones` | Tabla de recomendaciones con filtros (tipo de relación), tabs de estado, drawer de detalle, pills de tipo/estado. |
+| `/app/mi-cluster`      | Resumen del cluster del usuario, miembros (cards), traits, cadenas de valor visualizadas.                         |
+| `/app/mi-negocio`      | Tabs (general, productos, programas, visibilidad) — perfil de la empresa del usuario.                             |
+| `/app/conexiones`      | Conexiones realizadas/aceptadas, stats, tabs por estado, pills de status.                                         |
+
+> Hoy las pantallas consumen mocks (`_data/mock-*.ts`). El cableado real al brain se hace por hook (`useUsers` ya existe como ejemplo) → Route Handler local → fetch al brain. Ver §5.
+
+---
+
+## 3. Arquitectura — Hexagonal en el front también
+
+Sí, el front también es hexagonal. Cada bounded context (hoy `users` como ejemplo) tiene tres capas con la misma regla de dependencia:
+
+```
+infrastructure → application → domain
+```
+
+```
+src/front/core/
+├── shared/
+│   ├── domain/                  # Entity, ValueObject, UseCase, Repository, Logger (TypeScript puro)
+│   └── infrastructure/
+│       ├── env.ts               # Zod schema de variables del front
+│       ├── http/httpClient.ts   # Axios singleton con interceptors
+│       ├── logger/              # ConsoleLogger | NullLogger según DEBUG_ENABLED
+│       ├── supabase/            # server.ts (BFF only) + database.types.ts auto-generado
+│       ├── swr/                 # SWRProvider + fetcher con AbortController
+│       └── theme/               # ThemeProvider + ThemeToggle (next-themes)
+└── users/                       # Bounded context de ejemplo
+    ├── domain/
+    │   ├── entities/User.ts                # private constructor + factory
+    │   └── repositories/UserRepository.ts  # port
+    ├── application/
+    │   └── use-cases/GetUsers.ts
+    └── infrastructure/
+        ├── repositories/
+        │   ├── SupabaseUserRepository.ts   # adapter prod (server-only)
+        │   └── InMemoryUserRepository.ts   # adapter test
+        ├── components/UserList.tsx          # client component
+        └── hooks/useUsers.ts                # SWR hook → /api/users
+```
+
+**Composition root** = los Route Handlers (`app/api/*/route.ts`). Ahí se instancian los adapters reales y se inyectan en el use case:
+
+```typescript
+// app/api/users/route.ts
+const supabase = createSupabaseServerClient()
+const repository = new SupabaseUserRepository(supabase)
+const getUsers = new GetUsers(repository)
+const { users } = await getUsers.execute()
+return Response.json({ users })
+```
+
+**Reglas no negociables:**
+
+- Domain NO importa nada de NestJS, Next, Supabase, ni siquiera React.
+- Use cases NO importan adapters concretos. Reciben ports por constructor.
+- Adapters server-only marcados con `import 'server-only'` (build error si se importan en cliente).
+
+---
+
+## 4. Provider stack y data flow
+
+### Provider stack (en `app/[locale]/layout.tsx`, de afuera hacia adentro)
+
+1. **`NextIntlClientProvider`** — i18n. Mensajes de `messages/es.json` (y `en.json` cuando se habilite).
+2. **`ThemeProvider`** — light/dark/system vía `next-themes`.
+3. **`SWRProvider`** — config global de SWR con fetcher basado en Axios (`AbortController` integrado).
+
+### Data flow — server-side (BFF)
+
+```
+Client Component
+  └── SWR hook (useUsers)
+        └── GET /api/users (Route Handler — composition root)
+              ├── createSupabaseServerClient()         (lee env validado)
+              ├── new SupabaseUserRepository(...)      (adapter)
+              ├── new GetUsers(repository)             (use case)
+              └── Response.json(...)                   (DTO)
+                    └── SWR cache → UI
+```
+
+### Data flow — server-side hacia el brain
+
+Cuando el front necesita datos que produce el brain (recomendaciones, clusters, eventos del agente), su Route Handler local actúa de **proxy/composition**:
+
+```
+Client Component
+  └── SWR hook
+        └── GET /api/recomendaciones      (Route Handler del front)
+              └── httpClient.get(`${BRAIN_URL}/api/recommendations/by-company/${id}`)
+                    └── brain (NestJS)
+                          ├── consulta Supabase
+                          ├── Gemini cache hit / lazy explain
+                          └── Response.json(...)
+```
+
+El cliente NUNCA conoce la URL del brain. Eso vive en el Route Handler. Si el brain se mueve a otra URL, se cambia una sola línea.
+
+---
+
+## 5. Cómo se consume al brain
+
+Hoy las pantallas usan mocks en `_data/`. La transición a datos reales sigue un patrón fijo:
+
+1. Crear el bounded context en `src/front/core/<contexto>/` (`recommendations`, `clusters`, etc.).
+2. Definir port `*Repository` con métodos coherentes con los endpoints del brain.
+3. Implementar adapter `Brain*Repository` que use `httpClient` (Axios) para consumir REST del brain.
+4. Implementar use cases (`GetCompanyRecommendations`, `ExplainRecommendation`...).
+5. Crear Route Handler en `app/api/<recurso>/...` como composition root: instancia adapter, ejecuta use case, devuelve DTO.
+6. Crear hook SWR en `src/front/core/<contexto>/infrastructure/hooks/use<Recurso>.ts` que apunta al Route Handler local.
+7. Componente cliente consume el hook.
+
+**Por qué este zigzag.** Permite cambiar el brain sin tocar UI; aislar errores y logs en el Route Handler; sanitizar DTOs antes de exponerlos al cliente; agregar caché HTTP en la edge de Vercel sobre los Route Handlers.
+
+---
+
+## 6. i18n
+
+| Config     | Valor                                           |
+| ---------- | ----------------------------------------------- |
+| Librería   | `next-intl` 4.x                                 |
+| Locales    | `es` (default), `en` (placeholder)              |
+| Estrategia | URL-based routing (`/es/...`, `/en/...`)        |
+| Prefix     | `as-needed` (el default omite prefijo)          |
+| Mensajes   | `messages/es.json` (y `en.json` cuando se sume) |
+| Proxy      | `proxy.ts` (Next.js 16 — ex `middleware.ts`)    |
+
+Agregar traducciones: añadir keys a `messages/<locale>.json` y consumir con `useTranslations('Namespace')` (server o client component, ambos funcionan vía `NextIntlClientProvider`).
+
+Agregar locale: agregar el código a `i18n/routing.ts → locales`, crear `messages/<locale>.json`, listo.
+
+---
+
+## 7. Stack y dependencias clave
+
+| Bloque        | Pieza                                           | Qué hace                                         |
+| ------------- | ----------------------------------------------- | ------------------------------------------------ |
+| Framework     | `next` 16.2.4 (App Router + React Compiler)     | Server Components, Route Handlers, streaming     |
+| UI            | `react` 19.2, `tailwindcss` 4, `lucide-react`   | Components + iconos + utilidades                 |
+| Animación     | `motion`                                        | Microinteracciones del landing y app             |
+| Data fetching | `swr` + `axios`                                 | Cliente con cache, revalidación e interceptors   |
+| i18n          | `next-intl`                                     | Routing por locale + mensajes                    |
+| Theme         | `next-themes`                                   | Light/dark/system                                |
+| Supabase      | `@supabase/ssr`, `@supabase/supabase-js`        | Cliente server-only (BFF)                        |
+| Validación    | `zod` 4                                         | Env vars + schemas del wizard de registro        |
+| Tests         | `vitest` 4 + `@testing-library/react` + `jsdom` | Unit (node) + integration (jsdom)                |
+| Lint/format   | `eslint-config-next`, `eslint-config-prettier`  | + plugin de orden de clases Tailwind en Prettier |
+
+> **React Compiler está activado** (`reactCompiler: true` en `next.config.ts`). No hace falta `useMemo` / `useCallback` manual — el compilador lo hace por vos.
+
+---
+
+## 8. Variables de entorno
+
+Validadas con Zod en `core/shared/infrastructure/env.ts`. Falla rápido si falta una requerida.
+
+| Variable                    | Side   | Descripción                                      |
+| --------------------------- | ------ | ------------------------------------------------ |
+| `SUPABASE_URL`              | Server | URL del proyecto Supabase                        |
+| `SUPABASE_PUBLISHABLE_KEY`  | Server | Publishable key (ex anon key)                    |
+| `DEBUG_ENABLED`             | Server | `true` activa `ConsoleLogger` server-side        |
+| `NEXT_PUBLIC_DEBUG_ENABLED` | Client | `true` activa `ConsoleLogger` client-side        |
+| `NEXT_PUBLIC_APP_URL`       | Client | URL pública de la app (canonical, OG tags, etc.) |
+
+**Disciplina BFF.** Las únicas variables `NEXT_PUBLIC_*` permitidas son las dos de arriba — no son secretos. **Nada de `NEXT_PUBLIC_SUPABASE_*`.** Detalle completo en [`AGENTS.md`](../../AGENTS.md) §8.
+
+---
+
+## 9. Cómo correr
+
+### Desde la raíz del monorepo
+
+```bash
+bun install
+cp .env.example .env       # configurar credenciales
+bun dev:front              # http://localhost:3000
+```
+
+### Desde la carpeta del front
+
+```bash
+cd src/front
+bun dev                    # dev server con HMR
+bun build                  # build de producción
+bun start                  # servir el build
+bun lint                   # ESLint
+bun test                   # vitest watch
+bun test:run               # vitest single run
+bun test:coverage          # coverage report
+bun supabase:types         # regenera database.types.ts desde el proyecto Supabase linkeado
+```
+
+### Filtrado desde la raíz (sin cambiar de directorio)
+
+```bash
+bun --filter front dev
+bun --filter front test:run
+bun --filter front build
+```
+
+> El brain debe estar levantado en paralelo (`bun dev:brain`) para que las pantallas reales (no mocks) tengan datos. OpenAPI del brain en `http://localhost:3001/docs`.
+
+---
+
+## 10. Tests — TDD estricto
+
+`ARQ-007` aplica al front también. Coverage > 80% sobre `src/front/core/**`.
+
+```
+src/front/__tests__/
+├── core/                   # Unit tests (env: 'node')
+│   ├── shared/domain/      # Entity, ValueObject, etc.
+│   ├── users/              # User entity, GetUsers use case, repos
+│   └── app/                # Route handler tests, env validation
+├── integration/            # Component tests (env: 'jsdom')
+│   └── users/              # UserList integration tests
+└── unit/                   # Reservado para unit tests no-core
+```
+
+**Convención de ubicación de tests:**
+
+| Source                                                        | Test                                            |
+| ------------------------------------------------------------- | ----------------------------------------------- |
+| `src/front/core/users/domain/entities/User.ts`                | `__tests__/core/users/User.test.ts`             |
+| `src/front/core/users/application/use-cases/GetUsers.ts`      | `__tests__/core/users/GetUsers.test.ts`         |
+| `src/front/app/api/users/route.ts`                            | `__tests__/core/app/api/users/route.test.ts`    |
+| `src/front/core/users/infrastructure/components/UserList.tsx` | `__tests__/integration/users/UserList.test.tsx` |
+
+**Nunca** poner tests dentro de `src/`.
+
+---
+
+## 11. Path aliases
+
+```
+"paths": { "@/*": ["./src/*"] }   // (relativo al root del monorepo)
+```
+
+Reglas:
+
+- **Siempre** `@/...` para imports cross-folder (en `src/` y en `__tests__/`).
+- `./` solo entre archivos hermanos en la misma carpeta (ej. `./fetcher` dentro de `swr/`).
+- **Nunca** `../` para subir directorios — si lo necesitás, hay que crear o usar un alias.
+- Crear nuevos aliases en `tsconfig.json → paths` cuando emerja un patrón. Documentar en `AGENTS.md`.
+
+---
+
+## 12. Convenciones (resumen)
+
+Detalle completo en [`AGENTS.md`](../../AGENTS.md). Lo crítico:
+
+1. **Hexagonal estricta** — domain con cero imports externos.
+2. **BFF estricto** — UI / Client Components nunca llaman Supabase ni Gemini directo. Todo pasa por Route Handlers o por el brain.
+3. **Tests fuera de `src/`** (`__tests__/` espejo de `src/`).
+4. **Path aliases** siempre.
+5. **Validación con Zod** en factories de entities y en env.
+6. **`no-console: error`** — usar el `Logger` port (`serverLogger` / `clientLogger`).
+7. **Conventional commits**, sin atribución a IA.
+8. **Pre-commit:** lint-staged + commitlint. **Pre-push:** `bun test:run`.
+9. **TDD:** RED → GREEN → REFACTOR.
+10. **Next.js 16:** `proxy.ts` (no `middleware.ts`), `params` es `Promise` (await antes de leer), React Compiler activo.
+
+---
+
+## 13. Diferencias clave vs. Next.js 15 y anteriores
+
+Next.js 16 tiene cambios breaking. **No es el Next que conocés.** Antes de tocar APIs del framework, leé `node_modules/next/dist/docs/`. Lo más importante:
+
+| Antes                                     | Ahora (Next.js 16)                                                                 |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| `middleware.ts` con `middleware()` export | `proxy.ts` con `default` export usando `proxy()` API                               |
+| `params: { locale: string }`              | `params: Promise<{ locale: string }>` — `await params`                             |
+| `useMemo` / `useCallback` manuales        | React Compiler los aplica automáticamente                                          |
+| ESLint 9                                  | ESLint 10 — `context.getFilename()` removido. `react.version` debe estar explícito |
+
+---
+
+## 14. Referencias
+
+- **Producto y narrativa completa:** [`README.md`](../../README.md) raíz.
+- **Brain (motor inteligente que consume este front):** [`src/brain/README.md`](../brain/README.md).
+- **Convenciones del monorepo:** [`AGENTS.md`](../../AGENTS.md).
+- **Documentación funcional del entregable:** [`docs/documentacion.md`](../../docs/documentacion.md).
+- **Planeación:** [`docs/planeacion/`](../../docs/planeacion/).


### PR DESCRIPTION
- expand root README with monorepo arch, stack and run commands
- rewrite src/brain/README.md covering capabilities, ai role, contexts
- add src/front/README.md with screens, hexagonal layout and bff flow
- add docs/scoring.md as single source of truth for score formulas