### PR TITLE
feat: ai signup classification and grouped recommendations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ GEMINI_CHAT_MODEL=gemini-2.5-flash
 GEMINI_EMBEDDING_MODEL=text-embedding-004
 
 # ===========================================
+# Front → Brain (BFF integration)
+# ===========================================
+# Base URL of the NestJS backend that the Next.js BFF talks to server-side.
+# In dev: http://localhost:3001. In prod: the deployed brain endpoint.
+BRAIN_API_URL=http://localhost:3001
+
+# ===========================================
 # Brain — Agent (clustering scheduler)
 # ===========================================
 # Cron schedule for the clustering agent (default: every 60s)

--- a/src/brain/__tests__/companies/ClassifyCompanyFromDescription.test.ts
+++ b/src/brain/__tests__/companies/ClassifyCompanyFromDescription.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+
+class ScriptedGemini implements GeminiPort {
+  public readonly prompts: string[] = []
+  private call = 0
+
+  constructor(private readonly responses: unknown[]) {}
+
+  async generateText(prompt: string): Promise<string> {
+    this.prompts.push(prompt)
+    return JSON.stringify(this.responses[this.call++] ?? {})
+  }
+
+  async inferStructured<T>(
+    prompt: string,
+    validate: (raw: unknown) => T,
+  ): Promise<T> {
+    this.prompts.push(prompt)
+    const response = this.responses[this.call++]
+    return validate(response)
+  }
+}
+
+const restaurant = CiiuActivity.create({
+  code: '5611',
+  titulo: 'Expendio a la mesa de comidas preparadas',
+  seccion: 'I',
+  division: '56',
+  grupo: '561',
+  tituloSeccion: 'Alojamiento y servicios de comida',
+  tituloDivision: 'Actividades de servicios de comidas y bebidas',
+  tituloGrupo: 'Actividades de restaurantes',
+  macroSector: 'Servicios',
+})
+
+const retail = CiiuActivity.create({
+  code: '4711',
+  titulo: 'Comercio al por menor en establecimientos no especializados',
+  seccion: 'G',
+  division: '47',
+  grupo: '471',
+  tituloSeccion: 'Comercio',
+  tituloDivision: 'Comercio al por menor',
+  tituloGrupo: 'Establecimientos no especializados',
+  macroSector: 'Comercio',
+})
+
+describe('ClassifyCompanyFromDescription', () => {
+  let taxonomyRepo: InMemoryCiiuTaxonomyRepository
+
+  beforeEach(async () => {
+    taxonomyRepo = new InMemoryCiiuTaxonomyRepository([restaurant, retail])
+  })
+
+  it('returns CIIU code + taxonomy data when Gemini answers with a valid code', async () => {
+    const gemini = new ScriptedGemini([
+      {
+        ciiuCode: '5611',
+        reasoning:
+          'Restaurante boutique de comida del Caribe — clase 5611 expende a la mesa.',
+      },
+    ])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    const result = await useCase.execute({
+      description: 'Restaurante boutique en El Rodadero, comida del Caribe.',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+    })
+
+    expect(result.ciiu.code).toBe('5611')
+    expect(result.ciiu.titulo).toBe('Expendio a la mesa de comidas preparadas')
+    expect(result.ciiu.seccion).toBe('I')
+    expect(result.ciiu.division).toBe('56')
+    expect(result.ciiu.grupo).toBe('561')
+    expect(result.ciiu.macroSector).toBe('Servicios')
+    expect(result.reasoning).toContain('5611')
+  })
+
+  it('passes the description, business name and municipio inside the prompt', async () => {
+    const gemini = new ScriptedGemini([
+      { ciiuCode: '4711', reasoning: 'tienda de barrio' },
+    ])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    await useCase.execute({
+      description: 'Tienda de barrio que vende víveres',
+      businessName: 'Donde Doña Marta',
+      municipio: 'SANTA MARTA',
+    })
+
+    const prompt = gemini.prompts[0]
+    expect(prompt).toContain('Tienda de barrio que vende víveres')
+    expect(prompt).toContain('Donde Doña Marta')
+    expect(prompt).toContain('SANTA MARTA')
+  })
+
+  it('retries once when Gemini returns a code that does not exist in the taxonomy', async () => {
+    const gemini = new ScriptedGemini([
+      { ciiuCode: '9999', reasoning: 'nope' },
+      { ciiuCode: '5611', reasoning: 'restaurante' },
+    ])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    const result = await useCase.execute({
+      description: 'Restaurante',
+      businessName: 'X',
+      municipio: 'SANTA MARTA',
+    })
+
+    expect(result.ciiu.code).toBe('5611')
+    expect(gemini.prompts).toHaveLength(2)
+    expect(gemini.prompts[1]).toContain('9999')
+  })
+
+  it('throws after the retry if the second response is also invalid', async () => {
+    const gemini = new ScriptedGemini([
+      { ciiuCode: '9999', reasoning: 'nope' },
+      { ciiuCode: '8888', reasoning: 'still nope' },
+    ])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    await expect(
+      useCase.execute({
+        description: 'algo raro',
+        businessName: 'X',
+        municipio: 'SANTA MARTA',
+      }),
+    ).rejects.toThrow(/CIIU/)
+  })
+
+  it('rejects empty descriptions', async () => {
+    const gemini = new ScriptedGemini([])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    await expect(
+      useCase.execute({
+        description: '   ',
+        businessName: 'X',
+        municipio: 'SANTA MARTA',
+      }),
+    ).rejects.toThrow(/description/i)
+  })
+
+  it('throws when Gemini response shape is invalid', async () => {
+    const gemini = new ScriptedGemini([{ wrong: 'shape' }])
+    const useCase = new ClassifyCompanyFromDescription(gemini, taxonomyRepo)
+
+    await expect(
+      useCase.execute({
+        description: 'cualquier cosa',
+        businessName: 'X',
+        municipio: 'SANTA MARTA',
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
+++ b/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
@@ -1,0 +1,152 @@
+import { BadRequestException } from '@nestjs/common'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
+import { OnboardCompanyFromSignup } from '@/companies/application/use-cases/OnboardCompanyFromSignup'
+import { CompanyOnboardingController } from '@/companies/infrastructure/http/company-onboarding.controller'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+
+class FixedGemini implements GeminiPort {
+  constructor(private readonly response: unknown) {}
+  async generateText() {
+    return JSON.stringify(this.response)
+  }
+  async inferStructured<T>(
+    _prompt: string,
+    validate: (raw: unknown) => T,
+  ): Promise<T> {
+    return validate(this.response)
+  }
+}
+
+describe('CompanyOnboardingController', () => {
+  let controller: CompanyOnboardingController
+
+  beforeEach(async () => {
+    const taxonomy = new InMemoryCiiuTaxonomyRepository([
+      CiiuActivity.create({
+        code: '5611',
+        titulo: 'Expendio a la mesa',
+        seccion: 'I',
+        division: '56',
+        grupo: '561',
+        tituloSeccion: 'Alojamiento y comida',
+        tituloDivision: 'Comidas y bebidas',
+        tituloGrupo: 'Restaurantes',
+        macroSector: 'Servicios',
+      }),
+    ])
+    const clusterRepo = new InMemoryClusterRepository()
+    const ciiuMapping = new InMemoryClusterCiiuMappingRepository()
+    await clusterRepo.saveMany([
+      Cluster.create({
+        id: 'gastro',
+        codigo: 'GASTRO',
+        titulo: 'Gastronomía',
+        tipo: 'predefined',
+      }),
+    ])
+    await ciiuMapping.saveMany([{ clusterId: 'gastro', ciiuCode: '5611' }])
+
+    const companyRepo = new InMemoryCompanyRepository()
+    const recRepo = new InMemoryRecommendationRepository()
+    const membershipRepo = new InMemoryClusterMembershipRepository()
+    const featureBuilder = new FeatureVectorBuilder()
+
+    const classify = new ClassifyCompanyFromDescription(
+      new FixedGemini({
+        ciiuCode: '5611',
+        reasoning: 'restaurante',
+      }),
+      taxonomy,
+    )
+    const onboard = new OnboardCompanyFromSignup(
+      classify,
+      companyRepo,
+      clusterRepo,
+      ciiuMapping,
+      membershipRepo,
+      recRepo,
+      new PeerMatcher(featureBuilder),
+      new ValueChainMatcher(),
+      new AllianceMatcher(),
+    )
+    controller = new CompanyOnboardingController(onboard)
+  })
+
+  it('returns DTO with company, classification, clusters and grouped recommendations', async () => {
+    const result = await controller.onboard({
+      userId: 'user-1',
+      description: 'Restaurante boutique en El Rodadero',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: '5_10',
+      hasChamber: true,
+      nit: '900123456',
+    })
+
+    expect(result.company.id).toBe('900123456')
+    expect(result.company.razonSocial).toBe('Casa Bambú')
+    expect(result.company.ciiu).toBe('5611')
+    expect(result.classification.ciiuTitulo).toBe('Expendio a la mesa')
+    expect(result.classification.reasoning).toBe('restaurante')
+    expect(result.clusters).toEqual([
+      {
+        id: 'gastro',
+        codigo: 'GASTRO',
+        titulo: 'Gastronomía',
+        tipo: 'predefined',
+        descripcion: null,
+      },
+    ])
+    expect(result.recommendations).toEqual({
+      proveedor: [],
+      cliente: [],
+      aliado: [],
+      referente: [],
+    })
+  })
+
+  it('throws BadRequestException when required fields are missing', async () => {
+    await expect(
+      controller.onboard({
+        userId: '',
+        description: 'Restaurante',
+        businessName: 'Casa Bambú',
+        municipio: 'SANTA MARTA',
+      }),
+    ).rejects.toThrow(BadRequestException)
+
+    await expect(
+      controller.onboard({
+        userId: 'u-1',
+        description: '   ',
+        businessName: 'Casa Bambú',
+        municipio: 'SANTA MARTA',
+      }),
+    ).rejects.toThrow(BadRequestException)
+  })
+
+  it('rejects invalid yearsOfOperation values', async () => {
+    await expect(
+      controller.onboard({
+        userId: 'u-1',
+        description: 'Restaurante',
+        businessName: 'Casa Bambú',
+        municipio: 'SANTA MARTA',
+        yearsOfOperation: 'forever' as never,
+      }),
+    ).rejects.toThrow(BadRequestException)
+  })
+})

--- a/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
+++ b/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
+import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
+import { InMemoryClusterCiiuMappingRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterCiiuMappingRepository'
+import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterMembershipRepository'
+import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
+import { Company } from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
+import { OnboardCompanyFromSignup } from '@/companies/application/use-cases/OnboardCompanyFromSignup'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+
+class FixedGemini implements GeminiPort {
+  constructor(private readonly response: unknown) {}
+  async generateText() {
+    return JSON.stringify(this.response)
+  }
+  async inferStructured<T>(
+    _prompt: string,
+    validate: (raw: unknown) => T,
+  ): Promise<T> {
+    return validate(this.response)
+  }
+}
+
+const restaurantActivity = CiiuActivity.create({
+  code: '5611',
+  titulo: 'Expendio a la mesa de comidas preparadas',
+  seccion: 'I',
+  division: '56',
+  grupo: '561',
+  tituloSeccion: 'Alojamiento y servicios de comida',
+  tituloDivision: 'Servicios de comidas y bebidas',
+  tituloGrupo: 'Restaurantes',
+  macroSector: 'Servicios',
+})
+
+const gastronomiaCluster = Cluster.create({
+  id: 'cluster-gastronomia',
+  codigo: 'GASTRO',
+  titulo: 'Gastronomía Caribe',
+  descripcion: 'Restaurantes y servicios de comida del Caribe',
+  tipo: 'predefined',
+  memberCount: 0,
+})
+
+const turismoCluster = Cluster.create({
+  id: 'cluster-turismo',
+  codigo: 'TUR',
+  titulo: 'Turismo y experiencias',
+  tipo: 'predefined',
+  memberCount: 0,
+})
+
+function buildFixtures() {
+  const taxonomy = new InMemoryCiiuTaxonomyRepository([restaurantActivity])
+  const companyRepo = new InMemoryCompanyRepository()
+  const clusterRepo = new InMemoryClusterRepository()
+  const ciiuMapping = new InMemoryClusterCiiuMappingRepository()
+  const membershipRepo = new InMemoryClusterMembershipRepository()
+  const recRepo = new InMemoryRecommendationRepository()
+  const gemini = new FixedGemini({
+    ciiuCode: '5611',
+    reasoning: 'Restaurante de comida del Caribe — clase 5611.',
+  })
+  const classify = new ClassifyCompanyFromDescription(gemini, taxonomy)
+  const featureBuilder = new FeatureVectorBuilder()
+
+  return {
+    taxonomy,
+    companyRepo,
+    clusterRepo,
+    ciiuMapping,
+    membershipRepo,
+    recRepo,
+    classify,
+    featureBuilder,
+  }
+}
+
+async function buildUseCase(
+  overrides: Partial<{
+    classify: ClassifyCompanyFromDescription
+  }> = {},
+) {
+  const f = buildFixtures()
+  await f.clusterRepo.saveMany([gastronomiaCluster, turismoCluster])
+  await f.ciiuMapping.saveMany([
+    { clusterId: 'cluster-gastronomia', ciiuCode: '5611' },
+    { clusterId: 'cluster-turismo', ciiuCode: '5611' },
+  ])
+  const useCase = new OnboardCompanyFromSignup(
+    overrides.classify ?? f.classify,
+    f.companyRepo,
+    f.clusterRepo,
+    f.ciiuMapping,
+    f.membershipRepo,
+    f.recRepo,
+    new PeerMatcher(f.featureBuilder),
+    new ValueChainMatcher(),
+    new AllianceMatcher(),
+  )
+  return { useCase, ...f }
+}
+
+describe('OnboardCompanyFromSignup', () => {
+  let fixtures: Awaited<ReturnType<typeof buildUseCase>>
+
+  beforeEach(async () => {
+    fixtures = await buildUseCase()
+  })
+
+  it('classifies, persists the company, and links clusters via CIIU mapping', async () => {
+    const result = await fixtures.useCase.execute({
+      userId: 'user-1',
+      description: 'Restaurante boutique en El Rodadero, comida del Caribe.',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: '5_10',
+      hasChamber: true,
+      nit: '900123456',
+    })
+
+    expect(result.company.ciiu).toBe('5611')
+    expect(result.company.razonSocial).toBe('Casa Bambú')
+    expect(result.company.municipio).toBe('SANTA MARTA')
+    expect(result.classification.reasoning).toContain('5611')
+    expect(result.classification.ciiuTitulo).toContain('Expendio a la mesa')
+    expect(result.clusters.map((c) => c.id).sort()).toEqual(
+      ['cluster-gastronomia', 'cluster-turismo'].sort(),
+    )
+
+    const stored = await fixtures.companyRepo.findById(result.company.id)
+    expect(stored).not.toBeNull()
+    const memberships = await fixtures.membershipRepo.findClusterIdsByCompany(
+      result.company.id,
+    )
+    expect(memberships.sort()).toEqual(
+      ['cluster-gastronomia', 'cluster-turismo'].sort(),
+    )
+  })
+
+  it('uses sanitized nit as company id when nit is provided', async () => {
+    const result = await fixtures.useCase.execute({
+      userId: 'user-1',
+      description: 'Restaurante',
+      businessName: 'Acme SAS',
+      municipio: 'SANTA MARTA',
+      nit: '900-123.456',
+    })
+    expect(result.company.id).toBe('900123456')
+  })
+
+  it('falls back to signup-{userId} when no nit is provided', async () => {
+    const result = await fixtures.useCase.execute({
+      userId: 'abc-uuid',
+      description: 'Restaurante',
+      businessName: 'Acme',
+      municipio: 'SANTA MARTA',
+    })
+    expect(result.company.id).toBe('signup-abc-uuid')
+  })
+
+  it('derives fechaMatricula and etapa from yearsOfOperation', async () => {
+    const newbie = await fixtures.useCase.execute({
+      userId: 'u-newbie',
+      description: 'Restaurante recién abierto',
+      businessName: 'Nuevo',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: 'menos_1',
+    })
+    expect(newbie.company.etapa).toBe('nacimiento')
+
+    const veteran = await fixtures.useCase.execute({
+      userId: 'u-vet',
+      description: 'Restaurante de toda la vida',
+      businessName: 'Vetera',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: 'mas_10',
+    })
+    expect(['consolidacion', 'madurez']).toContain(veteran.company.etapa)
+  })
+
+  it('generates recommendations linking the new company against the existing universe', async () => {
+    await fixtures.companyRepo.saveMany([
+      Company.create({
+        id: 'peer-1',
+        razonSocial: 'Restaurante existente',
+        ciiu: 'I5611',
+        municipio: 'SANTA MARTA',
+        fechaMatricula: new Date('2020-01-01'),
+        personal: 5,
+      }),
+      Company.create({
+        id: 'peer-2',
+        razonSocial: 'Otro restaurante',
+        ciiu: 'I5613',
+        municipio: 'SANTA MARTA',
+        fechaMatricula: new Date('2021-01-01'),
+        personal: 3,
+      }),
+    ])
+
+    const result = await fixtures.useCase.execute({
+      userId: 'u-1',
+      description: 'Restaurante',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: '3_5',
+    })
+
+    expect(result.recommendations.length).toBeGreaterThan(0)
+    for (const rec of result.recommendations) {
+      expect(rec.sourceCompanyId).toBe(result.company.id)
+    }
+
+    const persisted = await fixtures.recRepo.findBySource(result.company.id)
+    expect(persisted.length).toBe(result.recommendations.length)
+  })
+
+  it('does not crash when no clusters map to the classified CIIU', async () => {
+    const f = buildFixtures()
+    const useCase = new OnboardCompanyFromSignup(
+      f.classify,
+      f.companyRepo,
+      f.clusterRepo,
+      f.ciiuMapping,
+      f.membershipRepo,
+      f.recRepo,
+      new PeerMatcher(f.featureBuilder),
+      new ValueChainMatcher(),
+      new AllianceMatcher(),
+    )
+
+    const result = await useCase.execute({
+      userId: 'lonely',
+      description: 'Restaurante',
+      businessName: 'Solo',
+      municipio: 'SANTA MARTA',
+    })
+
+    expect(result.clusters).toEqual([])
+    const memberships = await f.membershipRepo.findClusterIdsByCompany(
+      result.company.id,
+    )
+    expect(memberships).toEqual([])
+  })
+
+  it('caps recommendations per relation type to avoid flooding', async () => {
+    const peers = Array.from({ length: 50 }, (_, i) =>
+      Company.create({
+        id: `peer-${i}`,
+        razonSocial: `Peer ${i}`,
+        ciiu: 'I5611',
+        municipio: 'SANTA MARTA',
+        fechaMatricula: new Date('2020-01-01'),
+        personal: 4,
+      }),
+    )
+    await fixtures.companyRepo.saveMany(peers)
+
+    const result = await fixtures.useCase.execute({
+      userId: 'u-many',
+      description: 'Restaurante',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+    })
+
+    const referentes = result.recommendations.filter(
+      (r) => r.relationType === 'referente',
+    )
+    expect(referentes.length).toBeLessThanOrEqual(10)
+  })
+})

--- a/src/brain/__tests__/recommendations/GetGroupedCompanyRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GetGroupedCompanyRecommendations.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { GetCompanyRecommendations } from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import { GetGroupedCompanyRecommendations } from '@/recommendations/application/use-cases/GetGroupedCompanyRecommendations'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c',
+    razonSocial: 'Acme',
+    ciiu: 'I5611',
+    municipio: 'SANTA MARTA',
+    ...overrides,
+  })
+
+const rec = (
+  id: string,
+  overrides: Partial<{
+    score: number
+    relationType: RelationType
+    targetCompanyId: string
+    sourceCompanyId: string
+  }> = {},
+): Recommendation =>
+  Recommendation.create({
+    id,
+    sourceCompanyId: overrides.sourceCompanyId ?? 'src',
+    targetCompanyId: overrides.targetCompanyId ?? 'tgt-1',
+    relationType: overrides.relationType ?? 'cliente',
+    score: overrides.score ?? 0.7,
+    reasons: Reasons.empty(),
+    source: 'rule',
+  })
+
+describe('GetGroupedCompanyRecommendations', () => {
+  let recRepo: InMemoryRecommendationRepository
+  let companyRepo: InMemoryCompanyRepository
+  let useCase: GetGroupedCompanyRecommendations
+
+  beforeEach(async () => {
+    recRepo = new InMemoryRecommendationRepository()
+    companyRepo = new InMemoryCompanyRepository()
+    useCase = new GetGroupedCompanyRecommendations(
+      new GetCompanyRecommendations(recRepo, companyRepo),
+    )
+
+    await companyRepo.saveMany([
+      company({ id: 'src' }),
+      company({ id: 'p1', razonSocial: 'Proveedor 1', ciiu: 'I5611' }),
+      company({ id: 'p2', razonSocial: 'Proveedor 2', ciiu: 'I5611' }),
+      company({ id: 'p3', razonSocial: 'Proveedor 3', ciiu: 'I5611' }),
+      company({ id: 'p4', razonSocial: 'Proveedor 4', ciiu: 'I5611' }),
+      company({ id: 'c1', razonSocial: 'Cliente 1', ciiu: 'G4711' }),
+      company({ id: 'c2', razonSocial: 'Cliente 2', ciiu: 'G4711' }),
+      company({ id: 'a1', razonSocial: 'Aliado 1', ciiu: 'I5611' }),
+      company({ id: 'r1', razonSocial: 'Referente 1', ciiu: 'I5611' }),
+      company({ id: 'r2', razonSocial: 'Referente 2', ciiu: 'I5611' }),
+      company({ id: 'r3', razonSocial: 'Referente 3', ciiu: 'I5611' }),
+    ])
+  })
+
+  it('returns recommendations grouped by relation type', async () => {
+    await recRepo.saveAll([
+      rec('rp1', {
+        targetCompanyId: 'p1',
+        relationType: 'proveedor',
+        score: 0.9,
+      }),
+      rec('rp2', {
+        targetCompanyId: 'p2',
+        relationType: 'proveedor',
+        score: 0.8,
+      }),
+      rec('rp3', {
+        targetCompanyId: 'p3',
+        relationType: 'proveedor',
+        score: 0.7,
+      }),
+      rec('rc1', {
+        targetCompanyId: 'c1',
+        relationType: 'cliente',
+        score: 0.95,
+      }),
+      rec('rc2', {
+        targetCompanyId: 'c2',
+        relationType: 'cliente',
+        score: 0.85,
+      }),
+      rec('ra1', {
+        targetCompanyId: 'a1',
+        relationType: 'aliado',
+        score: 0.6,
+      }),
+      rec('rr1', {
+        targetCompanyId: 'r1',
+        relationType: 'referente',
+        score: 0.5,
+      }),
+      rec('rr2', {
+        targetCompanyId: 'r2',
+        relationType: 'referente',
+        score: 0.4,
+      }),
+      rec('rr3', {
+        targetCompanyId: 'r3',
+        relationType: 'referente',
+        score: 0.3,
+      }),
+    ])
+
+    const result = await useCase.execute({ companyId: 'src' })
+
+    expect(result.proveedor.map((r) => r.id)).toEqual(['rp1', 'rp2', 'rp3'])
+    expect(result.cliente.map((r) => r.id)).toEqual(['rc1', 'rc2'])
+    expect(result.aliado.map((r) => r.id)).toEqual(['ra1'])
+    expect(result.referente.map((r) => r.id)).toEqual(['rr1', 'rr2', 'rr3'])
+  })
+
+  it('caps each relation type at 10 items', async () => {
+    const many = Array.from({ length: 15 }, (_, i) =>
+      rec(`rec-${i}`, {
+        targetCompanyId: `p${i}`,
+        relationType: 'proveedor',
+        score: 0.1 + i * 0.01,
+      }),
+    )
+    await companyRepo.saveMany(
+      Array.from({ length: 15 }, (_, i) =>
+        company({ id: `p${i}`, ciiu: 'I5611' }),
+      ),
+    )
+    await recRepo.saveAll(many)
+
+    const result = await useCase.execute({ companyId: 'src' })
+    expect(result.proveedor).toHaveLength(10)
+    expect(result.cliente).toHaveLength(0)
+  })
+
+  it('flags partial=true when any relation type has fewer than 3 recommendations', async () => {
+    await recRepo.saveAll([
+      rec('rp1', {
+        targetCompanyId: 'p1',
+        relationType: 'proveedor',
+        score: 0.9,
+      }),
+      rec('rp2', {
+        targetCompanyId: 'p2',
+        relationType: 'proveedor',
+        score: 0.8,
+      }),
+      rec('rp3', {
+        targetCompanyId: 'p3',
+        relationType: 'proveedor',
+        score: 0.7,
+      }),
+      rec('rc1', {
+        targetCompanyId: 'c1',
+        relationType: 'cliente',
+        score: 0.95,
+      }),
+    ])
+
+    const result = await useCase.execute({ companyId: 'src' })
+    expect(result.partial).toBe(true)
+    expect(result.cliente).toHaveLength(1)
+  })
+
+  it('flags partial=false when every relation type has at least 3', async () => {
+    const recs: Recommendation[] = []
+    const types: RelationType[] = [
+      'proveedor',
+      'cliente',
+      'aliado',
+      'referente',
+    ]
+    const targets: Record<RelationType, string[]> = {
+      proveedor: ['p1', 'p2', 'p3'],
+      cliente: ['c1', 'c2', 'r1'],
+      aliado: ['a1', 'r2', 'r3'],
+      referente: ['p4', 'p1', 'p2'],
+    }
+    for (const t of types) {
+      for (const tgt of targets[t]) {
+        recs.push(
+          rec(`${t}-${tgt}`, {
+            targetCompanyId: tgt,
+            relationType: t,
+            score: 0.5,
+          }),
+        )
+      }
+    }
+    await recRepo.saveAll(recs)
+
+    const result = await useCase.execute({ companyId: 'src' })
+    expect(result.partial).toBe(false)
+  })
+
+  it('returns empty arrays and partial=true when no recommendations exist', async () => {
+    const result = await useCase.execute({ companyId: 'unknown' })
+    expect(result.proveedor).toEqual([])
+    expect(result.cliente).toEqual([])
+    expect(result.aliado).toEqual([])
+    expect(result.referente).toEqual([])
+    expect(result.partial).toBe(true)
+  })
+})

--- a/src/brain/__tests__/recommendations/RecommendationsController.test.ts
+++ b/src/brain/__tests__/recommendations/RecommendationsController.test.ts
@@ -14,6 +14,7 @@ import { ValueChainMatcher } from '@/recommendations/application/services/ValueC
 import { ExplainRecommendation } from '@/recommendations/application/use-cases/ExplainRecommendation'
 import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
 import { GetCompanyRecommendations } from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import { GetGroupedCompanyRecommendations } from '@/recommendations/application/use-cases/GetGroupedCompanyRecommendations'
 import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
 import { Reasons } from '@/recommendations/domain/value-objects/Reason'
 import { CompanyRecommendationsController } from '@/recommendations/infrastructure/http/company-recommendations.controller'
@@ -69,12 +70,13 @@ function makeWiring() {
   )
   const explain = new ExplainRecommendation(recRepo, companyRepo, gemini)
   const get = new GetCompanyRecommendations(recRepo, companyRepo)
+  const grouped = new GetGroupedCompanyRecommendations(get)
   return {
     companyRepo,
     recRepo,
     gemini,
     controller: new RecommendationsController(generate, explain),
-    companyController: new CompanyRecommendationsController(get),
+    companyController: new CompanyRecommendationsController(get, grouped),
   }
 }
 
@@ -254,5 +256,57 @@ describe('CompanyRecommendationsController', () => {
 
     const invalid = await setup.companyController.list('src', undefined, 'oops')
     expect(invalid.recommendations.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('GET /:id/recommendations/grouped returns recs grouped by relation type with partial flag', async () => {
+    const setup = makeWiring()
+    await setup.companyRepo.saveMany([
+      Company.create({
+        id: 'src',
+        razonSocial: 'Acme',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'tgt-c',
+        razonSocial: 'Cliente',
+        ciiu: 'I5611',
+        municipio: 'SANTA MARTA',
+      }),
+      Company.create({
+        id: 'tgt-p',
+        razonSocial: 'Proveedor',
+        ciiu: 'A0122',
+        municipio: 'SANTA MARTA',
+      }),
+    ])
+    await setup.recRepo.saveAll([
+      Recommendation.create({
+        id: 'rc',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'tgt-c',
+        relationType: 'cliente',
+        score: 0.9,
+        reasons: Reasons.empty(),
+        source: 'rule',
+      }),
+      Recommendation.create({
+        id: 'rp',
+        sourceCompanyId: 'src',
+        targetCompanyId: 'tgt-p',
+        relationType: 'proveedor',
+        score: 0.8,
+        reasons: Reasons.empty(),
+        source: 'rule',
+      }),
+    ])
+
+    const result = await setup.companyController.grouped('src')
+
+    expect(result.cliente.map((r) => r.id)).toEqual(['rc'])
+    expect(result.proveedor.map((r) => r.id)).toEqual(['rp'])
+    expect(result.aliado).toEqual([])
+    expect(result.referente).toEqual([])
+    expect(result.partial).toBe(true)
   })
 })

--- a/src/brain/src/clusters/clusters.module.ts
+++ b/src/brain/src/clusters/clusters.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
 import { CompaniesModule } from '@/companies/companies.module'
 import { ExplainCluster } from './application/use-cases/ExplainCluster'
 import { GenerateClusters } from './application/use-cases/GenerateClusters'
@@ -16,7 +16,7 @@ import { SupabaseClusterRepository } from './infrastructure/repositories/Supabas
 import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
 
 @Module({
-  imports: [CiiuTaxonomyModule, CompaniesModule],
+  imports: [CiiuTaxonomyModule, forwardRef(() => CompaniesModule)],
   controllers: [ClustersController, CompanyClustersController],
   providers: [
     {

--- a/src/brain/src/companies/application/use-cases/ClassifyCompanyFromDescription.ts
+++ b/src/brain/src/companies/application/use-cases/ClassifyCompanyFromDescription.ts
@@ -1,0 +1,155 @@
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { z } from 'zod'
+import {
+  CIIU_TAXONOMY_REPOSITORY,
+  type CiiuTaxonomyRepository,
+} from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
+import { GEMINI_PORT } from '@/shared/shared.module'
+import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface ClassifyCompanyFromDescriptionInput {
+  description: string
+  businessName: string
+  municipio: string
+}
+
+export interface ClassifiedCiiu {
+  code: string
+  titulo: string
+  seccion: string
+  division: string
+  grupo: string
+  macroSector: string | null
+}
+
+export interface ClassifyCompanyFromDescriptionResult {
+  ciiu: ClassifiedCiiu
+  reasoning: string
+}
+
+const responseSchema = z.object({
+  ciiuCode: z
+    .string()
+    .trim()
+    .regex(/^\d{4}$/, 'ciiuCode must be a 4-digit string'),
+  reasoning: z.string().trim().min(1),
+})
+
+@Injectable()
+export class ClassifyCompanyFromDescription implements UseCase<
+  ClassifyCompanyFromDescriptionInput,
+  ClassifyCompanyFromDescriptionResult
+> {
+  private readonly logger = new Logger(ClassifyCompanyFromDescription.name)
+
+  constructor(
+    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+    @Inject(CIIU_TAXONOMY_REPOSITORY)
+    private readonly taxonomy: CiiuTaxonomyRepository,
+  ) {}
+
+  async execute(
+    input: ClassifyCompanyFromDescriptionInput,
+  ): Promise<ClassifyCompanyFromDescriptionResult> {
+    const description = input.description.trim()
+    if (description.length === 0) {
+      throw new Error('description cannot be empty')
+    }
+
+    const businessName = input.businessName.trim()
+    const municipio = input.municipio.trim()
+
+    const firstPrompt = buildPrompt({
+      description,
+      businessName,
+      municipio,
+    })
+    const first = await this.callGemini(firstPrompt)
+    const firstActivity = await this.taxonomy.findByCode(first.ciiuCode)
+    if (firstActivity) {
+      return toResult(firstActivity, first.reasoning)
+    }
+
+    this.logger.warn(
+      `Gemini returned unknown CIIU '${first.ciiuCode}' — retrying once`,
+    )
+    const retryPrompt = buildPrompt({
+      description,
+      businessName,
+      municipio,
+      previousInvalidCode: first.ciiuCode,
+    })
+    const retry = await this.callGemini(retryPrompt)
+    const retryActivity = await this.taxonomy.findByCode(retry.ciiuCode)
+    if (!retryActivity) {
+      throw new Error(
+        `Could not classify business: Gemini returned invalid CIIU codes (${first.ciiuCode}, ${retry.ciiuCode})`,
+      )
+    }
+    return toResult(retryActivity, retry.reasoning)
+  }
+
+  private async callGemini(
+    prompt: string,
+  ): Promise<z.infer<typeof responseSchema>> {
+    return this.gemini.inferStructured(prompt, (raw) =>
+      responseSchema.parse(raw),
+    )
+  }
+}
+
+function toResult(
+  activity: {
+    code: string
+    titulo: string
+    seccion: string
+    division: string
+    grupo: string
+    macroSector: string | null
+  },
+  reasoning: string,
+): ClassifyCompanyFromDescriptionResult {
+  return {
+    ciiu: {
+      code: activity.code,
+      titulo: activity.titulo,
+      seccion: activity.seccion,
+      division: activity.division,
+      grupo: activity.grupo,
+      macroSector: activity.macroSector,
+    },
+    reasoning,
+  }
+}
+
+interface PromptParams {
+  description: string
+  businessName: string
+  municipio: string
+  previousInvalidCode?: string
+}
+
+function buildPrompt(params: PromptParams): string {
+  const retryNote = params.previousInvalidCode
+    ? `\nIMPORTANTE: el código '${params.previousInvalidCode}' que sugeriste antes NO existe en la taxonomía CIIU 4 dígitos del DANE. Volvé a clasificar con un código válido distinto.`
+    : ''
+
+  return `Sos un experto en clasificación CIIU (Clasificación Industrial Internacional Uniforme) versión 4 adaptada por el DANE de Colombia.
+Tu tarea: dado el negocio descrito abajo, devolver el CÓDIGO CIIU de 4 dígitos que mejor lo representa.
+
+Negocio: "${params.businessName}"
+Municipio: ${params.municipio}
+Descripción: ${params.description}${retryNote}
+
+Reglas:
+- Devolvé SOLO un objeto JSON válido, sin markdown ni texto extra.
+- "ciiuCode": exactamente 4 dígitos (sin la letra de sección).
+- "reasoning": una frase breve en español explicando por qué ese código encaja, basada en la descripción.
+
+Formato de respuesta (JSON):
+{
+  "ciiuCode": "5611",
+  "reasoning": "..."
+}`
+}

--- a/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
+++ b/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
@@ -1,0 +1,229 @@
+import { Inject, Injectable, Logger } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import {
+  CLUSTER_CIIU_MAPPING_REPOSITORY,
+  type ClusterCiiuMappingRepository,
+} from '@/clusters/domain/repositories/ClusterCiiuMappingRepository'
+import {
+  CLUSTER_MEMBERSHIP_REPOSITORY,
+  type ClusterMembershipRepository,
+  type Membership,
+} from '@/clusters/domain/repositories/ClusterMembershipRepository'
+import {
+  CLUSTER_REPOSITORY,
+  type ClusterRepository,
+} from '@/clusters/domain/repositories/ClusterRepository'
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import { Company } from '@/companies/domain/entities/Company'
+import {
+  COMPANY_REPOSITORY,
+  type CompanyRepository,
+} from '@/companies/domain/repositories/CompanyRepository'
+import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
+import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
+import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import {
+  RECOMMENDATION_REPOSITORY,
+  type RecommendationRepository,
+} from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export type YearsOfOperation = 'menos_1' | '1_3' | '3_5' | '5_10' | 'mas_10'
+
+export interface OnboardCompanyFromSignupInput {
+  userId: string
+  description: string
+  businessName: string
+  municipio: string
+  yearsOfOperation?: YearsOfOperation | null
+  hasChamber?: boolean
+  nit?: string | null
+}
+
+export interface OnboardCompanyFromSignupResult {
+  company: Company
+  classification: { ciiuTitulo: string; reasoning: string }
+  clusters: Cluster[]
+  recommendations: Recommendation[]
+}
+
+const TOP_PER_TYPE = 10
+
+@Injectable()
+export class OnboardCompanyFromSignup implements UseCase<
+  OnboardCompanyFromSignupInput,
+  OnboardCompanyFromSignupResult
+> {
+  private readonly logger = new Logger(OnboardCompanyFromSignup.name)
+
+  constructor(
+    private readonly classify: ClassifyCompanyFromDescription,
+    @Inject(COMPANY_REPOSITORY)
+    private readonly companyRepo: CompanyRepository,
+    @Inject(CLUSTER_REPOSITORY)
+    private readonly clusterRepo: ClusterRepository,
+    @Inject(CLUSTER_CIIU_MAPPING_REPOSITORY)
+    private readonly ciiuMappingRepo: ClusterCiiuMappingRepository,
+    @Inject(CLUSTER_MEMBERSHIP_REPOSITORY)
+    private readonly membershipRepo: ClusterMembershipRepository,
+    @Inject(RECOMMENDATION_REPOSITORY)
+    private readonly recRepo: RecommendationRepository,
+    private readonly peer: PeerMatcher,
+    private readonly valueChain: ValueChainMatcher,
+    private readonly alliance: AllianceMatcher,
+  ) {}
+
+  async execute(
+    input: OnboardCompanyFromSignupInput,
+  ): Promise<OnboardCompanyFromSignupResult> {
+    const classification = await this.classify.execute({
+      description: input.description,
+      businessName: input.businessName,
+      municipio: input.municipio,
+    })
+
+    const companyId = resolveCompanyId(input)
+    const fechaMatricula = derivedFechaMatricula(input.yearsOfOperation)
+    const company = Company.create({
+      id: companyId,
+      razonSocial: input.businessName,
+      ciiu: `${classification.ciiu.seccion}${classification.ciiu.code}`,
+      municipio: input.municipio,
+      fechaMatricula,
+      estado: 'ACTIVO',
+    })
+    await this.companyRepo.saveMany([company])
+
+    const clusters = await this.resolveClusters(classification.ciiu.code)
+    if (clusters.length > 0) {
+      const memberships: Membership[] = clusters.map((c) => ({
+        clusterId: c.id,
+        companyId: company.id,
+      }))
+      await this.membershipRepo.saveMany(memberships)
+    }
+
+    const recommendations = await this.generateRecommendations(company)
+    if (recommendations.length > 0) {
+      await this.recRepo.saveAll(recommendations)
+    }
+
+    this.logger.log(
+      `Onboarded ${company.id} ciiu=${company.ciiu} clusters=${clusters.length} recs=${recommendations.length}`,
+    )
+
+    return {
+      company,
+      classification: {
+        ciiuTitulo: classification.ciiu.titulo,
+        reasoning: classification.reasoning,
+      },
+      clusters,
+      recommendations,
+    }
+  }
+
+  private async resolveClusters(ciiuCode: string): Promise<Cluster[]> {
+    const ciiuToClusters = await this.ciiuMappingRepo.getCiiuToClusterMap()
+    const clusterIds = ciiuToClusters.get(ciiuCode) ?? []
+    if (clusterIds.length === 0) return []
+    return this.clusterRepo.findManyByIds(clusterIds)
+  }
+
+  private async generateRecommendations(
+    newCompany: Company,
+  ): Promise<Recommendation[]> {
+    const universe = await this.companyRepo.findAll()
+    const activeUniverse = universe.filter((c) => c.isActive)
+    if (activeUniverse.length <= 1) return []
+
+    const peerRecs = this.peer.match(activeUniverse, { topN: 20 })
+    const valueChainRecs = this.valueChain.match(activeUniverse)
+    const allianceRecs = this.alliance.match(activeUniverse)
+
+    const fromNew = mergeFromSource(newCompany.id, [
+      peerRecs,
+      valueChainRecs,
+      allianceRecs,
+    ])
+    const deduped = dedupeByTargetAndType(fromNew)
+    const capped = capPerType(deduped, TOP_PER_TYPE)
+    return capped.map((r) =>
+      Recommendation.create({
+        id: randomUUID(),
+        sourceCompanyId: r.sourceCompanyId,
+        targetCompanyId: r.targetCompanyId,
+        relationType: r.relationType,
+        score: r.score,
+        reasons: r.reasons,
+        source: r.source,
+      }),
+    )
+  }
+}
+
+function resolveCompanyId(input: OnboardCompanyFromSignupInput): string {
+  if (input.nit && input.nit.trim().length > 0) {
+    const sanitized = input.nit.replace(/[^0-9]/g, '')
+    if (sanitized.length > 0) return sanitized
+  }
+  return `signup-${input.userId}`
+}
+
+function derivedFechaMatricula(
+  years: YearsOfOperation | null | undefined,
+): Date | null {
+  if (!years) return null
+  const now = new Date()
+  const monthsBack: Record<YearsOfOperation, number> = {
+    menos_1: 6,
+    '1_3': 24,
+    '3_5': 48,
+    '5_10': 84,
+    mas_10: 144,
+  }
+  const date = new Date(now)
+  date.setMonth(date.getMonth() - monthsBack[years])
+  return date
+}
+
+function mergeFromSource(
+  sourceId: string,
+  maps: Map<string, Recommendation[]>[],
+): Recommendation[] {
+  const out: Recommendation[] = []
+  for (const map of maps) {
+    const recs = map.get(sourceId) ?? []
+    out.push(...recs)
+  }
+  return out
+}
+
+function dedupeByTargetAndType(recs: Recommendation[]): Recommendation[] {
+  const byKey = new Map<string, Recommendation>()
+  for (const rec of recs) {
+    const key = `${rec.targetCompanyId}|${rec.relationType}`
+    const existing = byKey.get(key)
+    if (!existing || rec.score > existing.score) {
+      byKey.set(key, rec)
+    }
+  }
+  return Array.from(byKey.values())
+}
+
+function capPerType(recs: Recommendation[], perType: number): Recommendation[] {
+  const sorted = [...recs].sort((a, b) => b.score - a.score)
+  const counts = new Map<RelationType, number>()
+  const out: Recommendation[] = []
+  for (const rec of sorted) {
+    const c = counts.get(rec.relationType) ?? 0
+    if (c < perType) {
+      out.push(rec)
+      counts.set(rec.relationType, c + 1)
+    }
+  }
+  return out
+}

--- a/src/brain/src/companies/companies.module.ts
+++ b/src/brain/src/companies/companies.module.ts
@@ -1,16 +1,27 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
+import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
+import { ClustersModule } from '@/clusters/clusters.module'
+import { RecommendationsModule } from '@/recommendations/recommendations.module'
+import { ClassifyCompanyFromDescription } from './application/use-cases/ClassifyCompanyFromDescription'
 import { FindCompanyById } from './application/use-cases/FindCompanyById'
 import { GetCompanies } from './application/use-cases/GetCompanies'
 import { GetCompaniesUpdatedSince } from './application/use-cases/GetCompaniesUpdatedSince'
+import { OnboardCompanyFromSignup } from './application/use-cases/OnboardCompanyFromSignup'
 import { SyncCompaniesFromSource } from './application/use-cases/SyncCompaniesFromSource'
 import { COMPANY_REPOSITORY } from './domain/repositories/CompanyRepository'
 import { COMPANY_SOURCE } from './domain/sources/CompanySource'
 import { CompaniesController } from './infrastructure/http/companies.controller'
+import { CompanyOnboardingController } from './infrastructure/http/company-onboarding.controller'
 import { SupabaseCompanyRepository } from './infrastructure/repositories/SupabaseCompanyRepository'
 import { CsvCompanySource } from './infrastructure/sources/CsvCompanySource'
 
 @Module({
-  controllers: [CompaniesController],
+  imports: [
+    CiiuTaxonomyModule,
+    forwardRef(() => ClustersModule),
+    forwardRef(() => RecommendationsModule),
+  ],
+  controllers: [CompaniesController, CompanyOnboardingController],
   providers: [
     {
       provide: COMPANY_REPOSITORY,
@@ -25,6 +36,8 @@ import { CsvCompanySource } from './infrastructure/sources/CsvCompanySource'
     FindCompanyById,
     GetCompaniesUpdatedSince,
     SyncCompaniesFromSource,
+    ClassifyCompanyFromDescription,
+    OnboardCompanyFromSignup,
   ],
   exports: [
     COMPANY_REPOSITORY,
@@ -33,6 +46,8 @@ import { CsvCompanySource } from './infrastructure/sources/CsvCompanySource'
     FindCompanyById,
     GetCompaniesUpdatedSince,
     SyncCompaniesFromSource,
+    ClassifyCompanyFromDescription,
+    OnboardCompanyFromSignup,
   ],
 })
 export class CompaniesModule {}

--- a/src/brain/src/companies/infrastructure/http/company-onboarding.controller.ts
+++ b/src/brain/src/companies/infrastructure/http/company-onboarding.controller.ts
@@ -1,0 +1,144 @@
+import { BadRequestException, Body, Controller, Post } from '@nestjs/common'
+import { ApiOperation, ApiTags } from '@nestjs/swagger'
+import { z } from 'zod'
+import {
+  OnboardCompanyFromSignup,
+  type YearsOfOperation,
+} from '@/companies/application/use-cases/OnboardCompanyFromSignup'
+import type { Company } from '@/companies/domain/entities/Company'
+import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import {
+  RELATION_TYPES,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+
+const yearsValues: [YearsOfOperation, ...YearsOfOperation[]] = [
+  'menos_1',
+  '1_3',
+  '3_5',
+  '5_10',
+  'mas_10',
+]
+
+const onboardBodySchema = z.object({
+  userId: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+  businessName: z.string().trim().min(1),
+  municipio: z.string().trim().min(1),
+  yearsOfOperation: z.enum(yearsValues).optional().nullable(),
+  hasChamber: z.boolean().optional(),
+  nit: z.string().trim().optional().nullable(),
+})
+
+interface CompanyDto {
+  id: string
+  razonSocial: string
+  ciiu: string
+  ciiuSeccion: string
+  ciiuDivision: string
+  municipio: string
+  etapa: string
+}
+
+interface ClusterDto {
+  id: string
+  codigo: string
+  titulo: string
+  tipo: string
+  descripcion: string | null
+}
+
+interface RecommendationDto {
+  id: string
+  targetCompanyId: string
+  score: number
+  relationType: RelationType
+  reasons: ReturnType<Recommendation['reasons']['toJson']>
+}
+
+interface OnboardResponse {
+  company: CompanyDto
+  classification: { ciiuTitulo: string; reasoning: string }
+  clusters: ClusterDto[]
+  recommendations: Record<RelationType, RecommendationDto[]>
+}
+
+@ApiTags('companies')
+@Controller('companies')
+export class CompanyOnboardingController {
+  constructor(private readonly onboardUseCase: OnboardCompanyFromSignup) {}
+
+  @Post('onboard')
+  @ApiOperation({
+    summary: 'Classify a business from its description and persist it',
+  })
+  async onboard(@Body() body: unknown): Promise<OnboardResponse> {
+    const parsed = onboardBodySchema.safeParse(body)
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.message)
+    }
+    const result = await this.onboardUseCase.execute({
+      userId: parsed.data.userId,
+      description: parsed.data.description,
+      businessName: parsed.data.businessName,
+      municipio: parsed.data.municipio,
+      yearsOfOperation: parsed.data.yearsOfOperation ?? null,
+      hasChamber: parsed.data.hasChamber,
+      nit: parsed.data.nit,
+    })
+
+    return {
+      company: toCompanyDto(result.company),
+      classification: result.classification,
+      clusters: result.clusters.map(toClusterDto),
+      recommendations: groupRecs(result.recommendations),
+    }
+  }
+}
+
+function toCompanyDto(c: Company): CompanyDto {
+  return {
+    id: c.id,
+    razonSocial: c.razonSocial,
+    ciiu: c.ciiu,
+    ciiuSeccion: c.ciiuSeccion,
+    ciiuDivision: c.ciiuDivision,
+    municipio: c.municipio,
+    etapa: c.etapa,
+  }
+}
+
+function toClusterDto(c: Cluster): ClusterDto {
+  return {
+    id: c.id,
+    codigo: c.codigo,
+    titulo: c.titulo,
+    tipo: c.tipo,
+    descripcion: c.descripcion,
+  }
+}
+
+function groupRecs(
+  recs: Recommendation[],
+): Record<RelationType, RecommendationDto[]> {
+  const out: Record<RelationType, RecommendationDto[]> = {
+    proveedor: [],
+    cliente: [],
+    aliado: [],
+    referente: [],
+  }
+  for (const rec of recs) {
+    out[rec.relationType].push({
+      id: rec.id,
+      targetCompanyId: rec.targetCompanyId,
+      score: rec.score,
+      relationType: rec.relationType,
+      reasons: rec.reasons.toJson(),
+    })
+  }
+  for (const t of RELATION_TYPES) {
+    out[t].sort((a, b) => b.score - a.score)
+  }
+  return out
+}

--- a/src/brain/src/recommendations/application/use-cases/GetGroupedCompanyRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GetGroupedCompanyRecommendations.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common'
+import {
+  GetCompanyRecommendations,
+  type RecommendationView,
+} from '@/recommendations/application/use-cases/GetCompanyRecommendations'
+import {
+  RELATION_TYPES,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+import type { UseCase } from '@/shared/domain/UseCase'
+
+export interface GetGroupedCompanyRecommendationsInput {
+  companyId: string
+}
+
+export type GroupedRecommendations = Record<RelationType, RecommendationView[]>
+
+export interface GetGroupedCompanyRecommendationsResult extends GroupedRecommendations {
+  partial: boolean
+}
+
+const PER_TYPE_LIMIT = 10
+const PER_TYPE_MIN = 3
+
+@Injectable()
+export class GetGroupedCompanyRecommendations implements UseCase<
+  GetGroupedCompanyRecommendationsInput,
+  GetGroupedCompanyRecommendationsResult
+> {
+  constructor(private readonly getRecommendations: GetCompanyRecommendations) {}
+
+  async execute(
+    input: GetGroupedCompanyRecommendationsInput,
+  ): Promise<GetGroupedCompanyRecommendationsResult> {
+    const entries = await Promise.all(
+      RELATION_TYPES.map(async (type) => {
+        const result = await this.getRecommendations.execute({
+          companyId: input.companyId,
+          type,
+          limit: PER_TYPE_LIMIT,
+        })
+        return [type, result.recommendations] as const
+      }),
+    )
+
+    const grouped: GroupedRecommendations = {
+      proveedor: [],
+      cliente: [],
+      aliado: [],
+      referente: [],
+    }
+    for (const [type, recs] of entries) {
+      grouped[type] = recs
+    }
+
+    const partial = RELATION_TYPES.some(
+      (type) => grouped[type].length < PER_TYPE_MIN,
+    )
+
+    return { ...grouped, partial }
+  }
+}

--- a/src/brain/src/recommendations/infrastructure/http/company-recommendations.controller.ts
+++ b/src/brain/src/recommendations/infrastructure/http/company-recommendations.controller.ts
@@ -5,6 +5,10 @@ import {
   type GetCompanyRecommendationsResult,
 } from '@/recommendations/application/use-cases/GetCompanyRecommendations'
 import {
+  GetGroupedCompanyRecommendations,
+  type GetGroupedCompanyRecommendationsResult,
+} from '@/recommendations/application/use-cases/GetGroupedCompanyRecommendations'
+import {
   isRelationType,
   type RelationType,
 } from '@/recommendations/domain/value-objects/RelationType'
@@ -14,7 +18,18 @@ import {
 export class CompanyRecommendationsController {
   constructor(
     private readonly getCompanyRecommendations: GetCompanyRecommendations,
+    private readonly getGroupedCompanyRecommendations: GetGroupedCompanyRecommendations,
   ) {}
+
+  @Get(':id/recommendations/grouped')
+  @ApiOperation({
+    summary: 'Recommendations for a company grouped by relation type',
+  })
+  async grouped(
+    @Param('id') id: string,
+  ): Promise<GetGroupedCompanyRecommendationsResult> {
+    return this.getGroupedCompanyRecommendations.execute({ companyId: id })
+  }
 
   @Get(':id/recommendations')
   @ApiOperation({ summary: 'List recommendations for a given company' })

--- a/src/brain/src/recommendations/recommendations.module.ts
+++ b/src/brain/src/recommendations/recommendations.module.ts
@@ -11,6 +11,7 @@ import { ValueChainMatcher } from './application/services/ValueChainMatcher'
 import { ExplainRecommendation } from './application/use-cases/ExplainRecommendation'
 import { GenerateRecommendations } from './application/use-cases/GenerateRecommendations'
 import { GetCompanyRecommendations } from './application/use-cases/GetCompanyRecommendations'
+import { GetGroupedCompanyRecommendations } from './application/use-cases/GetGroupedCompanyRecommendations'
 import { AI_MATCH_CACHE_REPOSITORY } from './domain/repositories/AiMatchCacheRepository'
 import { RECOMMENDATION_REPOSITORY } from './domain/repositories/RecommendationRepository'
 import { CompanyRecommendationsController } from './infrastructure/http/company-recommendations.controller'
@@ -39,6 +40,7 @@ import { SupabaseRecommendationRepository } from './infrastructure/repositories/
     ValueChainMatcher,
     GenerateRecommendations,
     GetCompanyRecommendations,
+    GetGroupedCompanyRecommendations,
     ExplainRecommendation,
   ],
   exports: [
@@ -46,6 +48,7 @@ import { SupabaseRecommendationRepository } from './infrastructure/repositories/
     AI_MATCH_CACHE_REPOSITORY,
     GenerateRecommendations,
     GetCompanyRecommendations,
+    GetGroupedCompanyRecommendations,
     ExplainRecommendation,
   ],
 })

--- a/src/brain/src/recommendations/recommendations.module.ts
+++ b/src/brain/src/recommendations/recommendations.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, forwardRef } from '@nestjs/common'
 import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
 import { CompaniesModule } from '@/companies/companies.module'
 import { AiMatchEngine } from './application/services/AiMatchEngine'
@@ -19,7 +19,7 @@ import { SupabaseAiMatchCacheRepository } from './infrastructure/repositories/Su
 import { SupabaseRecommendationRepository } from './infrastructure/repositories/SupabaseRecommendationRepository'
 
 @Module({
-  imports: [CiiuTaxonomyModule, CompaniesModule],
+  imports: [CiiuTaxonomyModule, forwardRef(() => CompaniesModule)],
   controllers: [RecommendationsController, CompanyRecommendationsController],
   providers: [
     {

--- a/src/front/__tests__/core/app/api/auth/register/route.test.ts
+++ b/src/front/__tests__/core/app/api/auth/register/route.test.ts
@@ -8,6 +8,23 @@ vi.mock('@/core/shared/infrastructure/env', () => ({
   env: {
     SUPABASE_URL: 'https://test.supabase.co',
     SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test',
+    BRAIN_API_URL: 'http://localhost:3001',
+  },
+}))
+
+// Mock brain client — never hit the real backend during tests
+const mockBrainPost = vi.fn()
+const mockBrainGet = vi.fn()
+vi.mock('@/core/shared/infrastructure/brain/brainClient', () => ({
+  brainClient: { post: mockBrainPost, get: mockBrainGet },
+  BrainHttpError: class BrainHttpError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly body: unknown,
+      message: string,
+    ) {
+      super(message)
+    }
   },
 }))
 
@@ -29,6 +46,8 @@ const mockInsert = vi.fn()
 const mockSelect = vi.fn()
 const mockSingle = vi.fn()
 const mockFrom = vi.fn()
+const mockUpdate = vi.fn()
+const mockEq = vi.fn()
 
 vi.mock('@/core/shared/infrastructure/supabase/server', () => {
   return {
@@ -93,8 +112,33 @@ describe('POST /api/auth/register', () => {
       select: mockSelect,
     })
 
+    mockEq.mockResolvedValue({ data: null, error: null })
+    mockUpdate.mockReturnValue({ eq: mockEq })
+
     mockFrom.mockReturnValue({
       insert: mockInsert,
+      update: mockUpdate,
+    })
+
+    // Default brain onboarding response (success). Tests can override.
+    mockBrainPost.mockResolvedValue({
+      company: {
+        id: 'co-user-123',
+        razonSocial: 'Test Business',
+        ciiu: '4711',
+        ciiuSeccion: 'G',
+        ciiuDivision: '47',
+        municipio: 'Santa Marta',
+        etapa: 'crecimiento',
+      },
+      classification: { ciiuTitulo: 'Comercio', reasoning: 'tienda' },
+      clusters: [],
+      recommendations: {
+        proveedor: [],
+        cliente: [],
+        aliado: [],
+        referente: [],
+      },
     })
   })
 
@@ -110,6 +154,7 @@ describe('POST /api/auth/register', () => {
           municipio: 'Santa Marta',
           barrio: 'Centro',
           hasChamber: false,
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -138,6 +183,7 @@ describe('POST /api/auth/register', () => {
           yearsOfOperation: '5_10',
           nit: '123456789',
           whatsapp: '+573001234567',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -170,6 +216,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -193,6 +240,7 @@ describe('POST /api/auth/register', () => {
           yearsOfOperation: null,
           nit: null,
           whatsapp: null,
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -219,6 +267,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -238,6 +287,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -257,6 +307,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -276,6 +327,7 @@ describe('POST /api/auth/register', () => {
           email: 'test@example.com',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -334,6 +386,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -354,6 +407,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -374,6 +428,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -394,6 +449,7 @@ describe('POST /api/auth/register', () => {
           password: 'Short1',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -414,6 +470,7 @@ describe('POST /api/auth/register', () => {
           password: 'testpass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -434,6 +491,7 @@ describe('POST /api/auth/register', () => {
           password: 'TESTPASS123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -454,6 +512,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPassword',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -481,6 +540,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -506,6 +566,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -531,6 +592,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -556,6 +618,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -581,6 +644,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -602,6 +666,7 @@ describe('POST /api/auth/register', () => {
           municipio: 'Santa Marta',
           barrio: 'Centro',
           whatsapp: '',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -633,6 +698,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -654,6 +720,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -672,6 +739,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -691,6 +759,7 @@ describe('POST /api/auth/register', () => {
           municipio: 'Santa Marta',
           barrio: 'Centro',
           hasChamber: 'true', // string instead of boolean
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -711,6 +780,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -775,6 +845,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -793,6 +864,7 @@ describe('POST /api/auth/register', () => {
           password: 'TestPass123',
           municipio: 'Santa Marta',
           barrio: 'Centro',
+          descripcion: 'Negocio de prueba que vende productos a clientes',
         }),
       })
 
@@ -803,6 +875,163 @@ describe('POST /api/auth/register', () => {
           id: 'user-123',
         }),
       )
+    })
+  })
+
+  describe('Brain Onboarding Integration', () => {
+    function validBody(overrides: Record<string, unknown> = {}) {
+      return JSON.stringify({
+        businessName: 'Casa Bambú',
+        sector: 'gastronomia',
+        email: 'casa@example.com',
+        password: 'TestPass123',
+        municipio: 'Santa Marta',
+        barrio: 'Centro',
+        hasChamber: false,
+        descripcion: 'Restaurante boutique en El Rodadero, comida del Caribe',
+        ...overrides,
+      })
+    }
+
+    it('rejects descripcion shorter than 10 characters', async () => {
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody({ descripcion: 'corto' }),
+      })
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+      const data = await response.json()
+      expect(data.error).toMatch(/descripcion/i)
+    })
+
+    it('rejects descripcion longer than 280 characters', async () => {
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody({ descripcion: 'x'.repeat(281) }),
+      })
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects missing descripcion', async () => {
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          businessName: 'X',
+          sector: 'comercio',
+          email: 'x@y.com',
+          password: 'TestPass123',
+          municipio: 'Santa Marta',
+          barrio: 'Centro',
+        }),
+      })
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+    })
+
+    it('forwards descripcion to the brain onboarding endpoint', async () => {
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody({
+          yearsOfOperation: '5_10',
+          nit: '900-123.456',
+        }),
+      })
+      await POST(request)
+
+      expect(mockBrainPost).toHaveBeenCalledWith(
+        '/api/companies/onboard',
+        expect.objectContaining({
+          userId: 'user-123',
+          description: 'Restaurante boutique en El Rodadero, comida del Caribe',
+          businessName: 'Casa Bambú',
+          municipio: 'Santa Marta',
+          yearsOfOperation: '5_10',
+          nit: '900-123.456',
+        }),
+      )
+    })
+
+    it('returns the brain onboarding payload alongside auth tokens', async () => {
+      const onboarding = {
+        company: {
+          id: '900123456',
+          razonSocial: 'Casa Bambú',
+          ciiu: '5611',
+          ciiuSeccion: 'I',
+          ciiuDivision: '56',
+          municipio: 'Santa Marta',
+          etapa: 'crecimiento',
+        },
+        classification: {
+          ciiuTitulo: 'Expendio a la mesa',
+          reasoning: 'restaurante boutique',
+        },
+        clusters: [
+          {
+            id: 'gastro',
+            codigo: 'GASTRO',
+            titulo: 'Gastronomía',
+            tipo: 'predefined',
+            descripcion: null,
+          },
+        ],
+        recommendations: {
+          proveedor: [],
+          cliente: [],
+          aliado: [],
+          referente: [],
+        },
+      }
+      mockBrainPost.mockResolvedValueOnce(onboarding)
+
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody(),
+      })
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(201)
+      expect(data.data.onboarding).toEqual(onboarding)
+    })
+
+    it('persists company_id back into the user row', async () => {
+      mockBrainPost.mockResolvedValueOnce({
+        company: { id: 'co-42' },
+        classification: { ciiuTitulo: 't', reasoning: 'r' },
+        clusters: [],
+        recommendations: {
+          proveedor: [],
+          cliente: [],
+          aliado: [],
+          referente: [],
+        },
+      })
+
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody(),
+      })
+      await POST(request)
+
+      expect(mockUpdate).toHaveBeenCalledWith({ company_id: 'co-42' })
+      expect(mockEq).toHaveBeenCalledWith('id', 'user-123')
+    })
+
+    it('still returns 201 when the brain is unreachable (best-effort onboarding)', async () => {
+      mockBrainPost.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: validBody(),
+      })
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(201)
+      expect(data.data.user.id).toBe('user-123')
+      expect(data.data.onboarding).toBeNull()
     })
   })
 })

--- a/src/front/__tests__/core/recommendations/brainToRecomendacion.test.ts
+++ b/src/front/__tests__/core/recommendations/brainToRecomendacion.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mapBrainGroupedToRecomendaciones,
+  mapBrainViewToRecomendacion,
+} from '@/core/recommendations/infrastructure/adapters/brainToRecomendacion'
+import type { BrainRecommendationView } from '@/core/shared/infrastructure/brain/brainClient'
+
+const targetCompany = {
+  id: 'co-42',
+  razonSocial: 'Doña Lucía Lavandería',
+  ciiu: '9601',
+  ciiuSeccion: 'S',
+  ciiuDivision: '96',
+  municipio: 'SANTA MARTA',
+  etapa: 'crecimiento',
+  personal: 3,
+  ingreso: 12_000_000,
+}
+
+const view = (
+  overrides: Partial<BrainRecommendationView> = {},
+): BrainRecommendationView => ({
+  id: 'r1',
+  targetCompany,
+  relationType: 'proveedor',
+  score: 0.9234,
+  reasons: [
+    {
+      feature: 'cadena_valor_directa',
+      weight: 0.7,
+      description: 'Lavandería sirve a hoteles boutique',
+    },
+  ],
+  source: 'rule',
+  explanation: null,
+  ...overrides,
+})
+
+describe('mapBrainViewToRecomendacion', () => {
+  it('maps target company into Actor and rounds score to 0–100', () => {
+    const result = mapBrainViewToRecomendacion(view())!
+    expect(result.id).toBe('r1')
+    expect(result.target.id).toBe('co-42')
+    expect(result.target.nombre).toBe('Doña Lucía Lavandería')
+    expect(result.target.iniciales).toBe('DL')
+    expect(result.target.barrio).toBe('SANTA MARTA')
+    expect(result.target.origen).toBe('formal')
+    expect(result.target.avatarColor).toMatch(/^bg-/)
+    expect(result.score).toBe(92)
+    expect(result.tipoRelacion).toBe('proveedor')
+    expect(result.estado).toBe('nueva')
+  })
+
+  it('uses explanation as razon when available', () => {
+    const result = mapBrainViewToRecomendacion(
+      view({ explanation: 'Tres hoteles cercanos ya trabajan con ellos.' }),
+    )!
+    expect(result.razon).toBe('Tres hoteles cercanos ya trabajan con ellos.')
+  })
+
+  it('joins reasons descriptions when explanation is null', () => {
+    const result = mapBrainViewToRecomendacion(
+      view({
+        reasons: [
+          { feature: 'a', weight: 0.5, description: 'Misma división CIIU' },
+          { feature: 'b', weight: 0.3, description: 'Mismo municipio' },
+        ],
+      }),
+    )!
+    expect(result.razon).toContain('Misma división CIIU')
+    expect(result.razon).toContain('Mismo municipio')
+  })
+
+  it('returns null when targetCompany is missing', () => {
+    expect(
+      mapBrainViewToRecomendacion(view({ targetCompany: null })),
+    ).toBeNull()
+  })
+
+  it('builds anclas (max 3) from the brain reasons', () => {
+    const result = mapBrainViewToRecomendacion(
+      view({
+        reasons: Array.from({ length: 5 }, (_, i) => ({
+          feature: `f${i}`,
+          weight: 0.1,
+          description: `desc-${i}`,
+        })),
+      }),
+    )!
+    expect(result.anclas).toHaveLength(3)
+  })
+
+  it('produces stable avatar color per company id', () => {
+    const a = mapBrainViewToRecomendacion(view())!
+    const b = mapBrainViewToRecomendacion(view())!
+    expect(a.target.avatarColor).toBe(b.target.avatarColor)
+  })
+})
+
+describe('mapBrainGroupedToRecomendaciones', () => {
+  it('flattens all relation types and drops null targets', () => {
+    const result = mapBrainGroupedToRecomendaciones({
+      proveedor: [view({ id: 'p1' })],
+      cliente: [view({ id: 'c1', relationType: 'cliente' })],
+      aliado: [],
+      referente: [view({ id: 'r1', targetCompany: null })],
+      partial: false,
+    })
+    expect(result.map((r) => r.id).sort()).toEqual(['c1', 'p1'])
+  })
+})

--- a/src/front/app/[locale]/_components/landing/landing-client.tsx
+++ b/src/front/app/[locale]/_components/landing/landing-client.tsx
@@ -5,9 +5,9 @@ import { useState } from 'react'
 import { RegistroWizard } from '../../registro/_components/registro-wizard'
 import { LandingValueProp } from './landing-value-prop'
 
-type Step = 1 | 2 | 3
+type Step = 1 | 2 | 3 | 4
 
-const TOTAL_STEPS = 3
+const TOTAL_STEPS = 4
 
 export function LandingClient() {
   const [step, setStep] = useState<Step>(1)

--- a/src/front/app/[locale]/_components/landing/landing-value-prop.tsx
+++ b/src/front/app/[locale]/_components/landing/landing-value-prop.tsx
@@ -3,7 +3,7 @@ import { BadgeCheck, Hand, Sparkles } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 type Props = {
-  currentStep: 1 | 2 | 3
+  currentStep: 1 | 2 | 3 | 4
   totalSteps: number
 }
 

--- a/src/front/app/[locale]/app/_components/reco-table.tsx
+++ b/src/front/app/[locale]/app/_components/reco-table.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 import { ArrowRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
+import { useRecomendaciones } from '@/core/recommendations/infrastructure/hooks/useRecomendaciones'
 import { mockRecomendaciones } from '../_data/mock-recomendaciones'
 import type { EstadoReco, Recomendacion, TipoRelacion } from '../_data/types'
 
@@ -18,18 +19,27 @@ const PAGE_SIZE = 8
 export function RecoTable() {
   const t = useTranslations('App.Recomendaciones')
 
+  const { data: live, isLoading } = useRecomendaciones()
+
   const [active, setActive] = useState<TabValue>('todas')
   const [showAll, setShowAll] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [overrides, setOverrides] = useState<Record<string, EstadoReco>>({})
 
+  // Use real data when available; fall back to mock so the UI still renders
+  // before the brain has finished onboarding the user's company.
+  const source: Recomendacion[] =
+    live && live.length > 0 ? live : mockRecomendaciones
+
   const data = useMemo(
     () =>
-      mockRecomendaciones.map((reco) =>
+      source.map((reco) =>
         overrides[reco.id] ? { ...reco, estado: overrides[reco.id]! } : reco,
       ),
-    [overrides],
+    [source, overrides],
   )
+
+  void isLoading
 
   const counts = useMemo(() => {
     const base: Record<TabValue, number> = {

--- a/src/front/app/[locale]/registro/_components/registro-wizard.tsx
+++ b/src/front/app/[locale]/registro/_components/registro-wizard.tsx
@@ -12,28 +12,40 @@ import { useTranslations } from 'next-intl'
 import type { z } from 'zod'
 
 import { useRouter } from '@/i18n/navigation'
+import { createSupabaseBrowserClient } from '@/core/shared/infrastructure/supabase/client'
 
 import { RegistroStepBusiness } from './registro-step-business'
 import { RegistroStepConfirm } from './registro-step-confirm'
 import { RegistroStepContact } from './registro-step-contact'
+import { RegistroStepPassword } from './registro-step-password'
 import {
   businessStepSchema,
   confirmStepSchema,
   contactStepSchema,
   emptyRegistroData,
+  passwordStepSchema,
 } from './schema'
 import type { RegistroDataPartial } from './schema'
 
 const REDIRECT_DELAY_MS = 1500
 const REDIRECT_TARGET = '/app/recomendaciones'
 
-type Step = 1 | 2 | 3
+type Step = 1 | 2 | 3 | 4
 type StepErrors = Record<string, string>
 
 const stepSchemas: Record<Step, z.ZodTypeAny> = {
   1: businessStepSchema,
   2: contactStepSchema,
   3: confirmStepSchema,
+  4: passwordStepSchema,
+}
+
+function normalizeWhatsapp(phone: string | undefined): string {
+  if (!phone) return ''
+  const cleaned = phone.replace(/\s/g, '')
+  if (cleaned.startsWith('+')) return cleaned
+  if (cleaned.startsWith('57')) return `+${cleaned}`
+  return `+57${cleaned}`
 }
 
 type Props = {
@@ -60,6 +72,7 @@ export function RegistroWizard({ step: stepProp, onStepChange }: Props = {}) {
   const [data, setData] = useState<RegistroDataPartial>(emptyRegistroData)
   const [errors, setErrors] = useState<StepErrors>({})
   const [submitted, setSubmitted] = useState(false)
+  const [apiError, setApiError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 
   function patchData(patch: RegistroDataPartial) {
@@ -91,20 +104,59 @@ export function RegistroWizard({ step: stepProp, onStepChange }: Props = {}) {
 
   function handleNext() {
     if (!validateCurrentStep()) return
-    if (step < 3) setStep((step + 1) as Step)
+    if (step < 4) setStep((step + 1) as Step)
   }
 
   function handleBack() {
     setErrors({})
+    setApiError(null)
     if (step > 1) setStep((step - 1) as Step)
   }
 
   function handleSubmit() {
     if (!validateCurrentStep()) return
-    startTransition(() => {
-      setTimeout(() => {
+
+    setApiError(null)
+    startTransition(async () => {
+      try {
+        const payload = {
+          businessName: data.nombre,
+          sector: data.sector,
+          yearsOfOperation: data.tiempoOperando,
+          municipio: data.municipio,
+          barrio: data.barrio,
+          hasChamber: data.registradoCamara,
+          nit: data.nit,
+          whatsapp: data.whatsapp
+            ? normalizeWhatsapp(data.whatsapp)
+            : undefined,
+          email: data.email,
+          password: data.password,
+          descripcion: data.descripcion,
+        }
+
+        const response = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+
+        if (!response.ok) {
+          const result = await response.json()
+          setApiError(result.error || 'Error al crear la cuenta')
+          return
+        }
+
+        const result = await response.json()
+        const supabase = createSupabaseBrowserClient()
+        await supabase.auth.setSession({
+          access_token: result.data.accessToken,
+          refresh_token: result.data.refreshToken,
+        })
         setSubmitted(true)
-      }, 800)
+      } catch (err) {
+        setApiError(err instanceof Error ? err.message : 'Error de conexión')
+      }
     })
   }
 
@@ -155,10 +207,23 @@ export function RegistroWizard({ step: stepProp, onStepChange }: Props = {}) {
           onChange={patchData}
           onEdit={(target) => {
             setErrors({})
-            setStep(target)
+            setStep(target as Step)
           }}
         />
       ) : null}
+      {step === 4 ? (
+        <RegistroStepPassword
+          data={data}
+          errors={errors}
+          onChange={patchData}
+        />
+      ) : null}
+
+      {apiError && (
+        <div className="bg-error/10 text-error mt-6 rounded-lg border border-red-200 p-3 text-sm">
+          {apiError}
+        </div>
+      )}
 
       <div className="border-border-soft mt-8 flex flex-col-reverse items-center justify-between gap-3 border-t pt-6 sm:flex-row">
         <button
@@ -171,7 +236,7 @@ export function RegistroWizard({ step: stepProp, onStepChange }: Props = {}) {
           {t('back')}
         </button>
 
-        {step < 3 ? (
+        {step < 4 ? (
           <button
             type="button"
             onClick={handleNext}

--- a/src/front/app/api/auth/register/route.ts
+++ b/src/front/app/api/auth/register/route.ts
@@ -1,6 +1,20 @@
+import {
+  brainClient,
+  BrainHttpError,
+  type BrainOnboardRequest,
+  type BrainOnboardResponse,
+} from '@/core/shared/infrastructure/brain/brainClient'
 import { serverLogger } from '@/core/shared/infrastructure/logger/serverLogger'
 import { createSupabaseServerClient } from '@/core/shared/infrastructure/supabase/server'
 import { User } from '@/core/users/domain/entities/User'
+
+const VALID_YEARS = new Set<BrainOnboardRequest['yearsOfOperation']>([
+  'menos_1',
+  '1_3',
+  '3_5',
+  '5_10',
+  'mas_10',
+])
 
 export async function POST(request: Request) {
   try {
@@ -17,6 +31,7 @@ export async function POST(request: Request) {
       whatsapp,
       email,
       password,
+      descripcion,
     } = body
 
     // Validate required fields
@@ -34,6 +49,17 @@ export async function POST(request: Request) {
         {
           error: 'municipio and barrio are required',
         },
+        { status: 400 },
+      )
+    }
+
+    if (
+      typeof descripcion !== 'string' ||
+      descripcion.trim().length < 10 ||
+      descripcion.trim().length > 280
+    ) {
+      return Response.json(
+        { error: 'descripcion must be between 10 and 280 characters' },
         { status: 400 },
       )
     }
@@ -62,7 +88,6 @@ export async function POST(request: Request) {
     const supabase = createSupabaseServerClient()
 
     // Create Supabase auth user (email + password)
-    // Using signUp instead of admin.createUser to get a session with tokens
     const { data: authData, error: authError } = await supabase.auth.signUp({
       email,
       password,
@@ -79,8 +104,7 @@ export async function POST(request: Request) {
       )
     }
 
-    // Since we want auto-login, we need to confirm the email
-    // Get the user object and use admin API to confirm
+    // Auto-confirm email so the user gets a session immediately
     const { error: confirmError } = await supabase.auth.admin.updateUserById(
       authData.user.id,
       {
@@ -93,7 +117,6 @@ export async function POST(request: Request) {
         '[POST /api/auth/register] Email confirm error:',
         confirmError,
       )
-      // Delete the auth user since confirmation failed
       await supabase.auth.admin.deleteUser(authData.user.id)
       return Response.json(
         { error: confirmError?.message || 'Failed to confirm email' },
@@ -125,7 +148,6 @@ export async function POST(request: Request) {
         '[POST /api/auth/register] Profile error:',
         profileError,
       )
-      // Delete the auth user since profile creation failed
       await supabase.auth.admin.deleteUser(authData.user.id)
       return Response.json(
         { error: profileError?.message || 'Failed to create user profile' },
@@ -133,7 +155,6 @@ export async function POST(request: Request) {
       )
     }
 
-    // Create User entity
     const typedData = data as {
       id: string
       name: string
@@ -147,6 +168,51 @@ export async function POST(request: Request) {
       typedData.email,
     )
 
+    // Classify the business + persist Company + clusters + initial recommendations
+    let onboarding: BrainOnboardResponse | null = null
+    try {
+      const safeYears = VALID_YEARS.has(yearsOfOperation)
+        ? (yearsOfOperation as BrainOnboardRequest['yearsOfOperation'])
+        : null
+      onboarding = await brainClient.post<BrainOnboardResponse>(
+        '/api/companies/onboard',
+        {
+          userId: user.id,
+          description: descripcion.trim(),
+          businessName,
+          municipio,
+          yearsOfOperation: safeYears,
+          hasChamber: Boolean(hasChamber),
+          nit: nit || null,
+        } satisfies BrainOnboardRequest,
+      )
+
+      const { error: linkError } = await supabase
+        .from('users')
+        .update({ company_id: onboarding.company.id })
+        .eq('id', user.id)
+      if (linkError) {
+        serverLogger.warn(
+          '[POST /api/auth/register] Could not link user→company',
+          linkError,
+        )
+      }
+    } catch (brainErr) {
+      // Onboarding is best-effort — user already exists; classification can
+      // be retried later. We log and surface a warning instead of failing.
+      if (brainErr instanceof BrainHttpError) {
+        serverLogger.error(
+          `[POST /api/auth/register] Brain onboarding failed (${brainErr.status})`,
+          brainErr.body,
+        )
+      } else {
+        serverLogger.error(
+          '[POST /api/auth/register] Brain onboarding error',
+          brainErr,
+        )
+      }
+    }
+
     return Response.json(
       {
         data: {
@@ -157,6 +223,7 @@ export async function POST(request: Request) {
             email: user.email,
             createdAt: user.createdAt.toISOString(),
           },
+          onboarding,
         },
       },
       { status: 201 },

--- a/src/front/app/api/me/recommendations/grouped/route.ts
+++ b/src/front/app/api/me/recommendations/grouped/route.ts
@@ -1,0 +1,64 @@
+import {
+  brainClient,
+  BrainHttpError,
+  type BrainGroupedRecommendationsResponse,
+} from '@/core/shared/infrastructure/brain/brainClient'
+import { mapBrainGroupedToRecomendaciones } from '@/core/recommendations/infrastructure/adapters/brainToRecomendacion'
+import { serverLogger } from '@/core/shared/infrastructure/logger/serverLogger'
+import { createSupabaseServerClient } from '@/core/shared/infrastructure/supabase/server'
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization') ?? ''
+  const token = authHeader.toLowerCase().startsWith('bearer ')
+    ? authHeader.slice(7).trim()
+    : null
+
+  if (!token) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createSupabaseServerClient()
+  const { data: userResp, error: userErr } = await supabase.auth.getUser(token)
+  if (userErr || !userResp.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile, error: profileErr } = await supabase
+    .from('users')
+    .select('company_id')
+    .eq('id', userResp.user.id)
+    .single()
+
+  if (profileErr || !profile?.company_id) {
+    return Response.json({
+      recomendaciones: [],
+      partial: true,
+      reason: 'no_company',
+    })
+  }
+
+  try {
+    const grouped = await brainClient.get<BrainGroupedRecommendationsResponse>(
+      `/api/companies/${encodeURIComponent(profile.company_id)}/recommendations/grouped`,
+    )
+    const recomendaciones = mapBrainGroupedToRecomendaciones(grouped)
+    return Response.json({
+      recomendaciones,
+      partial: grouped.partial,
+      reason: null,
+    })
+  } catch (err) {
+    if (err instanceof BrainHttpError) {
+      serverLogger.error(
+        `[GET /api/me/recommendations/grouped] Brain ${err.status}`,
+        err.body,
+      )
+    } else {
+      serverLogger.error('[GET /api/me/recommendations/grouped]', err)
+    }
+    return Response.json(
+      { error: 'Failed to fetch recommendations' },
+      { status: 502 },
+    )
+  }
+}

--- a/src/front/core/recommendations/infrastructure/adapters/brainToRecomendacion.ts
+++ b/src/front/core/recommendations/infrastructure/adapters/brainToRecomendacion.ts
@@ -1,0 +1,87 @@
+import type {
+  BrainGroupedRecommendationsResponse,
+  BrainRecommendationView,
+} from '@/core/shared/infrastructure/brain/brainClient'
+import type { Ancla, Recomendacion } from '@/app/[locale]/app/_data/types'
+
+const AVATAR_PALETTE: readonly string[] = [
+  'bg-primary-soft text-primary',
+  'bg-secondary-soft text-secondary-hover',
+  'bg-accent-soft text-accent',
+  'bg-info-soft text-info',
+  'bg-success-soft text-success',
+  'bg-warning-soft text-warning',
+]
+
+function pickAvatarColor(seed: string): string {
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0
+  }
+  return AVATAR_PALETTE[hash % AVATAR_PALETTE.length]
+}
+
+function buildIniciales(name: string): string {
+  const words = name
+    .split(/\s+/)
+    .filter((w) => w.length > 0 && /[a-záéíóúñ]/i.test(w[0]))
+  if (words.length === 0) return name.slice(0, 2).toUpperCase()
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return `${words[0][0]}${words[1][0]}`.toUpperCase()
+}
+
+function buildAnclas(view: BrainRecommendationView): Ancla[] {
+  return view.reasons.slice(0, 3).map((r) => ({
+    tipo: 'sector_compatible',
+    valor: r.description ?? r.feature,
+  }))
+}
+
+function buildRazon(view: BrainRecommendationView): string {
+  if (view.explanation && view.explanation.trim().length > 0) {
+    return view.explanation
+  }
+  if (view.reasons.length === 0) {
+    return 'Conexión sugerida por el sistema.'
+  }
+  return view.reasons.map((r) => r.description).join(' · ')
+}
+
+export function mapBrainViewToRecomendacion(
+  view: BrainRecommendationView,
+): Recomendacion | null {
+  if (!view.targetCompany) return null
+  const company = view.targetCompany
+  return {
+    id: view.id,
+    target: {
+      id: company.id,
+      iniciales: buildIniciales(company.razonSocial),
+      nombre: company.razonSocial,
+      sector: `CIIU ${company.ciiuSeccion}${company.ciiu}`,
+      barrio: company.municipio,
+      origen: 'formal',
+      avatarColor: pickAvatarColor(company.id),
+      descripcion: view.explanation ?? undefined,
+    },
+    tipoRelacion: view.relationType,
+    score: Math.round(view.score * 100),
+    razon: buildRazon(view),
+    estado: 'nueva',
+    anclas: buildAnclas(view),
+  }
+}
+
+export function mapBrainGroupedToRecomendaciones(
+  grouped: BrainGroupedRecommendationsResponse,
+): Recomendacion[] {
+  const flat: BrainRecommendationView[] = [
+    ...grouped.proveedor,
+    ...grouped.cliente,
+    ...grouped.aliado,
+    ...grouped.referente,
+  ]
+  return flat
+    .map(mapBrainViewToRecomendacion)
+    .filter((r): r is Recomendacion => r !== null)
+}

--- a/src/front/core/recommendations/infrastructure/hooks/useRecomendaciones.ts
+++ b/src/front/core/recommendations/infrastructure/hooks/useRecomendaciones.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import useSWR from 'swr'
+import type { Recomendacion } from '@/app/[locale]/app/_data/types'
+
+export interface RecomendacionesResponse {
+  recomendaciones: Recomendacion[]
+  partial: boolean
+  reason: string | null
+}
+
+interface UseRecomendacionesResult {
+  data: Recomendacion[] | undefined
+  partial: boolean
+  isLoading: boolean
+  error: Error | undefined
+  reason: string | null
+}
+
+export function useRecomendaciones(): UseRecomendacionesResult {
+  const { data, error, isLoading } = useSWR<RecomendacionesResponse>(
+    '/api/me/recommendations/grouped',
+  )
+
+  return {
+    data: data?.recomendaciones,
+    partial: data?.partial ?? true,
+    isLoading,
+    error: error instanceof Error ? error : undefined,
+    reason: data?.reason ?? null,
+  }
+}

--- a/src/front/core/shared/infrastructure/brain/brainClient.ts
+++ b/src/front/core/shared/infrastructure/brain/brainClient.ts
@@ -1,0 +1,143 @@
+import 'server-only'
+
+import { env } from '@/core/shared/infrastructure/env'
+
+/**
+ * Server-only thin wrapper for the NestJS brain. Lives in infrastructure
+ * because it adapts an external HTTP service into the BFF.
+ *
+ * NEVER import from a Client Component — `import 'server-only'` blocks it.
+ */
+export class BrainHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: unknown,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'BrainHttpError'
+  }
+}
+
+async function brainRequest<T>(path: string, init: RequestInit): Promise<T> {
+  const url = `${env.BRAIN_API_URL.replace(/\/$/, '')}${path}`
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+    cache: 'no-store',
+  })
+
+  const text = await response.text()
+  const body = text ? safeJson(text) : null
+
+  if (!response.ok) {
+    throw new BrainHttpError(
+      response.status,
+      body,
+      `Brain ${init.method ?? 'GET'} ${path} failed with ${response.status}`,
+    )
+  }
+
+  return body as T
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+export const brainClient = {
+  post<T>(path: string, body: unknown): Promise<T> {
+    return brainRequest<T>(path, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+  },
+  get<T>(path: string): Promise<T> {
+    return brainRequest<T>(path, { method: 'GET' })
+  },
+}
+
+export interface BrainOnboardRequest {
+  userId: string
+  description: string
+  businessName: string
+  municipio: string
+  yearsOfOperation?: 'menos_1' | '1_3' | '3_5' | '5_10' | 'mas_10' | null
+  hasChamber?: boolean
+  nit?: string | null
+}
+
+export interface BrainOnboardResponse {
+  company: {
+    id: string
+    razonSocial: string
+    ciiu: string
+    ciiuSeccion: string
+    ciiuDivision: string
+    municipio: string
+    etapa: string
+  }
+  classification: { ciiuTitulo: string; reasoning: string }
+  clusters: {
+    id: string
+    codigo: string
+    titulo: string
+    tipo: string
+    descripcion: string | null
+  }[]
+  recommendations: Record<
+    'proveedor' | 'cliente' | 'aliado' | 'referente',
+    {
+      id: string
+      targetCompanyId: string
+      score: number
+      relationType: 'proveedor' | 'cliente' | 'aliado' | 'referente'
+      reasons: {
+        feature: string
+        weight: number
+        value?: string | number
+        description: string
+      }[]
+    }[]
+  >
+}
+
+export interface BrainGroupedRecommendationsResponse {
+  proveedor: BrainRecommendationView[]
+  cliente: BrainRecommendationView[]
+  aliado: BrainRecommendationView[]
+  referente: BrainRecommendationView[]
+  partial: boolean
+}
+
+export interface BrainRecommendationView {
+  id: string
+  targetCompany: {
+    id: string
+    razonSocial: string
+    ciiu: string
+    ciiuSeccion: string
+    ciiuDivision: string
+    municipio: string
+    etapa: string
+    personal: number
+    ingreso: number
+  } | null
+  relationType: 'proveedor' | 'cliente' | 'aliado' | 'referente'
+  score: number
+  reasons: {
+    feature: string
+    weight: number
+    value?: string | number
+    description: string
+  }[]
+  source: 'rule' | 'cosine' | 'ecosystem' | 'ai-inferred'
+  explanation: string | null
+}

--- a/src/front/core/shared/infrastructure/env.ts
+++ b/src/front/core/shared/infrastructure/env.ts
@@ -20,6 +20,15 @@ export const envSchema = z.object({
    * Valores válidos: "true" | "false" (cualquier otro valor = false).
    */
   DEBUG_ENABLED: z.enum(['true', 'false']).optional().default('false'),
+  /**
+   * Base URL del backend NestJS (brain). El front lo invoca server-side
+   * para clasificación CIIU, generación de clusters y recomendaciones.
+   * Default razonable para dev local — en prod debe venir del entorno.
+   */
+  BRAIN_API_URL: z
+    .url({ error: 'BRAIN_API_URL must be a valid URL' })
+    .optional()
+    .default('http://localhost:3001'),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/src/front/core/shared/infrastructure/supabase/database.types.ts
+++ b/src/front/core/shared/infrastructure/supabase/database.types.ts
@@ -433,6 +433,7 @@ export type Database = {
       users: {
         Row: {
           barrio: string | null
+          company_id: string | null
           created_at: string
           email: string | null
           has_chamber: boolean | null
@@ -446,6 +447,7 @@ export type Database = {
         }
         Insert: {
           barrio?: string | null
+          company_id?: string | null
           created_at?: string
           email?: string | null
           has_chamber?: boolean | null
@@ -459,6 +461,7 @@ export type Database = {
         }
         Update: {
           barrio?: string | null
+          company_id?: string | null
           created_at?: string
           email?: string | null
           has_chamber?: boolean | null
@@ -470,7 +473,15 @@ export type Database = {
           whatsapp?: string | null
           years_of_operation?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: 'users_company_id_fkey'
+            columns: ['company_id']
+            isOneToOne: false
+            referencedRelation: 'companies'
+            referencedColumns: ['id']
+          },
+        ]
       }
     }
     Views: {

--- a/supabase/migrations/20260426065914_users_company_id.sql
+++ b/supabase/migrations/20260426065914_users_company_id.sql
@@ -1,0 +1,11 @@
+-- =====================================================================
+-- Link users → companies (1:1 ownership)
+-- A user (account) owns at most one company. Nullable so legacy users
+-- created before classification keep working.
+-- =====================================================================
+
+alter table users
+  add column if not exists company_id text
+    references companies(id) on delete set null;
+
+create index if not exists idx_users_company_id on users(company_id);


### PR DESCRIPTION
## Summary

Wires the front signup flow to the brain so a free-text business description gets classified into a CIIU code, persisted as a Company, mapped to clusters and seeded with initial recommendations — and surfaces those recommendations in the front dashboard via a new BFF endpoint.

- **Brain**: two new use cases (`ClassifyCompanyFromDescription`, `OnboardCompanyFromSignup`) plus a grouped-by-relation-type recommendations endpoint
- **Front**: BFF wiring so the signup wizard's `descripcion` reaches the brain and the recomendaciones page consumes live data with mock fallback
- **DB**: nullable `users.company_id` foreign key linking authenticated users to their classified company

## What changed

### Brain
- `POST /api/companies/onboard` — Zod-validated body. Pipeline: Gemini classification → CIIU taxonomy validation (retry once on hallucinated codes) → `Company.create` → save → resolve clusters via `ClusterCiiuMappingRepository.getCiiuToClusterMap` → save memberships → run Peer/ValueChain/Alliance matchers filtered to the new company id with top-10-per-relation cap → save recommendations
- `GET /api/companies/:id/recommendations/grouped` — returns `{ proveedor, cliente, aliado, referente, partial }` with limit=10 per type and `partial=true` when any type has fewer than 3 candidates
- `CompaniesModule ↔ {ClustersModule, RecommendationsModule}` circular dep resolved with `forwardRef` on both sides

### Front
- `BRAIN_API_URL` env var (default `http://localhost:3001`)
- Server-only `brainClient` with typed responses
- `POST /api/auth/register` validates `descripcion` (10-280 chars), forwards to brain, persists `users.company_id`, returns onboarding data alongside auth tokens. Brain failure is best-effort: user is still created and `onboarding` returns null
- `GET /api/me/recommendations/grouped` — bearer-auth BFF that resolves the user's `company_id` and proxies the brain endpoint
- Pure adapter `brainToRecomendacion` maps brain `RecommendationView` → front `Recomendacion` (iniciales, stable avatar color seeded by id, anclas from reasons)
- SWR hook `useRecomendaciones`; `RecoTable` consumes live data with mock fallback for first-load

### Tests
- **Brain**: 72 files / 591 tests — added 4 new test files (classify, onboard, controller, grouped)
- **Front**: 16 files / 123 tests — register integration covers descripcion validation + brain forwarding + company_id persistence + brain-down graceful degradation; new pure unit tests for the adapter; bonus jsdom pragma fix that recovered 4 useUsers hook tests that were silently broken

## Notes for reviewer

- Sync onboarding chosen for MVP (Gemini Flash ~1-2s in critical path is acceptable). Move to async if it becomes a problem.
- New companies use `nit` (sanitized) as id when provided, else `signup-{userId}` so we don't collide with the RUES matricula keyspace.
- The brain endpoint path is `/api/companies/:id/recommendations/grouped` — the existing per-type endpoint at `/api/companies/:id/recommendations?type=&limit=` is left untouched.

## Test plan

- [x] Apply migration `20260426065914_users_company_id.sql` on supabase before running
- [x] `bun supabase:types` to regenerate (current types were updated manually)
- [x] Spin up brain (`bun --filter brain dev`) and front (`bun --filter front dev`)
- [ ] Sign up with a real description — verify classification reasoning + clusters appear in the response
- [ ] Inspect `public.users` row: `company_id` should be set
- [ ] Inspect `public.companies` row: should have the classified ciiu/etapa/municipio
- [ ] Hit `/recomendaciones` after signup — `RecoTable` should show real recs (or fall back to mock if onboarding produced none)
- [ ] Kill the brain process and sign up again — registration should still return 201 with `onboarding: null` (best-effort)