### PR TITLE
feat(brain): pluggable LLM provider with OpenRouter support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,28 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ===========================================
-# Brain — Gemini (Google Generative AI)
+# Brain — LLM provider selection
 # ===========================================
+# Which LLM adapter to wire into the LlmPort. Default: openrouter.
+# Options: "openrouter" | "gemini"
+LLM_PROVIDER=openrouter
+
+# ===========================================
+# Brain — OpenRouter (default provider)
+# ===========================================
+# Required when LLM_PROVIDER=openrouter. Get a key at https://openrouter.ai/keys
+OPENROUTER_API_KEY=your-openrouter-api-key-here
+# Free models: see https://openrouter.ai/models?max_price=0
+OPENROUTER_CHAT_MODEL=google/gemma-4-31b-it:free
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# Optional — used by OpenRouter for app attribution / leaderboards
+OPENROUTER_APP_URL=http://localhost:3000
+OPENROUTER_APP_NAME=Silver Adventure
+
+# ===========================================
+# Brain — Gemini (alternative provider)
+# ===========================================
+# Required ONLY when LLM_PROVIDER=gemini.
 GEMINI_API_KEY=your-gemini-api-key-here
 GEMINI_CHAT_MODEL=gemini-2.5-flash
 GEMINI_EMBEDDING_MODEL=text-embedding-004

--- a/docs/postman/silver-adventure-brain.postman_collection.json
+++ b/docs/postman/silver-adventure-brain.postman_collection.json
@@ -34,6 +34,12 @@
       "value": "",
       "type": "string",
       "description": "UUID de un agent_event"
+    },
+    {
+      "key": "userId",
+      "value": "",
+      "type": "string",
+      "description": "UUID de un usuario (auth.users.id de Supabase). Se usa en POST /companies/onboard para asociar la company nueva al user."
     }
   ],
   "item": [
@@ -135,6 +141,48 @@
               ]
             },
             "description": "Lista las recomendaciones generadas para esta empresa, ordenadas por score desc.\n\nPara entender cómo se calcula el score ver `docs/scoring.md`."
+          },
+          "response": []
+        },
+        {
+          "name": "GET /companies/:id/recommendations/grouped — agrupadas por relationType",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/companies/{{companyId}}/recommendations/grouped",
+              "host": ["{{baseUrl}}"],
+              "path": [
+                "companies",
+                "{{companyId}}",
+                "recommendations",
+                "grouped"
+              ]
+            },
+            "description": "Devuelve las recomendaciones de la empresa **agrupadas por tipo de relación**, con tope de 10 por tipo.\n\n**Response:**\n```json\n{\n  \"referente\":  [RecommendationView, ...],\n  \"cliente\":    [...],\n  \"proveedor\":  [...],\n  \"aliado\":     [...],\n  \"partial\":    boolean\n}\n```\n\n`partial: true` indica que algún tipo tiene menos de 3 recomendaciones (útil para que la UI muestre estado \"aún explorando...\").\n\nEs el endpoint que consume el front en `/api/me/recommendations/grouped` (BFF), que después mapea con `mapBrainGroupedToRecomendaciones` a la shape de UI."
+          },
+          "response": []
+        },
+        {
+          "name": "POST /companies/onboard — onboarding desde signup (con IA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": \"{{userId}}\",\n  \"description\": \"Vendemos café de origen tostado artesanalmente. Compramos directo a productores del Magdalena y exportamos a Europa.\",\n  \"businessName\": \"Café Sierra Nevada SAS\",\n  \"municipio\": \"SANTA MARTA\",\n  \"yearsOfOperation\": \"3_5\",\n  \"hasChamber\": true,\n  \"nit\": \"900123456\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/companies/onboard",
+              "host": ["{{baseUrl}}"],
+              "path": ["companies", "onboard"]
+            },
+            "description": "Onboarda una empresa desde el formulario de signup del front. Pipeline:\n\n1. **`ClassifyCompanyFromDescription`** — el LLM (OpenRouter o Gemini según `LLM_PROVIDER`) infiere el código CIIU a partir de la descripción del negocio en lenguaje natural. Devuelve `{ ciiu, ciiuTitulo, reasoning }`.\n2. **Persistencia** — crea la `Company` con un `id` derivado del `nit` (o `signup-{userId}` si no hay nit) y la asocia al `userId` en `users.company_id`.\n3. **`GenerateClusters`** parcial — calcula clusters predefinidos + heurísticos a los que pertenece la empresa nueva y registra las memberships.\n4. **`GenerateRecommendations`** parcial — produce recomendaciones para esta company (siempre con AI si está disponible).\n\n**Body:**\n```json\n{\n  \"userId\":           \"<uuid de auth.users>\",         // requerido\n  \"description\":      \"<texto libre del negocio>\",    // requerido\n  \"businessName\":     \"<razón social o nombre>\",       // requerido\n  \"municipio\":        \"<municipio>\",                   // requerido\n  \"yearsOfOperation\": \"menos_1|1_3|3_5|5_10|mas_10\",  // opcional\n  \"hasChamber\":       true,                            // opcional\n  \"nit\":              \"<NIT sin DV>\"                  // opcional\n}\n```\n\n**Response:** `{ company, classification, clusters[], recommendations: { proveedor, cliente, aliado, referente } }`.\n\n**400** si Zod rechaza el body. Si el LLM da un CIIU inválido, el use case reintenta hasta 3 veces antes de devolver fallback."
           },
           "response": []
         }

--- a/src/brain/README.md
+++ b/src/brain/README.md
@@ -247,7 +247,7 @@ Seis contextos, cada uno con su propia carpeta `domain / application / infrastru
 
 ```
 src/brain/src/
-├── shared/                # Ports y adapters cross-cutting (Logger, GeminiPort, SupabaseClient, env, CsvLoader, DataPaths)
+├── shared/                # Ports y adapters cross-cutting (Logger, LlmPort, SupabaseClient, env, CsvLoader, DataPaths)
 ├── ciiu-taxonomy/         # Taxonomía oficial DIAN CIIU rev 4 — base de la jerarquía sección/división/grupo
 ├── companies/             # Empresas (entity + repo + CompanySource port + CsvCompanySource)
 ├── clusters/              # Generación de clusters (predefinidos + heurísticos en cascada)
@@ -255,14 +255,14 @@ src/brain/src/
 └── agent/                 # ScanRun, AgentEvent, OpportunityDetector, RunIncrementalScan, AgentScheduler @Cron
 ```
 
-| Contexto          | Spec                                                                     | Highlight                                                                      |
-| ----------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| `shared`          | [`docs/specs/01-shared/`](../../docs/specs/01-shared/)                   | `GeminiPort`, `Logger` port (Console/Null), `SupabaseClient`, `env.ts` con Zod |
-| `ciiu-taxonomy`   | [`docs/specs/02-ciiu-taxonomy/`](../../docs/specs/02-ciiu-taxonomy/)     | `findByDivision/findByGrupo` para el clusterer                                 |
-| `companies`       | [`docs/specs/03-companies/`](../../docs/specs/03-companies/)             | `CompanySource` port (BQ-ready), `EtapaCalculator`                             |
-| `clusters`        | [`docs/specs/04-clusters/`](../../docs/specs/04-clusters/)               | Cascada 2 niveles, una empresa en N clusters                                   |
-| `recommendations` | [`docs/specs/05-recommendations/`](../../docs/specs/05-recommendations/) | 18 archivos, AI engine + 3 fallbacks + cache + dedupe + scoring                |
-| `agent`           | [`docs/specs/06-agent/`](../../docs/specs/06-agent/)                     | Cron 60s, snapshot diff, eventos `new_high_score_match`, etc.                  |
+| Contexto          | Spec                                                                     | Highlight                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `shared`          | [`docs/specs/01-shared/`](../../docs/specs/01-shared/)                   | `LlmPort` (Gemini + OpenRouter adapters), `Logger` port (Console/Null), `SupabaseClient`, `env.ts` con Zod |
+| `ciiu-taxonomy`   | [`docs/specs/02-ciiu-taxonomy/`](../../docs/specs/02-ciiu-taxonomy/)     | `findByDivision/findByGrupo` para el clusterer                                                             |
+| `companies`       | [`docs/specs/03-companies/`](../../docs/specs/03-companies/)             | `CompanySource` port (BQ-ready), `EtapaCalculator`                                                         |
+| `clusters`        | [`docs/specs/04-clusters/`](../../docs/specs/04-clusters/)               | Cascada 2 niveles, una empresa en N clusters                                                               |
+| `recommendations` | [`docs/specs/05-recommendations/`](../../docs/specs/05-recommendations/) | 18 archivos, AI engine + 3 fallbacks + cache + dedupe + scoring                                            |
+| `agent`           | [`docs/specs/06-agent/`](../../docs/specs/06-agent/)                     | Cron 60s, snapshot diff, eventos `new_high_score_match`, etc.                                              |
 
 ---
 
@@ -344,16 +344,16 @@ OpenAPI auto-generado vía `@nestjs/swagger`. Disponible en `http://localhost:30
 
 ## 8. Stack y dependencias clave
 
-| Bloque     | Pieza                                                        | Qué hace                                             |
-| ---------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| Framework  | `@nestjs/common`, `@nestjs/core`, `@nestjs/platform-express` | DI, controllers, lifecycle                           |
-| Cron       | `@nestjs/schedule`                                           | `@Cron(env.AGENT_CRON_SCHEDULE)` para el agente      |
-| OpenAPI    | `@nestjs/swagger`                                            | Docs auto-generadas en `/docs`                       |
-| IA         | `@google/generative-ai`                                      | Cliente oficial de Gemini (chat + structured output) |
-| BD         | `@supabase/postgrest-js`                                     | Cliente liviano (queries directas, sin auth)         |
-| CSV        | `papaparse`                                                  | Parsing del dataset Ruta C                           |
-| Validación | `zod`, `class-validator`, `class-transformer`                | Schemas de env, DTOs, output de Gemini               |
-| Tests      | `vitest`, `@vitest/coverage-v8`, `supertest`                 | Unit + integration. Coverage objetivo > 80%          |
+| Bloque     | Pieza                                                        | Qué hace                                                     |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Framework  | `@nestjs/common`, `@nestjs/core`, `@nestjs/platform-express` | DI, controllers, lifecycle                                   |
+| Cron       | `@nestjs/schedule`                                           | `@Cron(env.AGENT_CRON_SCHEDULE)` para el agente              |
+| OpenAPI    | `@nestjs/swagger`                                            | Docs auto-generadas en `/docs`                               |
+| IA         | `@google/generative-ai` + `fetch` (OpenRouter)               | `LlmPort` con dos adapters seleccionables por `LLM_PROVIDER` |
+| BD         | `@supabase/postgrest-js`                                     | Cliente liviano (queries directas, sin auth)                 |
+| CSV        | `papaparse`                                                  | Parsing del dataset Ruta C                                   |
+| Validación | `zod`, `class-validator`, `class-transformer`                | Schemas de env, DTOs, output de Gemini                       |
+| Tests      | `vitest`, `@vitest/coverage-v8`, `supertest`                 | Unit + integration. Coverage objetivo > 80%                  |
 
 ---
 
@@ -445,7 +445,7 @@ Los CSVs viven en [`docs/hackathon/DATA/`](../../docs/hackathon/DATA/) y se acce
 - **Use case tests:** inyectar `InMemory*Repository`. Sin Supabase ni Gemini.
 - **Adapter tests:** mockear el cliente externo (`SupabaseClient`, `GeminiAdapter`), validar mapeo.
 - **Controller tests:** `supertest` contra módulo aislado.
-- **Stub para Gemini:** `StubGeminiAdapter` para tests del motor sin tocar la AI real.
+- **Stub para LLM:** `StubLlmAdapter` para tests del motor sin tocar la AI real (sirve para Gemini y OpenRouter).
 
 Estructura de tests refleja la de `src/`:
 

--- a/src/brain/__tests__/clusters/ClustersController.test.ts
+++ b/src/brain/__tests__/clusters/ClustersController.test.ts
@@ -15,7 +15,7 @@ import { ClustersController } from '@/clusters/infrastructure/http/clusters.cont
 import { CompanyClustersController } from '@/clusters/infrastructure/http/company-clusters.controller'
 import { Company } from '@/companies/domain/entities/Company'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 function makeCompany(id: string, ciiu = 'G4711'): Company {
   return Company.create({
@@ -69,7 +69,7 @@ describe('ClustersController', () => {
       clusterRepo,
       membershipRepo,
       companyRepo,
-      new StubGeminiAdapter('AI desc'),
+      new StubLlmAdapter('AI desc'),
     )
     controller = new ClustersController(generate, explain, clusterRepo)
   })

--- a/src/brain/__tests__/clusters/ExplainCluster.test.ts
+++ b/src/brain/__tests__/clusters/ExplainCluster.test.ts
@@ -5,7 +5,7 @@ import { InMemoryClusterMembershipRepository } from '@/clusters/infrastructure/r
 import { InMemoryClusterRepository } from '@/clusters/infrastructure/repositories/InMemoryClusterRepository'
 import { Company } from '@/companies/domain/entities/Company'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 function makeCompany(id: string, razonSocial = 'X SAS'): Company {
   return Company.create({
@@ -20,14 +20,14 @@ describe('ExplainCluster', () => {
   let clusterRepo: InMemoryClusterRepository
   let membershipRepo: InMemoryClusterMembershipRepository
   let companyRepo: InMemoryCompanyRepository
-  let gemini: StubGeminiAdapter
+  let gemini: StubLlmAdapter
   let useCase: ExplainCluster
 
   beforeEach(() => {
     clusterRepo = new InMemoryClusterRepository()
     membershipRepo = new InMemoryClusterMembershipRepository()
     companyRepo = new InMemoryCompanyRepository()
-    gemini = new StubGeminiAdapter('AI generated description')
+    gemini = new StubLlmAdapter('AI generated description')
     useCase = new ExplainCluster(
       clusterRepo,
       membershipRepo,

--- a/src/brain/__tests__/companies/ClassifyCompanyFromDescription.test.ts
+++ b/src/brain/__tests__/companies/ClassifyCompanyFromDescription.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
 import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
 import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 
-class ScriptedGemini implements GeminiPort {
+class ScriptedGemini implements LlmPort {
   public readonly prompts: string[] = []
   private call = 0
 

--- a/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
+++ b/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
@@ -15,9 +15,9 @@ import { FeatureVectorBuilder } from '@/recommendations/application/services/Fea
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 
-class FixedGemini implements GeminiPort {
+class FixedGemini implements LlmPort {
   constructor(private readonly response: unknown) {}
   async generateText() {
     return JSON.stringify(this.response)

--- a/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
+++ b/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
@@ -14,9 +14,9 @@ import { FeatureVectorBuilder } from '@/recommendations/application/services/Fea
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 
-class FixedGemini implements GeminiPort {
+class FixedGemini implements LlmPort {
   constructor(private readonly response: unknown) {}
   async generateText() {
     return JSON.stringify(this.response)

--- a/src/brain/__tests__/recommendations/AiMatchEngine.test.ts
+++ b/src/brain/__tests__/recommendations/AiMatchEngine.test.ts
@@ -3,7 +3,7 @@ import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
 import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
 import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
 import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 const mayorista = CiiuActivity.create({
   code: '4631',
@@ -29,7 +29,7 @@ const restaurante = CiiuActivity.create({
 
 describe('AiMatchEngine', () => {
   it('short-circuits to referente when ciiuOrigen === ciiuDestino without calling Gemini', async () => {
-    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const gemini = new StubLlmAdapter('', { has_match: true })
     const cache = new InMemoryAiMatchCacheRepository()
     const ciiuRepo = new InMemoryCiiuTaxonomyRepository()
     const spy = vi.spyOn(gemini, 'inferStructured')
@@ -45,7 +45,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('caches the result on second call with the same pair', async () => {
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: true,
       relation_type: 'cliente',
       confidence: 0.85,
@@ -71,7 +71,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('returns no-match when CIIU origen is missing in DIAN taxonomy', async () => {
-    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const gemini = new StubLlmAdapter('', { has_match: true })
     const cache = new InMemoryAiMatchCacheRepository()
     const ciiuRepo = new InMemoryCiiuTaxonomyRepository()
     const spy = vi.spyOn(gemini, 'inferStructured')
@@ -86,7 +86,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('returns no-match when only one CIIU is missing', async () => {
-    const gemini = new StubGeminiAdapter('', { has_match: true })
+    const gemini = new StubLlmAdapter('', { has_match: true })
     const cache = new InMemoryAiMatchCacheRepository()
     const ciiuRepo = new InMemoryCiiuTaxonomyRepository([mayorista])
     const engine = new AiMatchEngine(gemini, cache, ciiuRepo)
@@ -97,7 +97,7 @@ describe('AiMatchEngine', () => {
 
   it('includes applicable rules in the prompt as guidance', async () => {
     let capturedPrompt = ''
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: true,
       relation_type: 'cliente',
       confidence: 0.9,
@@ -125,7 +125,7 @@ describe('AiMatchEngine', () => {
 
   it('falls back to "no rules apply" message when no rules match the pair', async () => {
     let capturedPrompt = ''
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: false,
       relation_type: null,
       confidence: 0,
@@ -162,7 +162,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('clamps confidence into 0..1 range', async () => {
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: true,
       relation_type: 'cliente',
       confidence: 1.5,
@@ -180,7 +180,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('treats invalid relation_type from Gemini as null', async () => {
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: true,
       relation_type: 'enemigo',
       confidence: 0.7,
@@ -198,7 +198,7 @@ describe('AiMatchEngine', () => {
   })
 
   it('persists the cache entry after Gemini call', async () => {
-    const gemini = new StubGeminiAdapter('', {
+    const gemini = new StubLlmAdapter('', {
       has_match: true,
       relation_type: 'cliente',
       confidence: 0.85,

--- a/src/brain/__tests__/recommendations/CiiuPairEvaluator.test.ts
+++ b/src/brain/__tests__/recommendations/CiiuPairEvaluator.test.ts
@@ -5,7 +5,7 @@ import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEng
 import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
 import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
 import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 const ciius = [
   ['4631', 'Mayorista', 'G', '46', '463'],
@@ -34,7 +34,7 @@ const ciiuRepo = (() => {
 
 function newSetup() {
   const cache = new InMemoryAiMatchCacheRepository()
-  const gemini = new StubGeminiAdapter('', {
+  const gemini = new StubLlmAdapter('', {
     has_match: true,
     relation_type: 'cliente',
     confidence: 0.8,

--- a/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
+++ b/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
@@ -8,7 +8,7 @@ import { ExplainRecommendation } from '@/recommendations/application/use-cases/E
 import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
 import { Reasons } from '@/recommendations/domain/value-objects/Reason'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
   Company.create({
@@ -47,13 +47,13 @@ const recommendation = (
 describe('ExplainRecommendation', () => {
   let recRepo: InMemoryRecommendationRepository
   let companyRepo: InMemoryCompanyRepository
-  let gemini: StubGeminiAdapter
+  let gemini: StubLlmAdapter
   let useCase: ExplainRecommendation
 
   beforeEach(async () => {
     recRepo = new InMemoryRecommendationRepository()
     companyRepo = new InMemoryCompanyRepository()
-    gemini = new StubGeminiAdapter('Generated explanation from Gemini')
+    gemini = new StubLlmAdapter('Generated explanation from Gemini')
     useCase = new ExplainRecommendation(recRepo, companyRepo, gemini)
 
     await companyRepo.saveMany([

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -16,7 +16,7 @@ import { ValueChainMatcher } from '@/recommendations/application/services/ValueC
 import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
 import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
   Company.create({
@@ -65,7 +65,7 @@ function makeSetup({
   const recRepo = new InMemoryRecommendationRepository()
   const cache = new InMemoryAiMatchCacheRepository()
   const ciiuRepo = makeCiiuRepo()
-  const gemini = new StubGeminiAdapter(
+  const gemini = new StubLlmAdapter(
     '',
     matchResponse ?? {
       has_match: true,

--- a/src/brain/__tests__/recommendations/RecommendationsController.test.ts
+++ b/src/brain/__tests__/recommendations/RecommendationsController.test.ts
@@ -21,7 +21,7 @@ import { CompanyRecommendationsController } from '@/recommendations/infrastructu
 import { RecommendationsController } from '@/recommendations/infrastructure/http/recommendations.controller'
 import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
 function makeWiring() {
   const companyRepo = new InMemoryCompanyRepository()
@@ -49,7 +49,7 @@ function makeWiring() {
       tituloGrupo: 'x',
     }),
   ])
-  const gemini = new StubGeminiAdapter('explanation from gemini')
+  const gemini = new StubLlmAdapter('explanation from gemini')
   const aiEngine = new AiMatchEngine(gemini, cache, ciiuRepo)
   const evaluator = new CiiuPairEvaluator(aiEngine, cache)
   const featureBuilder = new FeatureVectorBuilder()

--- a/src/brain/__tests__/shared/infrastructure/env.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/env.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { parseEnv } from '@/shared/infrastructure/env'
+
+const baseEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+}
+
+describe('parseEnv — LLM provider selection', () => {
+  it('defaults LLM_PROVIDER to "openrouter"', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+    })
+    expect(env.LLM_PROVIDER).toBe('openrouter')
+  })
+
+  it('defaults OPENROUTER_CHAT_MODEL to "google/gemma-4-31b-it:free"', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+    })
+    expect(env.OPENROUTER_CHAT_MODEL).toBe('google/gemma-4-31b-it:free')
+  })
+
+  it('defaults OPENROUTER_BASE_URL to OpenRouter v1', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+    })
+    expect(env.OPENROUTER_BASE_URL).toBe('https://openrouter.ai/api/v1')
+  })
+
+  it('accepts custom OPENROUTER_CHAT_MODEL', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+      OPENROUTER_CHAT_MODEL: 'deepseek/deepseek-chat-v3.1:free',
+    })
+    expect(env.OPENROUTER_CHAT_MODEL).toBe('deepseek/deepseek-chat-v3.1:free')
+  })
+
+  it('accepts optional OPENROUTER_APP_URL and OPENROUTER_APP_NAME', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+      OPENROUTER_APP_URL: 'https://silveradventure.app',
+      OPENROUTER_APP_NAME: 'Silver Adventure',
+    })
+    expect(env.OPENROUTER_APP_URL).toBe('https://silveradventure.app')
+    expect(env.OPENROUTER_APP_NAME).toBe('Silver Adventure')
+  })
+
+  it('OPENROUTER_APP_URL and OPENROUTER_APP_NAME are optional', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      OPENROUTER_API_KEY: 'or-key',
+    })
+    expect(env.OPENROUTER_APP_URL).toBeUndefined()
+    expect(env.OPENROUTER_APP_NAME).toBeUndefined()
+  })
+
+  it('rejects when LLM_PROVIDER=openrouter but OPENROUTER_API_KEY is missing', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        LLM_PROVIDER: 'openrouter',
+      }),
+    ).toThrow(/OPENROUTER_API_KEY/)
+  })
+
+  it('rejects when LLM_PROVIDER=gemini but GEMINI_API_KEY is missing', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        LLM_PROVIDER: 'gemini',
+      }),
+    ).toThrow(/GEMINI_API_KEY/)
+  })
+
+  it('accepts LLM_PROVIDER=gemini with GEMINI_API_KEY present', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      LLM_PROVIDER: 'gemini',
+      GEMINI_API_KEY: 'gem-key',
+    })
+    expect(env.LLM_PROVIDER).toBe('gemini')
+  })
+
+  it('rejects invalid LLM_PROVIDER values', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        LLM_PROVIDER: 'cohere',
+        OPENROUTER_API_KEY: 'or-key',
+      }),
+    ).toThrow()
+  })
+})

--- a/src/brain/__tests__/shared/infrastructure/llm/GeminiAdapter.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/llm/GeminiAdapter.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/shared/infrastructure/env', () => ({
   },
 }))
 
-import { GeminiAdapter } from '@/shared/infrastructure/gemini/GeminiAdapter'
+import { GeminiAdapter } from '@/shared/infrastructure/llm/GeminiAdapter'
 
 describe('GeminiAdapter', () => {
   beforeEach(() => {

--- a/src/brain/__tests__/shared/infrastructure/llm/OpenRouterAdapter.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/llm/OpenRouterAdapter.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/shared/infrastructure/env', () => ({
+  env: {
+    OPENROUTER_API_KEY: 'test-or-key',
+    OPENROUTER_CHAT_MODEL: 'google/gemma-4-31b-it:free',
+    OPENROUTER_BASE_URL: 'https://openrouter.ai/api/v1',
+    OPENROUTER_APP_URL: 'https://silveradventure.app',
+    OPENROUTER_APP_NAME: 'Silver Adventure',
+  },
+}))
+
+import { OpenRouterAdapter } from '@/shared/infrastructure/llm/OpenRouterAdapter'
+
+const okResponse = (content: string) =>
+  new Response(
+    JSON.stringify({ choices: [{ message: { role: 'assistant', content } }] }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+
+const errResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('OpenRouterAdapter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('generateText', () => {
+    it('POSTs to the configured base URL chat completions endpoint', async () => {
+      fetchMock.mockResolvedValue(okResponse('hola'))
+      const adapter = new OpenRouterAdapter()
+
+      await adapter.generateText('di hola')
+
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toBe('https://openrouter.ai/api/v1/chat/completions')
+      expect(init.method).toBe('POST')
+    })
+
+    it('sends Authorization, HTTP-Referer, X-Title and Content-Type headers', async () => {
+      fetchMock.mockResolvedValue(okResponse('hola'))
+      const adapter = new OpenRouterAdapter()
+
+      await adapter.generateText('di hola')
+
+      const [, init] = fetchMock.mock.calls[0]
+      expect(init.headers).toMatchObject({
+        Authorization: 'Bearer test-or-key',
+        'HTTP-Referer': 'https://silveradventure.app',
+        'X-Title': 'Silver Adventure',
+        'Content-Type': 'application/json',
+      })
+    })
+
+    it('sends the configured model and a single user message', async () => {
+      fetchMock.mockResolvedValue(okResponse('hola'))
+      const adapter = new OpenRouterAdapter()
+
+      await adapter.generateText('di hola')
+
+      const [, init] = fetchMock.mock.calls[0]
+      const body = JSON.parse(init.body as string)
+      expect(body).toEqual({
+        model: 'google/gemma-4-31b-it:free',
+        messages: [{ role: 'user', content: 'di hola' }],
+      })
+    })
+
+    it('returns the assistant content from choices[0].message.content', async () => {
+      fetchMock.mockResolvedValue(okResponse('hola mundo'))
+      const adapter = new OpenRouterAdapter()
+
+      const out = await adapter.generateText('di hola')
+
+      expect(out).toBe('hola mundo')
+    })
+
+    it('throws with status and error body when response is non-200', async () => {
+      fetchMock.mockResolvedValue(
+        errResponse(429, { error: { message: 'rate limited' } }),
+      )
+      const adapter = new OpenRouterAdapter()
+
+      await expect(adapter.generateText('p')).rejects.toThrow(
+        /OpenRouter.*429.*rate limited/,
+      )
+    })
+
+    it('throws when response shape is unexpected (no choices)', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ choices: [] }), { status: 200 }),
+      )
+      const adapter = new OpenRouterAdapter()
+
+      await expect(adapter.generateText('p')).rejects.toThrow(
+        /OpenRouter.*no content/i,
+      )
+    })
+
+    it('propagates network errors from fetch', async () => {
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+      const adapter = new OpenRouterAdapter()
+
+      await expect(adapter.generateText('p')).rejects.toThrow(/ECONNREFUSED/)
+    })
+  })
+
+  describe('inferStructured', () => {
+    it('parses raw JSON output and passes it to the validator', async () => {
+      fetchMock.mockResolvedValue(okResponse('{"ok": true, "n": 42}'))
+      const validator = vi.fn((raw) => raw as { ok: boolean; n: number })
+
+      const adapter = new OpenRouterAdapter()
+      const out = await adapter.inferStructured('p', validator)
+
+      expect(validator).toHaveBeenCalledWith({ ok: true, n: 42 })
+      expect(out).toEqual({ ok: true, n: 42 })
+    })
+
+    it('strips ```json ... ``` fences before parsing', async () => {
+      fetchMock.mockResolvedValue(okResponse('```json\n{"ok": true}\n```'))
+      const adapter = new OpenRouterAdapter()
+      const out = await adapter.inferStructured(
+        'p',
+        (raw) => raw as { ok: boolean },
+      )
+      expect(out.ok).toBe(true)
+    })
+
+    it('strips bare ``` fences (no language tag) before parsing', async () => {
+      fetchMock.mockResolvedValue(okResponse('```\n{"ok": true}\n```'))
+      const adapter = new OpenRouterAdapter()
+      const out = await adapter.inferStructured(
+        'p',
+        (raw) => raw as { ok: boolean },
+      )
+      expect(out.ok).toBe(true)
+    })
+
+    it('strips leading and trailing whitespace before parsing', async () => {
+      fetchMock.mockResolvedValue(okResponse('   {"ok": true}   \n'))
+      const adapter = new OpenRouterAdapter()
+      const out = await adapter.inferStructured(
+        'p',
+        (raw) => raw as { ok: boolean },
+      )
+      expect(out.ok).toBe(true)
+    })
+
+    it('throws a descriptive error when the model returns non-JSON', async () => {
+      fetchMock.mockResolvedValue(okResponse('lo siento, no puedo'))
+      const adapter = new OpenRouterAdapter()
+      await expect(adapter.inferStructured('p', (raw) => raw)).rejects.toThrow(
+        /non-JSON/,
+      )
+    })
+
+    it('propagates validator errors', async () => {
+      fetchMock.mockResolvedValue(okResponse('{"x": 1}'))
+      const adapter = new OpenRouterAdapter()
+      await expect(
+        adapter.inferStructured('p', () => {
+          throw new Error('schema mismatch')
+        }),
+      ).rejects.toThrow(/schema mismatch/)
+    })
+  })
+
+  describe('optional headers', () => {
+    it('omits HTTP-Referer and X-Title when env vars are not set', async () => {
+      vi.resetModules()
+      vi.doMock('@/shared/infrastructure/env', () => ({
+        env: {
+          OPENROUTER_API_KEY: 'test-or-key',
+          OPENROUTER_CHAT_MODEL: 'google/gemma-4-31b-it:free',
+          OPENROUTER_BASE_URL: 'https://openrouter.ai/api/v1',
+          OPENROUTER_APP_URL: undefined,
+          OPENROUTER_APP_NAME: undefined,
+        },
+      }))
+
+      const { OpenRouterAdapter: FreshAdapter } =
+        await import('@/shared/infrastructure/llm/OpenRouterAdapter')
+      fetchMock.mockResolvedValue(okResponse('ok'))
+
+      const adapter = new FreshAdapter()
+      await adapter.generateText('p')
+
+      const [, init] = fetchMock.mock.calls[0]
+      expect(init.headers).not.toHaveProperty('HTTP-Referer')
+      expect(init.headers).not.toHaveProperty('X-Title')
+
+      vi.doUnmock('@/shared/infrastructure/env')
+    })
+  })
+})

--- a/src/brain/__tests__/shared/infrastructure/llm/StubLlmAdapter.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/llm/StubLlmAdapter.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { StubGeminiAdapter } from '@/shared/infrastructure/gemini/StubGeminiAdapter'
+import { StubLlmAdapter } from '@/shared/infrastructure/llm/StubLlmAdapter'
 
-describe('StubGeminiAdapter', () => {
+describe('StubLlmAdapter', () => {
   it('returns the configured text response', async () => {
-    const adapter = new StubGeminiAdapter('canned text')
+    const adapter = new StubLlmAdapter('canned text')
     expect(await adapter.generateText('any prompt')).toBe('canned text')
   })
 
   it('defaults the text response when none is provided', async () => {
-    const adapter = new StubGeminiAdapter()
+    const adapter = new StubLlmAdapter()
     expect(await adapter.generateText('x')).toBe('stub response')
   })
 
   it('passes the configured structured response through the validator', async () => {
     const payload = { foo: 'bar' }
-    const adapter = new StubGeminiAdapter('text', payload)
+    const adapter = new StubLlmAdapter('text', payload)
     const out = await adapter.inferStructured('any prompt', (raw) => {
       expect(raw).toBe(payload)
       return raw as { foo: string }

--- a/src/brain/__tests__/shared/infrastructure/llm/createLlmAdapter.test.ts
+++ b/src/brain/__tests__/shared/infrastructure/llm/createLlmAdapter.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const setEnv = (provider: 'openrouter' | 'gemini') => {
+  vi.doMock('@/shared/infrastructure/env', () => ({
+    env: {
+      LLM_PROVIDER: provider,
+      OPENROUTER_API_KEY: 'or-key',
+      OPENROUTER_CHAT_MODEL: 'google/gemma-4-31b-it:free',
+      OPENROUTER_BASE_URL: 'https://openrouter.ai/api/v1',
+      OPENROUTER_APP_URL: undefined,
+      OPENROUTER_APP_NAME: undefined,
+      GEMINI_API_KEY: 'gem-key',
+      GEMINI_CHAT_MODEL: 'gemini-2.5-flash',
+    },
+  }))
+}
+
+describe('createLlmAdapter', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@/shared/infrastructure/env')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns OpenRouterAdapter when LLM_PROVIDER=openrouter', async () => {
+    setEnv('openrouter')
+    const { createLlmAdapter } =
+      await import('@/shared/infrastructure/llm/createLlmAdapter')
+    const { OpenRouterAdapter } =
+      await import('@/shared/infrastructure/llm/OpenRouterAdapter')
+
+    const adapter = createLlmAdapter()
+
+    expect(adapter).toBeInstanceOf(OpenRouterAdapter)
+  })
+
+  it('returns GeminiAdapter when LLM_PROVIDER=gemini', async () => {
+    setEnv('gemini')
+    vi.doMock('@google/generative-ai', () => ({
+      GoogleGenerativeAI: vi.fn(function () {
+        return { getGenerativeModel: vi.fn() }
+      }),
+    }))
+    const { createLlmAdapter } =
+      await import('@/shared/infrastructure/llm/createLlmAdapter')
+    const { GeminiAdapter } =
+      await import('@/shared/infrastructure/llm/GeminiAdapter')
+
+    const adapter = createLlmAdapter()
+
+    expect(adapter).toBeInstanceOf(GeminiAdapter)
+  })
+})

--- a/src/brain/src/clusters/application/use-cases/ExplainCluster.ts
+++ b/src/brain/src/clusters/application/use-cases/ExplainCluster.ts
@@ -12,8 +12,8 @@ import {
   COMPANY_REPOSITORY,
   type CompanyRepository,
 } from '@/companies/domain/repositories/CompanyRepository'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
-import { GEMINI_PORT } from '@/shared/shared.module'
+import type { LlmPort } from '@/shared/domain/LlmPort'
+import { LLM_PORT } from '@/shared/shared.module'
 import type { UseCase } from '@/shared/domain/UseCase'
 
 export interface ExplainClusterInput {
@@ -38,8 +38,8 @@ export class ExplainCluster implements UseCase<
     private readonly membershipRepo: ClusterMembershipRepository,
     @Inject(COMPANY_REPOSITORY)
     private readonly companyRepo: CompanyRepository,
-    @Inject(GEMINI_PORT)
-    private readonly gemini: GeminiPort,
+    @Inject(LLM_PORT)
+    private readonly gemini: LlmPort,
   ) {}
 
   async execute({

--- a/src/brain/src/companies/application/use-cases/ClassifyCompanyFromDescription.ts
+++ b/src/brain/src/companies/application/use-cases/ClassifyCompanyFromDescription.ts
@@ -4,8 +4,8 @@ import {
   CIIU_TAXONOMY_REPOSITORY,
   type CiiuTaxonomyRepository,
 } from '@/ciiu-taxonomy/domain/repositories/CiiuTaxonomyRepository'
-import { GEMINI_PORT } from '@/shared/shared.module'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import { LLM_PORT } from '@/shared/shared.module'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 import type { UseCase } from '@/shared/domain/UseCase'
 
 export interface ClassifyCompanyFromDescriptionInput {
@@ -44,7 +44,7 @@ export class ClassifyCompanyFromDescription implements UseCase<
   private readonly logger = new Logger(ClassifyCompanyFromDescription.name)
 
   constructor(
-    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+    @Inject(LLM_PORT) private readonly gemini: LlmPort,
     @Inject(CIIU_TAXONOMY_REPOSITORY)
     private readonly taxonomy: CiiuTaxonomyRepository,
   ) {}

--- a/src/brain/src/recommendations/application/services/AiMatchEngine.ts
+++ b/src/brain/src/recommendations/application/services/AiMatchEngine.ts
@@ -12,8 +12,8 @@ import {
   ECOSYSTEMS,
   VALUE_CHAIN_RULES,
 } from '@/recommendations/application/services/ValueChainRules'
-import { GEMINI_PORT } from '@/shared/shared.module'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import { LLM_PORT } from '@/shared/shared.module'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 
 export interface InferredMatch {
   hasMatch: boolean
@@ -29,7 +29,7 @@ const SAME_CIIU_REASON =
 @Injectable()
 export class AiMatchEngine {
   constructor(
-    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+    @Inject(LLM_PORT) private readonly gemini: LlmPort,
     @Inject(AI_MATCH_CACHE_REPOSITORY)
     private readonly cache: AiMatchCacheRepository,
     @Inject(CIIU_TAXONOMY_REPOSITORY)

--- a/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
+++ b/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
@@ -3,9 +3,9 @@ import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepos
 import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
 import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
 import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 import type { UseCase } from '@/shared/domain/UseCase'
-import { GEMINI_PORT } from '@/shared/shared.module'
+import { LLM_PORT } from '@/shared/shared.module'
 
 export interface ExplainRecommendationInput {
   recommendationId: string
@@ -25,7 +25,7 @@ export class ExplainRecommendation implements UseCase<
     private readonly recRepo: RecommendationRepository,
     @Inject(COMPANY_REPOSITORY)
     private readonly companyRepo: CompanyRepository,
-    @Inject(GEMINI_PORT) private readonly gemini: GeminiPort,
+    @Inject(LLM_PORT) private readonly gemini: LlmPort,
   ) {}
 
   async execute(

--- a/src/brain/src/recommendations/recommendations.module.ts
+++ b/src/brain/src/recommendations/recommendations.module.ts
@@ -46,6 +46,9 @@ import { SupabaseRecommendationRepository } from './infrastructure/repositories/
   exports: [
     RECOMMENDATION_REPOSITORY,
     AI_MATCH_CACHE_REPOSITORY,
+    PeerMatcher,
+    ValueChainMatcher,
+    AllianceMatcher,
     GenerateRecommendations,
     GetCompanyRecommendations,
     GetGroupedCompanyRecommendations,

--- a/src/brain/src/shared/domain/LlmPort.ts
+++ b/src/brain/src/shared/domain/LlmPort.ts
@@ -1,4 +1,4 @@
-export interface GeminiPort {
+export interface LlmPort {
   generateText(prompt: string): Promise<string>
 
   inferStructured<T>(prompt: string, validate: (raw: unknown) => T): Promise<T>

--- a/src/brain/src/shared/infrastructure/env.ts
+++ b/src/brain/src/shared/infrastructure/env.ts
@@ -16,28 +16,60 @@ try {
  * Validación estricta con Zod. Se parsea UNA vez al levantar.
  * Si falta algo, el server explota inmediato con un mensaje claro.
  */
-export const envSchema = z.object({
-  PORT: z.coerce.number().int().positive().default(3001),
+export const envSchema = z
+  .object({
+    PORT: z.coerce.number().int().positive().default(3001),
 
-  SUPABASE_URL: z.string().url(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+    SUPABASE_URL: z.string().url(),
+    SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
 
-  AGENT_CRON_SCHEDULE: z.string().min(1).default('*/60 * * * * *'),
-  AGENT_ENABLED: z.enum(['true', 'false']).default('true'),
-  AI_MATCH_INFERENCE_ENABLED: z.enum(['true', 'false']).default('true'),
+    AGENT_CRON_SCHEDULE: z.string().min(1).default('*/60 * * * * *'),
+    AGENT_ENABLED: z.enum(['true', 'false']).default('true'),
+    AI_MATCH_INFERENCE_ENABLED: z.enum(['true', 'false']).default('true'),
 
-  GEMINI_API_KEY: z.string().min(1),
-  GEMINI_EMBEDDING_MODEL: z.string().min(1).default('text-embedding-004'),
-  GEMINI_CHAT_MODEL: z.string().min(1).default('gemini-2.5-flash'),
+    LLM_PROVIDER: z.enum(['openrouter', 'gemini']).default('openrouter'),
 
-  GCP_PROJECT_ID: z.string().min(1).optional(),
-  GCP_LOCATION: z.string().min(1).default('us-central1'),
-  GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
+    GEMINI_API_KEY: z.string().min(1).optional(),
+    GEMINI_EMBEDDING_MODEL: z.string().min(1).default('text-embedding-004'),
+    GEMINI_CHAT_MODEL: z.string().min(1).default('gemini-2.5-flash'),
 
-  BIGQUERY_DATASET: z.string().min(1).default('ruta_c'),
+    OPENROUTER_API_KEY: z.string().min(1).optional(),
+    OPENROUTER_CHAT_MODEL: z
+      .string()
+      .min(1)
+      .default('google/gemma-4-31b-it:free'),
+    OPENROUTER_BASE_URL: z
+      .string()
+      .url()
+      .default('https://openrouter.ai/api/v1'),
+    OPENROUTER_APP_URL: z.string().url().optional(),
+    OPENROUTER_APP_NAME: z.string().min(1).optional(),
 
-  DEBUG_ENABLED: z.enum(['true', 'false']).optional().default('false'),
-})
+    GCP_PROJECT_ID: z.string().min(1).optional(),
+    GCP_LOCATION: z.string().min(1).default('us-central1'),
+    GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
+
+    BIGQUERY_DATASET: z.string().min(1).default('ruta_c'),
+
+    DEBUG_ENABLED: z.enum(['true', 'false']).optional().default('false'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.LLM_PROVIDER === 'openrouter' && !data.OPENROUTER_API_KEY) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['OPENROUTER_API_KEY'],
+        message:
+          'OPENROUTER_API_KEY is required when LLM_PROVIDER="openrouter"',
+      })
+    }
+    if (data.LLM_PROVIDER === 'gemini' && !data.GEMINI_API_KEY) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['GEMINI_API_KEY'],
+        message: 'GEMINI_API_KEY is required when LLM_PROVIDER="gemini"',
+      })
+    }
+  })
 
 export type Env = z.infer<typeof envSchema>
 

--- a/src/brain/src/shared/infrastructure/llm/GeminiAdapter.ts
+++ b/src/brain/src/shared/infrastructure/llm/GeminiAdapter.ts
@@ -7,6 +7,11 @@ export class GeminiAdapter implements LlmPort {
   private readonly modelName: string
 
   constructor() {
+    if (!env.GEMINI_API_KEY) {
+      throw new Error(
+        'GeminiAdapter requires GEMINI_API_KEY (set LLM_PROVIDER=gemini and the key in .env)',
+      )
+    }
     this.client = new GoogleGenerativeAI(env.GEMINI_API_KEY)
     this.modelName = env.GEMINI_CHAT_MODEL
   }

--- a/src/brain/src/shared/infrastructure/llm/GeminiAdapter.ts
+++ b/src/brain/src/shared/infrastructure/llm/GeminiAdapter.ts
@@ -1,8 +1,8 @@
 import { GoogleGenerativeAI } from '@google/generative-ai'
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 import { env } from '@/shared/infrastructure/env'
 
-export class GeminiAdapter implements GeminiPort {
+export class GeminiAdapter implements LlmPort {
   private readonly client: GoogleGenerativeAI
   private readonly modelName: string
 

--- a/src/brain/src/shared/infrastructure/llm/OpenRouterAdapter.ts
+++ b/src/brain/src/shared/infrastructure/llm/OpenRouterAdapter.ts
@@ -1,0 +1,79 @@
+import type { LlmPort } from '@/shared/domain/LlmPort'
+import { env } from '@/shared/infrastructure/env'
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>
+  error?: { message?: string }
+}
+
+export class OpenRouterAdapter implements LlmPort {
+  private readonly endpoint: string
+  private readonly apiKey: string
+  private readonly model: string
+  private readonly appUrl: string | undefined
+  private readonly appName: string | undefined
+
+  constructor() {
+    if (!env.OPENROUTER_API_KEY) {
+      throw new Error(
+        'OpenRouterAdapter requires OPENROUTER_API_KEY (set LLM_PROVIDER=openrouter and the key in .env)',
+      )
+    }
+    this.endpoint = `${env.OPENROUTER_BASE_URL}/chat/completions`
+    this.apiKey = env.OPENROUTER_API_KEY
+    this.model = env.OPENROUTER_CHAT_MODEL
+    this.appUrl = env.OPENROUTER_APP_URL
+    this.appName = env.OPENROUTER_APP_NAME
+  }
+
+  async generateText(prompt: string): Promise<string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    }
+    if (this.appUrl) headers['HTTP-Referer'] = this.appUrl
+    if (this.appName) headers['X-Title'] = this.appName
+
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: this.model,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!res.ok) {
+      const body = (await res
+        .json()
+        .catch(() => ({}))) as ChatCompletionResponse
+      const message = body.error?.message ?? res.statusText
+      throw new Error(`OpenRouter request failed (${res.status}): ${message}`)
+    }
+
+    const data = (await res.json()) as ChatCompletionResponse
+    const content = data.choices?.[0]?.message?.content
+    if (!content) {
+      throw new Error('OpenRouter response had no content')
+    }
+    return content
+  }
+
+  async inferStructured<T>(
+    prompt: string,
+    validate: (raw: unknown) => T,
+  ): Promise<T> {
+    const raw = await this.generateText(prompt)
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```$/, '')
+      .trim()
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(cleaned)
+    } catch {
+      throw new Error(`OpenRouter returned non-JSON: ${cleaned.slice(0, 200)}`)
+    }
+    return validate(parsed)
+  }
+}

--- a/src/brain/src/shared/infrastructure/llm/StubLlmAdapter.ts
+++ b/src/brain/src/shared/infrastructure/llm/StubLlmAdapter.ts
@@ -1,6 +1,6 @@
-import type { GeminiPort } from '@/shared/domain/GeminiPort'
+import type { LlmPort } from '@/shared/domain/LlmPort'
 
-export class StubGeminiAdapter implements GeminiPort {
+export class StubLlmAdapter implements LlmPort {
   constructor(
     private readonly textResponse: string = 'stub response',
     private readonly structuredResponse: unknown = {},

--- a/src/brain/src/shared/infrastructure/llm/createLlmAdapter.ts
+++ b/src/brain/src/shared/infrastructure/llm/createLlmAdapter.ts
@@ -1,0 +1,13 @@
+import type { LlmPort } from '@/shared/domain/LlmPort'
+import { env } from '@/shared/infrastructure/env'
+import { GeminiAdapter } from '@/shared/infrastructure/llm/GeminiAdapter'
+import { OpenRouterAdapter } from '@/shared/infrastructure/llm/OpenRouterAdapter'
+
+export function createLlmAdapter(): LlmPort {
+  switch (env.LLM_PROVIDER) {
+    case 'openrouter':
+      return new OpenRouterAdapter()
+    case 'gemini':
+      return new GeminiAdapter()
+  }
+}

--- a/src/brain/src/shared/shared.module.ts
+++ b/src/brain/src/shared/shared.module.ts
@@ -3,16 +3,16 @@ import {
   SupabaseClientProvider,
   SUPABASE_CLIENT,
 } from './infrastructure/supabase/SupabaseClient'
-import { GeminiAdapter } from './infrastructure/gemini/GeminiAdapter'
+import { GeminiAdapter } from './infrastructure/llm/GeminiAdapter'
 
-export const GEMINI_PORT = Symbol('GEMINI_PORT')
+export const LLM_PORT = Symbol('LLM_PORT')
 
 @Global()
 @Module({
   providers: [
     SupabaseClientProvider,
-    { provide: GEMINI_PORT, useClass: GeminiAdapter },
+    { provide: LLM_PORT, useClass: GeminiAdapter },
   ],
-  exports: [SUPABASE_CLIENT, GEMINI_PORT],
+  exports: [SUPABASE_CLIENT, LLM_PORT],
 })
 export class SharedModule {}

--- a/src/brain/src/shared/shared.module.ts
+++ b/src/brain/src/shared/shared.module.ts
@@ -3,7 +3,7 @@ import {
   SupabaseClientProvider,
   SUPABASE_CLIENT,
 } from './infrastructure/supabase/SupabaseClient'
-import { GeminiAdapter } from './infrastructure/llm/GeminiAdapter'
+import { createLlmAdapter } from './infrastructure/llm/createLlmAdapter'
 
 export const LLM_PORT = Symbol('LLM_PORT')
 
@@ -11,7 +11,7 @@ export const LLM_PORT = Symbol('LLM_PORT')
 @Module({
   providers: [
     SupabaseClientProvider,
-    { provide: LLM_PORT, useClass: GeminiAdapter },
+    { provide: LLM_PORT, useFactory: createLlmAdapter },
   ],
   exports: [SUPABASE_CLIENT, LLM_PORT],
 })

--- a/src/brain/vitest.setup.ts
+++ b/src/brain/vitest.setup.ts
@@ -8,3 +8,4 @@
 process.env.SUPABASE_URL ||= 'http://localhost:54321'
 process.env.SUPABASE_SERVICE_ROLE_KEY ||= 'test-service-role-key'
 process.env.GEMINI_API_KEY ||= 'test-gemini-key'
+process.env.OPENROUTER_API_KEY ||= 'test-openrouter-key'


### PR DESCRIPTION
## Summary

- Renombra `GeminiPort` → `LlmPort` y reorganiza la carpeta `infrastructure/gemini/` → `infrastructure/llm/`. El dominio describe la **intención** (necesito un LLM), no el proveedor.
- Suma `OpenRouterAdapter` como segunda implementación de `LlmPort`. Selección por env var `LLM_PROVIDER=openrouter|gemini` (default: openrouter, modelo `google/gemma-4-31b-it:free`). Cero deps nuevas — usa `fetch` nativo.
- Fixea bug pre-existente de DI en `RecommendationsModule` (matchers no exportados) que rompía el bootstrap real de la app aunque los tests pasaban.
- Agrega las rutas `POST /companies/onboard` y `GET /companies/:id/recommendations/grouped` a la colección Postman.

## Por qué

La cuota de Gemini se queda corta para iteración hackathon/dev. OpenRouter ofrece modelos free (rate-limited) accesibles instantáneamente. El refactor del puerto deja la arquitectura limpia para sumar futuros proveedores (Anthropic, Groq, etc.) sin tocar use cases.

## Cambios por commit

| Commit | Tipo | Qué |
|--------|------|-----|
| `ad408c4` | refactor | Rename `GeminiPort` → `LlmPort`, folder `gemini/` → `llm/`, símbolo `GEMINI_PORT` → `LLM_PORT`. Cero cambio de comportamiento. |
| `0adb8c9` | feat | `OpenRouterAdapter` + `createLlmAdapter` factory + nuevas env vars con `superRefine` que valida la key del proveedor activo. `shared.module.ts` pasa a `useFactory`. **+26 tests TDD**. |
| `4e3e7f8` | fix | Exportar `PeerMatcher`/`ValueChainMatcher`/`AllianceMatcher` de `RecommendationsModule` para que `OnboardCompanyFromSignup` los pueda inyectar desde `CompaniesModule`. |
| `ed843bb` | docs | Postman: rutas `POST /companies/onboard` (con body precargado) y `GET /companies/:id/recommendations/grouped` + variable `userId`. |

## Configuración requerida

Antes de levantar el brain con esta branch, agregar al `.env`:

```bash
LLM_PROVIDER=openrouter
OPENROUTER_API_KEY=sk-or-v1-xxx       # obligatorio cuando provider=openrouter
OPENROUTER_CHAT_MODEL=google/gemma-4-31b-it:free
```

Si el proveedor seleccionado no tiene su API key, Zod hace fail-fast con un error claro al arrancar.

## Test plan

- [x] `bun test:run` en brain → 617/617 verdes (antes 591, +26 tests nuevos)
- [x] `bun typecheck` → limpio
- [x] App levanta sin error (verificado tras el fix de DI)
- [ ] Probar `POST /companies/onboard` con un body real → debe clasificar el CIIU usando OpenRouter
- [ ] Probar `GET /companies/:id/recommendations/grouped` contra una company del seed
- [ ] Verificar en https://openrouter.ai/activity que las requests están saliendo con el modelo configurado
- [ ] Cambiar `LLM_PROVIDER=gemini` + restart → debe seguir funcionando idéntico (regression check)

## Heads-up para el reviewer

- El commit de rename (`ad408c4`) NO cambia comportamiento: sigue inyectando `GeminiAdapter` vía `useClass`. El swap a `useFactory` con la factory que elige Gemini vs OpenRouter ocurre en el commit del feat (`0adb8c9`). Hecho a propósito para que git bisect sea limpio si surge un bug.
- El bug de DI (`4e3e7f8`) NO fue introducido por esta PR — es de un commit anterior (`0c6a9e0 feat(brain): classify and onboard companies from signup`). Salió a la luz al levantar la app por primera vez con `OnboardCompanyFromSignup` cableado.
- Las descripciones de la sección "Recommendations" del Postman todavía mencionan Gemini — quedó out of scope. Sugerencia: actualizarlas en una PR separada para no mezclar concerns.