### PR TITLE
fix(signup): make signup → onboard flow resilient end-to-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,17 +396,19 @@ Validation is **fail-fast**: invalid or missing required variables crash the pro
 
 ### 8.3 BFF Pattern — `NEXT_PUBLIC_` Discipline
 
-All variables are **server-only** (NO `NEXT_PUBLIC_` prefix) by default. The two exceptions exist because they are NOT secrets:
+All variables are **server-only** (NO `NEXT_PUBLIC_` prefix) by default. The exceptions below exist because they are NOT secrets:
 
-| Variable                    | Side   | Purpose                                          |
-| --------------------------- | ------ | ------------------------------------------------ |
-| `SUPABASE_URL`              | Server | Supabase project URL                             |
-| `SUPABASE_PUBLISHABLE_KEY`  | Server | Supabase publishable API key                     |
-| `DEBUG_ENABLED`             | Server | Enable server-side logger (`"true"` / `"false"`) |
-| `NEXT_PUBLIC_DEBUG_ENABLED` | Client | Enable client-side logger (`"true"` / `"false"`) |
-| `NEXT_PUBLIC_APP_URL`       | Client | Application URL                                  |
+| Variable                               | Side   | Purpose                                                                              |
+| -------------------------------------- | ------ | ------------------------------------------------------------------------------------ |
+| `SUPABASE_URL`                         | Server | Supabase project URL                                                                 |
+| `SUPABASE_PUBLISHABLE_KEY`             | Server | Supabase publishable API key                                                         |
+| `DEBUG_ENABLED`                        | Server | Enable server-side logger (`"true"` / `"false"`)                                     |
+| `NEXT_PUBLIC_SUPABASE_URL`             | Client | Same value as `SUPABASE_URL`. Required by `createSupabaseBrowserClient` for auth.    |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Client | Same value as `SUPABASE_PUBLISHABLE_KEY`. Publishable by design — RLS protects data. |
+| `NEXT_PUBLIC_DEBUG_ENABLED`            | Client | Enable client-side logger (`"true"` / `"false"`)                                     |
+| `NEXT_PUBLIC_APP_URL`                  | Client | Application URL                                                                      |
 
-> `NEXT_PUBLIC_DEBUG_ENABLED` and `NEXT_PUBLIC_APP_URL` are the ONLY `NEXT_PUBLIC_` variables. They are boolean flags / URLs — they do NOT violate the BFF pattern. `DEBUG_ENABLED` is optional and defaults to `"false"`.
+> The four `NEXT_PUBLIC_` variables above are the EXHAUSTIVE list. All are non-secrets by design (URLs, boolean flags, Supabase publishable key). `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` are duplicated as `NEXT_PUBLIC_*` because Next.js requires the prefix to inline the value into the browser bundle. The BFF pattern is preserved because **all DB queries still go through `/api/*` Route Handlers** — the browser client only manages the auth session (`setSession`, `signOut`, refresh), never touches data tables. RLS policies on `public.users` enforce that even a leaked publishable key can only see/modify the row of an authenticated user. `DEBUG_ENABLED` is optional and defaults to `"false"`.
 
 ### 8.4 Adding a New Environment Variable
 

--- a/src/brain/__tests__/clusters/InMemoryClusterRepository.test.ts
+++ b/src/brain/__tests__/clusters/InMemoryClusterRepository.test.ts
@@ -94,4 +94,54 @@ describe('InMemoryClusterRepository', () => {
     await repo.saveMany([makeCluster({ id: '1' }), makeCluster({ id: '2' })])
     expect(await repo.count()).toBe(2)
   })
+
+  describe('findByGrupoAndMunicipio', () => {
+    it('returns matching heuristic-grupo cluster', async () => {
+      await repo.saveMany([
+        makeCluster({
+          id: 'heur-grupo-561-santa-marta',
+          codigo: 'H-561-SM',
+          titulo: 'Grupo 561 en SANTA MARTA',
+          tipo: 'heuristic-grupo',
+          ciiuDivision: '56',
+          ciiuGrupo: '561',
+          municipio: 'SANTA MARTA',
+        }),
+      ])
+      const result = await repo.findByGrupoAndMunicipio('561', 'SANTA MARTA')
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('heur-grupo-561-santa-marta')
+    })
+
+    it('returns null when no cluster matches grupo and municipio', async () => {
+      await repo.saveMany([
+        makeCluster({
+          id: 'heur-grupo-561-cartagena',
+          codigo: 'H-561-CTG',
+          titulo: 'Grupo 561 en CARTAGENA',
+          tipo: 'heuristic-grupo',
+          ciiuDivision: '56',
+          ciiuGrupo: '561',
+          municipio: 'CARTAGENA',
+        }),
+      ])
+      expect(
+        await repo.findByGrupoAndMunicipio('561', 'SANTA MARTA'),
+      ).toBeNull()
+    })
+
+    it('ignores clusters of other tipos', async () => {
+      await repo.saveMany([
+        makeCluster({
+          id: 'pred-1',
+          codigo: 'PRED',
+          titulo: 'Predefined',
+          tipo: 'predefined',
+        }),
+      ])
+      expect(
+        await repo.findByGrupoAndMunicipio('561', 'SANTA MARTA'),
+      ).toBeNull()
+    })
+  })
 })

--- a/src/brain/__tests__/clusters/SupabaseClusterRepository.test.ts
+++ b/src/brain/__tests__/clusters/SupabaseClusterRepository.test.ts
@@ -130,6 +130,42 @@ describe('SupabaseClusterRepository', () => {
     })
   })
 
+  describe('findByGrupoAndMunicipio', () => {
+    it('returns the heuristic-grupo cluster mapped from the row', async () => {
+      const grupoRow = {
+        ...validRow,
+        id: 'heur-grupo-561-santa-marta',
+        codigo: 'H-561-SM',
+        titulo: 'Grupo 561 en SANTA MARTA',
+        tipo: 'heuristic-grupo',
+        ciiu_division: '56',
+        ciiu_grupo: '561',
+        municipio: 'SANTA MARTA',
+      }
+      fake.setNext({ data: grupoRow, error: null })
+      const result = await repo.findByGrupoAndMunicipio('561', 'SANTA MARTA')
+      expect(result).not.toBeNull()
+      expect(result!.id).toBe('heur-grupo-561-santa-marta')
+      expect(fake.spies.eq).toHaveBeenCalledWith('tipo', 'heuristic-grupo')
+      expect(fake.spies.eq).toHaveBeenCalledWith('ciiu_grupo', '561')
+      expect(fake.spies.eq).toHaveBeenCalledWith('municipio', 'SANTA MARTA')
+    })
+
+    it('returns null when no row matches', async () => {
+      fake.setNext({ data: null, error: null })
+      expect(
+        await repo.findByGrupoAndMunicipio('561', 'SANTA MARTA'),
+      ).toBeNull()
+    })
+
+    it('throws when supabase returns error', async () => {
+      fake.setNext({ data: null, error: new Error('query boom') })
+      await expect(
+        repo.findByGrupoAndMunicipio('561', 'SANTA MARTA'),
+      ).rejects.toThrow(/query boom/)
+    })
+  })
+
   describe('saveMany', () => {
     it('upserts mapped rows with onConflict on id', async () => {
       fake.setNext({ data: null, error: null })

--- a/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
+++ b/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
@@ -224,7 +224,7 @@ describe('OnboardCompanyFromSignup', () => {
     expect(persisted.length).toBe(result.recommendations.length)
   })
 
-  it('does not crash when no clusters map to the classified CIIU', async () => {
+  it('auto-creates a heuristic-grupo cluster when no predefined mapping exists', async () => {
     const f = buildFixtures()
     const useCase = new OnboardCompanyFromSignup(
       f.classify,
@@ -245,11 +245,57 @@ describe('OnboardCompanyFromSignup', () => {
       municipio: 'SANTA MARTA',
     })
 
-    expect(result.clusters).toEqual([])
+    expect(result.clusters).toHaveLength(1)
+    const created = result.clusters[0]
+    expect(created.tipo).toBe('heuristic-grupo')
+    expect(created.ciiuGrupo).toBe('561')
+    expect(created.ciiuDivision).toBe('56')
+    expect(created.municipio).toBe('SANTA MARTA')
+
+    const persisted = await f.clusterRepo.findById(created.id)
+    expect(persisted).not.toBeNull()
+
     const memberships = await f.membershipRepo.findClusterIdsByCompany(
       result.company.id,
     )
-    expect(memberships).toEqual([])
+    expect(memberships).toEqual([created.id])
+  })
+
+  it('reuses an existing heuristic-grupo cluster instead of creating a duplicate', async () => {
+    const f = buildFixtures()
+    const existing = Cluster.create({
+      id: 'heur-grupo-561-santa-marta',
+      codigo: 'H-561-SANTA-MARTA',
+      titulo: 'Grupo 561 en SANTA MARTA',
+      tipo: 'heuristic-grupo',
+      ciiuDivision: '56',
+      ciiuGrupo: '561',
+      municipio: 'SANTA MARTA',
+    })
+    await f.clusterRepo.saveMany([existing])
+
+    const useCase = new OnboardCompanyFromSignup(
+      f.classify,
+      f.companyRepo,
+      f.clusterRepo,
+      f.ciiuMapping,
+      f.membershipRepo,
+      f.recRepo,
+      new PeerMatcher(f.featureBuilder),
+      new ValueChainMatcher(),
+      new AllianceMatcher(),
+    )
+
+    const result = await useCase.execute({
+      userId: 'reuser',
+      description: 'Restaurante',
+      businessName: 'Casa Reuse',
+      municipio: 'SANTA MARTA',
+    })
+
+    expect(result.clusters).toHaveLength(1)
+    expect(result.clusters[0].id).toBe('heur-grupo-561-santa-marta')
+    expect(await f.clusterRepo.count()).toBe(1)
   })
 
   it('caps recommendations per relation type to avoid flooding', async () => {
@@ -275,6 +321,6 @@ describe('OnboardCompanyFromSignup', () => {
     const referentes = result.recommendations.filter(
       (r) => r.relationType === 'referente',
     )
-    expect(referentes.length).toBeLessThanOrEqual(10)
+    expect(referentes.length).toBeLessThanOrEqual(2)
   })
 })

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -192,7 +192,7 @@ describe('GenerateRecommendations', () => {
       expect(await setup.recRepo.countBySource('src')).toBeLessThanOrEqual(20)
     })
 
-    it('caps each (relationType) to at most 5 recommendations per company', async () => {
+    it('caps each (relationType) to at most 2 recommendations per company', async () => {
       const setup = makeSetup()
       const companies: Company[] = [
         company({ id: 'banano', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
@@ -213,7 +213,7 @@ describe('GenerateRecommendations', () => {
         'banano',
         'cliente',
       )
-      expect(clientes.length).toBeLessThanOrEqual(5)
+      expect(clientes.length).toBeLessThanOrEqual(2)
     })
   })
 

--- a/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
+++ b/src/brain/__tests__/recommendations/SupabaseRecommendationRepository.test.ts
@@ -110,7 +110,7 @@ describe('SupabaseRecommendationRepository', () => {
             source: 'ai-inferred',
           }),
         ]),
-        { onConflict: 'id' },
+        { onConflict: 'source_company_id,target_company_id,relation_type' },
       )
     })
 

--- a/src/brain/src/clusters/domain/repositories/ClusterRepository.ts
+++ b/src/brain/src/clusters/domain/repositories/ClusterRepository.ts
@@ -8,6 +8,15 @@ export interface ClusterRepository {
   findById(id: string): Promise<Cluster | null>
   findManyByIds(ids: string[]): Promise<Cluster[]>
   findByTipo(tipo: ClusterType): Promise<Cluster[]>
+  /**
+   * Finds a heuristic-grupo cluster matching both ciiuGrupo and municipio.
+   * Used by the onboard flow to reuse existing heuristic clusters before
+   * creating a new one.
+   */
+  findByGrupoAndMunicipio(
+    ciiuGrupo: string,
+    municipio: string,
+  ): Promise<Cluster | null>
   saveMany(clusters: Cluster[]): Promise<void>
   updateDescripcion(id: string, descripcion: string): Promise<void>
   count(): Promise<number>

--- a/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/InMemoryClusterRepository.ts
@@ -24,6 +24,22 @@ export class InMemoryClusterRepository implements ClusterRepository {
     return Array.from(this.store.values()).filter((c) => c.tipo === tipo)
   }
 
+  async findByGrupoAndMunicipio(
+    ciiuGrupo: string,
+    municipio: string,
+  ): Promise<Cluster | null> {
+    for (const c of this.store.values()) {
+      if (
+        c.tipo === 'heuristic-grupo' &&
+        c.ciiuGrupo === ciiuGrupo &&
+        c.municipio === municipio
+      ) {
+        return c
+      }
+    }
+    return null
+  }
+
   async saveMany(clusters: Cluster[]): Promise<void> {
     for (const c of clusters) {
       this.store.set(c.id, c)

--- a/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterRepository.ts
+++ b/src/brain/src/clusters/infrastructure/repositories/SupabaseClusterRepository.ts
@@ -62,6 +62,21 @@ export class SupabaseClusterRepository implements ClusterRepository {
     return ((data ?? []) as ClusterRow[]).map((r) => this.toEntity(r))
   }
 
+  async findByGrupoAndMunicipio(
+    ciiuGrupo: string,
+    municipio: string,
+  ): Promise<Cluster | null> {
+    const { data, error } = await this.db
+      .from(TABLE)
+      .select('*')
+      .eq('tipo', 'heuristic-grupo')
+      .eq('ciiu_grupo', ciiuGrupo)
+      .eq('municipio', municipio)
+      .maybeSingle()
+    if (error) throw error
+    return data ? this.toEntity(data as ClusterRow) : null
+  }
+
   async saveMany(clusters: Cluster[]): Promise<void> {
     if (clusters.length === 0) return
     const rows = clusters.map((c) => this.toRow(c))

--- a/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
+++ b/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
@@ -13,7 +13,7 @@ import {
   CLUSTER_REPOSITORY,
   type ClusterRepository,
 } from '@/clusters/domain/repositories/ClusterRepository'
-import type { Cluster } from '@/clusters/domain/entities/Cluster'
+import { Cluster } from '@/clusters/domain/entities/Cluster'
 import { Company } from '@/companies/domain/entities/Company'
 import {
   COMPANY_REPOSITORY,
@@ -50,7 +50,7 @@ export interface OnboardCompanyFromSignupResult {
   recommendations: Recommendation[]
 }
 
-const TOP_PER_TYPE = 10
+const TOP_PER_TYPE = 2
 
 @Injectable()
 export class OnboardCompanyFromSignup implements UseCase<
@@ -97,7 +97,10 @@ export class OnboardCompanyFromSignup implements UseCase<
     })
     await this.companyRepo.saveMany([company])
 
-    const clusters = await this.resolveClusters(classification.ciiu.code)
+    const clusters = await this.resolveClusters(
+      classification.ciiu,
+      input.municipio,
+    )
     if (clusters.length > 0) {
       const memberships: Membership[] = clusters.map((c) => ({
         clusterId: c.id,
@@ -126,11 +129,35 @@ export class OnboardCompanyFromSignup implements UseCase<
     }
   }
 
-  private async resolveClusters(ciiuCode: string): Promise<Cluster[]> {
+  private async resolveClusters(
+    ciiu: { code: string; division: string; grupo: string },
+    municipio: string,
+  ): Promise<Cluster[]> {
     const ciiuToClusters = await this.ciiuMappingRepo.getCiiuToClusterMap()
-    const clusterIds = ciiuToClusters.get(ciiuCode) ?? []
-    if (clusterIds.length === 0) return []
-    return this.clusterRepo.findManyByIds(clusterIds)
+    const clusterIds = ciiuToClusters.get(ciiu.code) ?? []
+    if (clusterIds.length > 0) {
+      const predefined = await this.clusterRepo.findManyByIds(clusterIds)
+      if (predefined.length > 0) return predefined
+    }
+
+    const existing = await this.clusterRepo.findByGrupoAndMunicipio(
+      ciiu.grupo,
+      municipio,
+    )
+    if (existing) return [existing]
+
+    const slug = slugify(municipio)
+    const heuristic = Cluster.create({
+      id: `heur-grupo-${ciiu.grupo}-${slug}`,
+      codigo: `H-${ciiu.grupo}-${slug.toUpperCase()}`,
+      titulo: `Grupo ${ciiu.grupo} en ${municipio}`,
+      tipo: 'heuristic-grupo',
+      ciiuDivision: ciiu.division,
+      ciiuGrupo: ciiu.grupo,
+      municipio,
+    })
+    await this.clusterRepo.saveMany([heuristic])
+    return [heuristic]
   }
 
   private async generateRecommendations(
@@ -163,6 +190,15 @@ export class OnboardCompanyFromSignup implements UseCase<
       }),
     )
   }
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
 function resolveCompanyId(input: OnboardCompanyFromSignupInput): string {

--- a/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
@@ -40,7 +40,7 @@ export interface GenerateRecommendationsResult {
 }
 
 const MIN_CONFIDENCE = 0.5
-const TOP_PER_TYPE = 5
+const TOP_PER_TYPE = 2
 const TOP_TOTAL = 20
 const AI_WEIGHT = 0.6
 const PROXIMITY_WEIGHT = 0.4

--- a/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
+++ b/src/brain/src/recommendations/infrastructure/repositories/SupabaseRecommendationRepository.ts
@@ -43,9 +43,9 @@ export class SupabaseRecommendationRepository implements RecommendationRepositor
     const rows = recs.map((r) => this.toRow(r))
     for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
       const chunk = rows.slice(i, i + CHUNK_SIZE)
-      const { error } = await this.db
-        .from(TABLE)
-        .upsert(chunk, { onConflict: 'id' })
+      const { error } = await this.db.from(TABLE).upsert(chunk, {
+        onConflict: 'source_company_id,target_company_id,relation_type',
+      })
       if (error) throw error
     }
   }

--- a/src/front/__tests__/core/app/api/auth/register/route.test.ts
+++ b/src/front/__tests__/core/app/api/auth/register/route.test.ts
@@ -40,8 +40,6 @@ vi.mock('@/core/shared/infrastructure/logger/serverLogger', () => ({
 
 // Mock Supabase server client
 const mockSignUp = vi.fn()
-const mockUpdateUserById = vi.fn()
-const mockDeleteUser = vi.fn()
 const mockInsert = vi.fn()
 const mockSelect = vi.fn()
 const mockSingle = vi.fn()
@@ -54,11 +52,9 @@ vi.mock('@/core/shared/infrastructure/supabase/server', () => {
     createSupabaseServerClient: vi.fn(() => ({
       auth: {
         signUp: mockSignUp,
-        admin: {
-          updateUserById: mockUpdateUserById,
-          deleteUser: mockDeleteUser,
-        },
       },
+    })),
+    createSupabaseUserClient: vi.fn(() => ({
       from: mockFrom,
     })),
   }
@@ -84,12 +80,6 @@ describe('POST /api/auth/register', () => {
           refresh_token: 'refresh-token-456',
         },
       },
-      error: null,
-    })
-
-    // Default successful email confirmation
-    mockUpdateUserById.mockResolvedValue({
-      data: { user: { id: 'user-123' } },
       error: null,
     })
 
@@ -204,27 +194,6 @@ describe('POST /api/auth/register', () => {
           has_chamber: true,
         }),
       )
-    })
-
-    it('calls email confirmation after user creation', async () => {
-      const request = new Request('http://localhost/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({
-          businessName: 'Test Business',
-          sector: 'comercio',
-          email: 'test@example.com',
-          password: 'TestPass123',
-          municipio: 'Santa Marta',
-          barrio: 'Centro',
-          descripcion: 'Negocio de prueba que vende productos a clientes',
-        }),
-      })
-
-      await POST(request)
-
-      expect(mockUpdateUserById).toHaveBeenCalledWith('user-123', {
-        email_confirm: true,
-      })
     })
 
     it('handles null/undefined optional fields correctly', async () => {
@@ -550,60 +519,10 @@ describe('POST /api/auth/register', () => {
       const data = await response.json()
       expect(data.error).toContain('Email already exists')
     })
-
-    it('returns error when email confirmation fails', async () => {
-      mockUpdateUserById.mockResolvedValue({
-        data: null,
-        error: { message: 'Could not update user' },
-      })
-
-      const request = new Request('http://localhost/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({
-          businessName: 'Test Business',
-          sector: 'comercio',
-          email: 'test@example.com',
-          password: 'TestPass123',
-          municipio: 'Santa Marta',
-          barrio: 'Centro',
-          descripcion: 'Negocio de prueba que vende productos a clientes',
-        }),
-      })
-
-      const response = await POST(request)
-
-      expect(response.status).toBe(400)
-      const data = await response.json()
-      expect(data.error).toBe('Could not update user')
-    })
-
-    it('rolls back auth user if email confirmation fails', async () => {
-      mockUpdateUserById.mockResolvedValue({
-        data: null,
-        error: { message: 'Could not update user' },
-      })
-
-      const request = new Request('http://localhost/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({
-          businessName: 'Test Business',
-          sector: 'comercio',
-          email: 'test@example.com',
-          password: 'TestPass123',
-          municipio: 'Santa Marta',
-          barrio: 'Centro',
-          descripcion: 'Negocio de prueba que vende productos a clientes',
-        }),
-      })
-
-      await POST(request)
-
-      expect(mockDeleteUser).toHaveBeenCalledWith('user-123')
-    })
   })
 
   describe('Profile Creation Errors', () => {
-    it('rolls back auth user if profile creation fails', async () => {
+    it('returns 400 when profile insert fails', async () => {
       mockSingle.mockResolvedValue({
         data: null,
         error: { message: 'Insert failed' },
@@ -627,30 +546,6 @@ describe('POST /api/auth/register', () => {
       expect(response.status).toBe(400)
       const data = await response.json()
       expect(data.error).toBe('Insert failed')
-    })
-
-    it('deletes auth user when profile insert fails', async () => {
-      mockSingle.mockResolvedValue({
-        data: null,
-        error: { message: 'Insert failed' },
-      })
-
-      const request = new Request('http://localhost/api/auth/register', {
-        method: 'POST',
-        body: JSON.stringify({
-          businessName: 'Test Business',
-          sector: 'comercio',
-          email: 'test@example.com',
-          password: 'TestPass123',
-          municipio: 'Santa Marta',
-          barrio: 'Centro',
-          descripcion: 'Negocio de prueba que vende productos a clientes',
-        }),
-      })
-
-      await POST(request)
-
-      expect(mockDeleteUser).toHaveBeenCalledWith('user-123')
     })
   })
 
@@ -815,14 +710,6 @@ describe('POST /api/auth/register', () => {
         })
       })
 
-      mockUpdateUserById.mockImplementation(() => {
-        callOrder.push('updateUserById')
-        return Promise.resolve({
-          data: { user: { id: 'user-123' } },
-          error: null,
-        })
-      })
-
       mockSingle.mockImplementation(() => {
         callOrder.push('profileInsert')
         return Promise.resolve({
@@ -851,7 +738,7 @@ describe('POST /api/auth/register', () => {
 
       await POST(request)
 
-      expect(callOrder).toEqual(['signUp', 'updateUserById', 'profileInsert'])
+      expect(callOrder).toEqual(['signUp', 'profileInsert'])
     })
 
     it('inserts profile with correct user id from auth response', async () => {

--- a/src/front/__tests__/core/shared/infrastructure/env.test.ts
+++ b/src/front/__tests__/core/shared/infrastructure/env.test.ts
@@ -17,6 +17,12 @@ const envSchema = z.object({
   SUPABASE_PUBLISHABLE_KEY: z
     .string()
     .min(1, { error: 'SUPABASE_PUBLISHABLE_KEY cannot be empty' }),
+  NEXT_PUBLIC_SUPABASE_URL: z.url({
+    error: 'NEXT_PUBLIC_SUPABASE_URL must be a valid URL',
+  }),
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1, {
+    error: 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY cannot be empty',
+  }),
   DEBUG_ENABLED: z.enum(['true', 'false']).optional().default('false'),
 })
 
@@ -24,6 +30,8 @@ describe('envSchema', () => {
   const validEnv = {
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_abc123',
+    NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_abc123',
   }
 
   it('should parse valid environment variables', () => {
@@ -37,8 +45,40 @@ describe('envSchema', () => {
   })
 
   it('should reject missing SUPABASE_URL', () => {
+    const { SUPABASE_URL: _, ...withoutUrl } = validEnv
+    const result = envSchema.safeParse(withoutUrl)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject missing NEXT_PUBLIC_SUPABASE_URL', () => {
+    const { NEXT_PUBLIC_SUPABASE_URL: _, ...withoutPublicUrl } = validEnv
+    const result = envSchema.safeParse(withoutPublicUrl)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject missing NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', () => {
+    const { NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: _, ...withoutPublicKey } =
+      validEnv
+    const result = envSchema.safeParse(withoutPublicKey)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', () => {
     const result = envSchema.safeParse({
-      SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_abc123',
+      ...validEnv,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: '',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid URL for NEXT_PUBLIC_SUPABASE_URL', () => {
+    const result = envSchema.safeParse({
+      ...validEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'not-a-url',
     })
 
     expect(result.success).toBe(false)
@@ -54,9 +94,8 @@ describe('envSchema', () => {
   })
 
   it('should reject missing SUPABASE_PUBLISHABLE_KEY', () => {
-    const result = envSchema.safeParse({
-      SUPABASE_URL: 'https://example.supabase.co',
-    })
+    const { SUPABASE_PUBLISHABLE_KEY: _, ...withoutKey } = validEnv
+    const result = envSchema.safeParse(withoutKey)
 
     expect(result.success).toBe(false)
   })
@@ -127,12 +166,24 @@ describe('parseEnv', () => {
   const validEnv = {
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_abc123',
+    NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_abc123',
+  }
+
+  function setEnv() {
+    for (const [key, value] of Object.entries(validEnv)) {
+      process.env[key] = value
+    }
+  }
+
+  function unsetEnv() {
+    for (const key of Object.keys(validEnv)) {
+      delete process.env[key]
+    }
   }
 
   it('should return typed env object for valid input', async () => {
-    // Seteamos env vars ANTES de importar el módulo
-    process.env.SUPABASE_URL = validEnv.SUPABASE_URL
-    process.env.SUPABASE_PUBLISHABLE_KEY = validEnv.SUPABASE_PUBLISHABLE_KEY
+    setEnv()
 
     // Dynamic import — el módulo se evalúa con las env vars ya seteadas
     const { parseEnv } = await import('@/core/shared/infrastructure/env')
@@ -141,27 +192,26 @@ describe('parseEnv', () => {
 
     expect(env.SUPABASE_URL).toBe('https://example.supabase.co')
     expect(env.SUPABASE_PUBLISHABLE_KEY).toBe('sb_publishable_abc123')
+    expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe('https://example.supabase.co')
+    expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe(
+      'sb_publishable_abc123',
+    )
 
-    // Cleanup
-    delete process.env.SUPABASE_URL
-    delete process.env.SUPABASE_PUBLISHABLE_KEY
+    unsetEnv()
   })
 
   it('should throw with descriptive error for invalid input', async () => {
-    process.env.SUPABASE_URL = validEnv.SUPABASE_URL
-    process.env.SUPABASE_PUBLISHABLE_KEY = validEnv.SUPABASE_PUBLISHABLE_KEY
+    setEnv()
 
     const { parseEnv } = await import('@/core/shared/infrastructure/env')
 
     expect(() => parseEnv({})).toThrow('Invalid environment variables')
 
-    delete process.env.SUPABASE_URL
-    delete process.env.SUPABASE_PUBLISHABLE_KEY
+    unsetEnv()
   })
 
   it('should include variable name in error message', async () => {
-    process.env.SUPABASE_URL = validEnv.SUPABASE_URL
-    process.env.SUPABASE_PUBLISHABLE_KEY = validEnv.SUPABASE_PUBLISHABLE_KEY
+    setEnv()
 
     const { parseEnv } = await import('@/core/shared/infrastructure/env')
 
@@ -169,7 +219,6 @@ describe('parseEnv', () => {
       'SUPABASE_PUBLISHABLE_KEY',
     )
 
-    delete process.env.SUPABASE_URL
-    delete process.env.SUPABASE_PUBLISHABLE_KEY
+    unsetEnv()
   })
 })

--- a/src/front/app/api/auth/register/route.ts
+++ b/src/front/app/api/auth/register/route.ts
@@ -5,7 +5,10 @@ import {
   type BrainOnboardResponse,
 } from '@/core/shared/infrastructure/brain/brainClient'
 import { serverLogger } from '@/core/shared/infrastructure/logger/serverLogger'
-import { createSupabaseServerClient } from '@/core/shared/infrastructure/supabase/server'
+import {
+  createSupabaseServerClient,
+  createSupabaseUserClient,
+} from '@/core/shared/infrastructure/supabase/server'
 import { User } from '@/core/users/domain/entities/User'
 
 const VALID_YEARS = new Set<BrainOnboardRequest['yearsOfOperation']>([
@@ -96,7 +99,7 @@ export async function POST(request: Request) {
       },
     })
 
-    if (authError || !authData.user) {
+    if (authError || !authData.user || !authData.session) {
       serverLogger.error('[POST /api/auth/register] Auth error:', authError)
       return Response.json(
         { error: authError?.message || 'Failed to create user' },
@@ -104,28 +107,12 @@ export async function POST(request: Request) {
       )
     }
 
-    // Auto-confirm email so the user gets a session immediately
-    const { error: confirmError } = await supabase.auth.admin.updateUserById(
-      authData.user.id,
-      {
-        email_confirm: true,
-      },
-    )
-
-    if (confirmError) {
-      serverLogger.error(
-        '[POST /api/auth/register] Email confirm error:',
-        confirmError,
-      )
-      await supabase.auth.admin.deleteUser(authData.user.id)
-      return Response.json(
-        { error: confirmError?.message || 'Failed to confirm email' },
-        { status: 400 },
-      )
-    }
+    // From here on we act AS the new user so RLS policies (auth.uid() = id)
+    // allow inserting their own profile and linking the company later.
+    const userScoped = createSupabaseUserClient(authData.session.access_token)
 
     // Create user profile in public.users table
-    const { data, error: profileError } = await supabase
+    const { data, error: profileError } = await userScoped
       .from('users')
       .insert({
         id: authData.user.id,
@@ -148,7 +135,6 @@ export async function POST(request: Request) {
         '[POST /api/auth/register] Profile error:',
         profileError,
       )
-      await supabase.auth.admin.deleteUser(authData.user.id)
       return Response.json(
         { error: profileError?.message || 'Failed to create user profile' },
         { status: 400 },
@@ -187,7 +173,7 @@ export async function POST(request: Request) {
         } satisfies BrainOnboardRequest,
       )
 
-      const { error: linkError } = await supabase
+      const { error: linkError } = await userScoped
         .from('users')
         .update({ company_id: onboarding.company.id })
         .eq('id', user.id)

--- a/src/front/core/shared/infrastructure/env.ts
+++ b/src/front/core/shared/infrastructure/env.ts
@@ -7,13 +7,33 @@ import { z } from 'zod'
  * Se parsea UNA vez al levantar — si falta algo, explota inmediato
  * con un mensaje claro en vez de un error críptico en runtime.
  *
- * NINGUNA variable lleva NEXT_PUBLIC_ porque todo corre server-side (BFF).
+ * Casi todas son server-only (BFF). Las únicas excepciones `NEXT_PUBLIC_`
+ * están documentadas en AGENTS.md sección 8.3 — todas son no-secretos
+ * (URLs, flags, publishable keys diseñadas para vivir en el cliente).
  */
 export const envSchema = z.object({
   SUPABASE_URL: z.url({ error: 'SUPABASE_URL must be a valid URL' }),
   SUPABASE_PUBLISHABLE_KEY: z
     .string()
     .min(1, { error: 'SUPABASE_PUBLISHABLE_KEY cannot be empty' }),
+  /**
+   * Mismo valor que SUPABASE_URL pero con prefijo NEXT_PUBLIC_ para que
+   * Next.js lo inline en el bundle del browser. Necesario para que
+   * `createSupabaseBrowserClient` (cliente del lado del navegador) pueda
+   * gestionar la sesión de auth (setSession, refresh, signOut).
+   * NO es secreto — es la URL pública del proyecto Supabase.
+   */
+  NEXT_PUBLIC_SUPABASE_URL: z.url({
+    error: 'NEXT_PUBLIC_SUPABASE_URL must be a valid URL',
+  }),
+  /**
+   * Mismo valor que SUPABASE_PUBLISHABLE_KEY pero con prefijo NEXT_PUBLIC_.
+   * NO es secreto — la "publishable key" de Supabase está diseñada para
+   * vivir en el cliente. RLS es lo que protege la data.
+   */
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1, {
+    error: 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY cannot be empty',
+  }),
   /**
    * Habilita logging detallado en server-side.
    * Opcional — si no está definido, el logger queda deshabilitado (NullLogger).

--- a/src/front/core/shared/infrastructure/supabase/server.ts
+++ b/src/front/core/shared/infrastructure/supabase/server.ts
@@ -21,3 +21,19 @@ import type { Database } from './database.types'
 export function createSupabaseServerClient() {
   return createClient<Database>(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY)
 }
+
+/**
+ * Per-request Supabase client scoped to a specific user via their JWT.
+ * RLS sees `auth.uid()` resolved from the access_token, so policies that
+ * check `auth.uid() = users.id` apply correctly. Use this for any operation
+ * that must run as the user (insert/update/select on their own rows).
+ */
+export function createSupabaseUserClient(accessToken: string) {
+  return createClient<Database>(
+    env.SUPABASE_URL,
+    env.SUPABASE_PUBLISHABLE_KEY,
+    {
+      global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    },
+  )
+}

--- a/src/front/core/shared/infrastructure/swr/SWRProvider.tsx
+++ b/src/front/core/shared/infrastructure/swr/SWRProvider.tsx
@@ -2,7 +2,25 @@
 
 import { SWRConfig } from 'swr'
 
+import { setTokenProvider } from '@/core/shared/infrastructure/http/httpClient'
+import { createSupabaseBrowserClient } from '@/core/shared/infrastructure/supabase/client'
+
 import { fetcher } from './fetcher'
+
+// Enlazamos el httpClient con la sesión de Supabase a nivel de módulo
+// (no dentro de useEffect) para evitar la race condition donde un useSWR
+// dispara el fetch antes de que el efecto del provider corra. React ejecuta
+// los efectos bottom-up: el child fetcher saldría sin Authorization.
+// `typeof window` evita que esto se ejecute en SSR (este módulo carga en
+// el server para marcar el boundary 'use client', pero solo queremos
+// configurar el cliente en el browser).
+if (typeof window !== 'undefined') {
+  const supabase = createSupabaseBrowserClient()
+  setTokenProvider(async () => {
+    const { data } = await supabase.auth.getSession()
+    return data.session?.access_token ?? null
+  })
+}
 
 /**
  * SWR Provider — Client Component

--- a/supabase/migrations/20260426220000_users_rls_policies.sql
+++ b/supabase/migrations/20260426220000_users_rls_policies.sql
@@ -1,0 +1,32 @@
+-- =====================================================================
+-- RLS policies for public.users
+--
+-- The signup flow uses the publishable key + the new user's JWT to insert
+-- their own profile. RLS must allow each authenticated user to manage
+-- ONLY their own row (auth.uid() must match users.id, which is the same
+-- as auth.users.id by design).
+-- =====================================================================
+
+alter table public.users enable row level security;
+
+drop policy if exists "users_insert_own" on public.users;
+create policy "users_insert_own"
+  on public.users
+  for insert
+  to authenticated
+  with check (auth.uid() = id);
+
+drop policy if exists "users_select_own" on public.users;
+create policy "users_select_own"
+  on public.users
+  for select
+  to authenticated
+  using (auth.uid() = id);
+
+drop policy if exists "users_update_own" on public.users;
+create policy "users_update_own"
+  on public.users
+  for update
+  to authenticated
+  using (auth.uid() = id)
+  with check (auth.uid() = id);


### PR DESCRIPTION
## Summary

The signup wizard was failing at four different layers. This bundles the chain of fixes so the flow lands working end-to-end — from registration in the front to recommendations + clusters persisted in the brain.

### Front (auth + RLS + browser auth)

- **Drop `auth.admin.*`** from `POST /api/auth/register`. Those calls needed the service role key (only the publishable key is configured), so the auto-confirm + rollback path was returning "valid bearer token" errors. With *Confirm email* disabled in Supabase, `signUp` returns a session immediately. Tradeoff accepted: orphan `auth.users` rows on profile-insert failure.
- **RLS policies + per-user client** for `public.users` (insert / select / update own row, `auth.uid() = id`). New helper `createSupabaseUserClient(accessToken)` lets the route insert and link `company_id` AS the new user via their JWT, so RLS resolves correctly.
- **`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`** added to the Zod schema and AGENTS.md §8.3 as documented exceptions. Required by `createSupabaseBrowserClient` to manage the auth session client-side. BFF preserved — data queries still go through `/api/*`, RLS still protects rows.
- **Wire `setTokenProvider`** in `SWRProvider` at module load (not in `useEffect`, to avoid the bottom-up effect race where child `useSWR` fires before the parent provider sets the token). Every axios/SWR request now carries `Authorization: Bearer <access_token>`, fixing the 401 from `/api/me/recommendations/grouped`.

### Brain (onboard resilience)

- **Cap recommendations per relation type to 2** (was 10 in onboard, 5 in generate). Keeps MVP responses small.
- **Fix `23505` on re-onboard** — `SupabaseRecommendationRepository.saveAll` was upserting on `id`, but the table's business unique is `(source_company_id, target_company_id, relation_type)`. Each onboard generates new UUIDs, so the upsert never matched and Postgres tripped on the business unique. Switched `onConflict` to the business tuple. Verified no FKs reference `recommendations.id`.
- **3-step cluster fallback** so every onboarded company has at least one cluster, with zero seed data and zero LLM:
  1. Predefined via `cluster_ciiu_mapping` (existing behavior)
  2. Existing `heuristic-grupo` cluster matching `(ciiuGrupo, municipio)` — reused
  3. Auto-create deterministic `heuristic-grupo` cluster — id `heur-grupo-{ciiuGrupo}-{slug(municipio)}`. Two onboards in the same group + municipio fall into the same cluster.

## Migration

`20260426220000_users_rls_policies.sql` — apply with `supabase db push`. Already applied to the dev project on this branch. No brain migrations needed.

## Tests

- **Front**: 123 passed (16 files) — added 4 cases for the new env vars, updated route handler test mock to drop admin and add the per-user client.
- **Brain**: 624 passed (75 files), up from 617 — added 7 cases covering `findByGrupoAndMunicipio` (InMemory + Supabase), the cluster fallback / reuse paths in onboard, and updated the upsert assertion + cap assertions for the new values.

## Test plan

- [ ] In Supabase dashboard, **disable** *Authentication → Email → Confirm email* (required for `signUp` to return a session).
- [ ] Add `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` to `.env` and `.env.example` (same values as their server-side counterparts).
- [ ] Set `AGENT_ENABLED=false` and `AI_MATCH_INFERENCE_ENABLED=false` in `.env` to stop the brain cron from burning Gemini's free-tier quota (20 req/day) every minute. Without these, classification on signup still hits 429.
- [ ] Apply the migration: `supabase db push` (verify with `select policyname from pg_policies where tablename='users';` — should return three rows).
- [ ] Restart the dev server (Next.js inlines `NEXT_PUBLIC_*` at start, no HMR pickup) AND the brain (Nest reads env at boot).
- [ ] Walk the registration wizard end-to-end. Expect:
  - `POST /api/auth/register` → 201
  - Brain `POST /companies/onboard` → 200 with `clusters.length >= 1` (auto-created if no predefined mapping) and recommendations grouped by relation type, capped at 2 per type
  - Re-running the same registration (same NIT) should NOT throw `23505`
  - Auto-redirect to `/app/recomendaciones`
  - `GET /api/me/recommendations/grouped` → 200 (was 401)

## Follow-ups (not in this PR)

- Login form (`src/front/app/[locale]/login/_components/login-form.tsx`) is currently a `setTimeout` redirect — needs a real `signInWithPassword` implementation.
- Brain `POST /companies/onboard` 404 on Render is a deployment issue (manual redeploy of `silver-adventure-9f6p` from `main`), not a code issue.
- Render auto-deploy on `main` should be verified / enabled to avoid the missing-controller pattern recurring.
- The auto-created heuristic clusters get populated as the agent scan runs (when re-enabled). Worth adding a one-time backfill script if many companies onboard before the agent is turned back on.