### PR TITLE
chore(cursor): add supabase mcp server to example config

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -10,6 +10,9 @@
         "@21st-dev/magic@latest",
         "API_KEY=\"YOUR_21ST_DEV_API_KEY_HERE\""
       ]
+    },
+    "supabase": {
+      "url": "https://mcp.supabase.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds the Supabase MCP server entry to `.cursor/mcp.json.example` so the team gets it out of the box when bootstrapping their local `.cursor/mcp.json`.
- Uses the hosted endpoint `https://mcp.supabase.com/mcp` with OAuth 2.1 — no token committed, no env var required. Each developer authenticates from their own Cursor session.
- The real `.cursor/mcp.json` is gitignored (it contains other API keys), so this `.example` file is the canonical doc for the team.

## Why

We need the Supabase MCP available in Cursor to query/audit the database from the agent (`search_docs`, `execute_sql`, `get_advisors`, `apply_migration`, etc.) without leaving the editor. Documenting it in the example keeps the setup reproducible.

## Test plan

- [ ] Pull this branch, copy `.cursor/mcp.json.example` to `.cursor/mcp.json` (merge with your local entries if you already have one).
- [ ] Reload Cursor window.
- [ ] Open Settings → MCP & Integrations → confirm `supabase` appears.
- [ ] Click authenticate, complete the OAuth flow in the browser, select project `lsgovsiedibunnsxjdig`.
- [ ] Verify that in a new chat the agent can use Supabase MCP tools (e.g. `list_tables`, `get_advisors`).

## Notes

- The Supabase MCP server uses OAuth 2.1 — the user authorizes per-Cursor-session, no Personal Access Token is stored on disk.
- Does NOT modify the local `.cursor/mcp.json` (gitignored). Each developer must add the entry themselves or copy from the example.
- No app/runtime code changed. Pre-push test suite passed (front: 123, brain: 624).

Made with [Cursor](https://cursor.com)