### PR TITLE
feat(front): wire real supabase auth and current user across app

### DIFF
--- a/src/front/__tests__/core/app/api/me/route.test.ts
+++ b/src/front/__tests__/core/app/api/me/route.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/core/shared/infrastructure/env', () => ({
+  env: {
+    SUPABASE_URL: 'https://test.supabase.co',
+    SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test',
+  },
+}))
+
+vi.mock('@/core/shared/infrastructure/logger/serverLogger', () => ({
+  serverLogger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+const mockGetUser = vi.fn()
+const mockSingle = vi.fn()
+const mockEq = vi.fn(() => ({ single: mockSingle }))
+const mockSelect = vi.fn(() => ({ eq: mockEq }))
+const mockFrom = vi.fn(() => ({ select: mockSelect }))
+
+vi.mock('@/core/shared/infrastructure/supabase/server', () => ({
+  createSupabaseServerClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}))
+
+const { GET } = await import('@/app/api/me/route')
+
+function buildRequest(token: string | null): Request {
+  const headers: Record<string, string> = {}
+  if (token !== null) headers.Authorization = token
+  return new Request('http://localhost/api/me', { headers })
+}
+
+describe('GET /api/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const response = await GET(buildRequest(null))
+    expect(response.status).toBe(401)
+    expect(mockGetUser).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'invalid token' },
+    })
+
+    const response = await GET(buildRequest('Bearer bad-token'))
+    expect(response.status).toBe(401)
+    expect(mockGetUser).toHaveBeenCalledWith('bad-token')
+  })
+
+  it('returns 404 when user has no profile in public.users', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    })
+    mockSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'no rows' },
+    })
+
+    const response = await GET(buildRequest('Bearer good-token'))
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('Profile not found')
+  })
+
+  it('returns mapped profile on happy path', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    })
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'user-123',
+        name: 'Hotel Brisas',
+        email: 'hola@hotelbrisas.com',
+        sector: 'turismo',
+        barrio: 'Rodadero',
+        municipio: 'Santa Marta',
+        company_id: 'co-9',
+      },
+      error: null,
+    })
+
+    const response = await GET(buildRequest('Bearer good-token'))
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      user: {
+        id: string
+        name: string
+        email: string
+        sector: string
+        barrio: string
+        municipio: string
+        companyId: string
+      }
+    }
+    expect(body.user).toEqual({
+      id: 'user-123',
+      name: 'Hotel Brisas',
+      email: 'hola@hotelbrisas.com',
+      sector: 'turismo',
+      barrio: 'Rodadero',
+      municipio: 'Santa Marta',
+      companyId: 'co-9',
+    })
+    expect(mockSelect).toHaveBeenCalledWith(
+      'id, name, email, sector, barrio, municipio, company_id',
+    )
+    expect(mockEq).toHaveBeenCalledWith('id', 'user-123')
+  })
+
+  it('strips bearer prefix case-insensitively', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    })
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        id: 'user-123',
+        name: 'X',
+        email: null,
+        sector: null,
+        barrio: null,
+        municipio: null,
+        company_id: null,
+      },
+      error: null,
+    })
+
+    const response = await GET(buildRequest('bearer  TOK '))
+    expect(response.status).toBe(200)
+    expect(mockGetUser).toHaveBeenCalledWith('TOK')
+  })
+})

--- a/src/front/__tests__/integration/app/UserMenu.test.tsx
+++ b/src/front/__tests__/integration/app/UserMenu.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { CurrentUser } from '@/app/[locale]/app/_data/types'
+
+const mockPush = vi.fn()
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const mockSignOut = vi.fn()
+vi.mock('@/core/shared/infrastructure/supabase/client', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { signOut: mockSignOut },
+  }),
+}))
+
+const mockMutate = vi.fn().mockResolvedValue(undefined)
+vi.mock('swr', async () => {
+  const actual: object = await vi.importActual('swr')
+  return {
+    ...actual,
+    useSWRConfig: () => ({ mutate: mockMutate }),
+  }
+})
+
+const { UserMenu } = await import('@/app/[locale]/app/_components/user-menu')
+
+const sampleUser: CurrentUser = {
+  id: 'u-1',
+  nombre: 'Hotel Brisas Marinas',
+  iniciales: 'HB',
+  empresa: 'Hotel Brisas Marinas',
+  sector: 'turismo',
+  barrio: 'Rodadero',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSignOut.mockResolvedValue({ error: null })
+})
+
+describe('<UserMenu />', () => {
+  it('opens the menu and signs the user out', async () => {
+    const user = userEvent.setup()
+    render(<UserMenu currentUser={sampleUser} />)
+
+    await user.click(screen.getByRole('button', { expanded: false }))
+    await user.click(screen.getByRole('menuitem', { name: /logout/ }))
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('shows the user initials and name', () => {
+    render(<UserMenu currentUser={sampleUser} />)
+    expect(screen.getByText('HB')).toBeInTheDocument()
+    expect(screen.getByText('Hotel Brisas Marinas')).toBeInTheDocument()
+  })
+})

--- a/src/front/__tests__/integration/login/LoginForm.test.tsx
+++ b/src/front/__tests__/integration/login/LoginForm.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { type ReactNode, createElement } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockPush = vi.fn()
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  Link: ({ children, ...props }: { children: ReactNode; href: string }) =>
+    createElement('a', props, children),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace?: string) => {
+    const fn = (key: string) => (namespace ? `${namespace}.${key}` : key)
+    return fn
+  },
+}))
+
+const mockSignInWithPassword = vi.fn()
+vi.mock('@/core/shared/infrastructure/supabase/client', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { signInWithPassword: mockSignInWithPassword },
+  }),
+}))
+
+const { LoginForm } =
+  await import('@/app/[locale]/login/_components/login-form')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('<LoginForm />', () => {
+  it('shows validation errors for invalid email and short password', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<LoginForm />)
+
+    const emailInput = screen.getByLabelText(/Login.fields.email.label/i)
+    const passwordInput = screen.getByLabelText(/Login.fields.password.label/i)
+    await user.type(emailInput, 'nope')
+    await user.type(passwordInput, '123')
+
+    expect(emailInput).toHaveValue('nope')
+    expect(passwordInput).toHaveValue('123')
+
+    const form = container.querySelector('form')!
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThanOrEqual(2)
+    })
+    const alertTexts = screen.getAllByRole('alert').map((el) => el.textContent)
+    expect(alertTexts).toContain('Login.errors.invalidEmail')
+    expect(alertTexts).toContain('Login.errors.minLength')
+    expect(mockSignInWithPassword).not.toHaveBeenCalled()
+  })
+
+  it('redirects on successful sign in', async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({ data: {}, error: null })
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(
+      screen.getByLabelText(/Login.fields.email.label/i),
+      'hola@example.com',
+    )
+    await user.type(
+      screen.getByLabelText(/Login.fields.password.label/i),
+      'Secret123',
+    )
+    await user.click(screen.getByRole('button', { name: /Login\.cta/ }))
+
+    await waitFor(() => {
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: 'hola@example.com',
+        password: 'Secret123',
+      })
+    })
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/app/recomendaciones')
+    })
+  })
+
+  it('shows i18n credentials error on Supabase invalid credentials', async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: {},
+      error: { message: 'Invalid login credentials' },
+    })
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(
+      screen.getByLabelText(/Login.fields.email.label/i),
+      'hola@example.com',
+    )
+    await user.type(
+      screen.getByLabelText(/Login.fields.password.label/i),
+      'Secret123',
+    )
+    await user.click(screen.getByRole('button', { name: /Login\.cta/ }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Login.errors.invalidCredentials')
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('passes through other Supabase error messages verbatim', async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: {},
+      error: { message: 'Network unreachable' },
+    })
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(
+      screen.getByLabelText(/Login.fields.email.label/i),
+      'hola@example.com',
+    )
+    await user.type(
+      screen.getByLabelText(/Login.fields.password.label/i),
+      'Secret123',
+    )
+    await user.click(screen.getByRole('button', { name: /Login\.cta/ }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Network unreachable')
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+})

--- a/src/front/__tests__/integration/users/hooks/useCurrentUser.test.ts
+++ b/src/front/__tests__/integration/users/hooks/useCurrentUser.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { SWRConfig } from 'swr'
+
+import { httpClient } from '@/core/shared/infrastructure/http/httpClient'
+import { useCurrentUser } from '@/core/users/infrastructure/hooks/useCurrentUser'
+
+const mockGet = vi.spyOn(httpClient, 'get')
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      SWRConfig,
+      {
+        value: {
+          dedupingInterval: 0,
+          provider: () => new Map(),
+          shouldRetryOnError: false,
+          fetcher: async (url: string) => {
+            const res = await httpClient.get(url)
+            return res.data
+          },
+        },
+      },
+      children,
+    )
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useCurrentUser', () => {
+  it('maps the API response to a CurrentUser DTO and computes initials', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'u-1',
+          name: 'Hotel Brisas Marinas',
+          email: 'hola@brisas.com',
+          sector: 'turismo',
+          barrio: 'Rodadero',
+          municipio: 'Santa Marta',
+          companyId: 'co-9',
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+    })
+
+    const { result } = renderHook(() => useCurrentUser(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.user).toEqual({
+      id: 'u-1',
+      nombre: 'Hotel Brisas Marinas',
+      empresa: 'Hotel Brisas Marinas',
+      iniciales: 'HB',
+      sector: 'turismo',
+      barrio: 'Rodadero',
+    })
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('falls back to the first two characters when the name is a single word', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'u-2',
+          name: 'Empanadas',
+          email: null,
+          sector: null,
+          barrio: null,
+          municipio: null,
+          companyId: null,
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+    })
+
+    const { result } = renderHook(() => useCurrentUser(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.user?.iniciales).toBe('EM')
+    expect(result.current.user?.sector).toBe('')
+    expect(result.current.user?.barrio).toBe('')
+  })
+
+  it('uses raw slice fallback when the name has no alphabetic words', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'u-3',
+          name: '🏪',
+          email: null,
+          sector: null,
+          barrio: null,
+          municipio: null,
+          companyId: null,
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+    })
+
+    const { result } = renderHook(() => useCurrentUser(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.user?.iniciales).toBe('🏪'.slice(0, 2).toUpperCase())
+  })
+
+  it('exposes errors when the request fails', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    const { result } = renderHook(() => useCurrentUser(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined()
+    })
+
+    expect(result.current.user).toBeUndefined()
+    expect(result.current.error?.message).toBe('Unauthorized')
+  })
+
+  it('calls /api/me', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: 'u-1',
+          name: 'X Y',
+          email: null,
+          sector: null,
+          barrio: null,
+          municipio: null,
+          companyId: null,
+        },
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as never,
+    })
+
+    renderHook(() => useCurrentUser(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/me')
+    })
+  })
+})

--- a/src/front/app/[locale]/app/_components/app-header.tsx
+++ b/src/front/app/[locale]/app/_components/app-header.tsx
@@ -3,10 +3,8 @@ import { useTranslations } from 'next-intl'
 
 import { Link } from '@/i18n/navigation'
 
-import { mockCurrentUser } from '../_data/mock-user'
-
 import { AppNavLink } from './app-nav-link'
-import { UserMenu } from './user-menu'
+import { UserMenuLoader } from './user-menu-loader'
 
 export function AppHeader() {
   const t = useTranslations('App.Header')
@@ -50,7 +48,7 @@ export function AppHeader() {
           >
             <Bell className="h-5 w-5" />
           </button>
-          <UserMenu currentUser={mockCurrentUser} />
+          <UserMenuLoader />
         </div>
       </div>
     </header>

--- a/src/front/app/[locale]/app/_components/reco-header.tsx
+++ b/src/front/app/[locale]/app/_components/reco-header.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
+import { useCurrentUser } from '@/core/users/infrastructure/hooks/useCurrentUser'
+import { useRecomendaciones } from '@/core/recommendations/infrastructure/hooks/useRecomendaciones'
+
+/**
+ * Encabezado de la página de recomendaciones — client side para poder leer
+ * el conteo real de recos (SWR) y el nombre del negocio del usuario logueado
+ * sin depender de mocks.
+ */
+export function RecoHeader() {
+  const t = useTranslations('App.Recomendaciones')
+  const { data: recos, isLoading: isLoadingRecos } = useRecomendaciones()
+  const { user, isLoading: isLoadingUser } = useCurrentUser()
+
+  const count = recos?.length ?? 0
+  const empresa = user?.empresa ?? ''
+  const isLoading = isLoadingRecos || isLoadingUser
+
+  return (
+    <div>
+      <h1 className="font-display text-text text-3xl font-extrabold tracking-tight">
+        {t('title')}
+      </h1>
+      {isLoading ? (
+        <div
+          aria-hidden
+          className="bg-surface-hover mt-2 h-4 w-72 animate-pulse rounded"
+        />
+      ) : (
+        <p className="text-text-secondary mt-2 text-sm">
+          {t('subtitleTemplate', {
+            count,
+            empresa,
+            tiempo: t('lastUpdated'),
+          })}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/front/app/[locale]/app/_components/reco-table.tsx
+++ b/src/front/app/[locale]/app/_components/reco-table.tsx
@@ -5,7 +5,6 @@ import { ArrowRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { useRecomendaciones } from '@/core/recommendations/infrastructure/hooks/useRecomendaciones'
-import { mockRecomendaciones } from '../_data/mock-recomendaciones'
 import type { EstadoReco, Recomendacion, TipoRelacion } from '../_data/types'
 
 import { RecoActor } from './reco-actor'
@@ -19,27 +18,19 @@ const PAGE_SIZE = 8
 export function RecoTable() {
   const t = useTranslations('App.Recomendaciones')
 
-  const { data: live, isLoading } = useRecomendaciones()
+  const { data: live, isLoading, error, reason } = useRecomendaciones()
 
   const [active, setActive] = useState<TabValue>('todas')
   const [showAll, setShowAll] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [overrides, setOverrides] = useState<Record<string, EstadoReco>>({})
 
-  // Use real data when available; fall back to mock so the UI still renders
-  // before the brain has finished onboarding the user's company.
-  const source: Recomendacion[] =
-    live && live.length > 0 ? live : mockRecomendaciones
-
-  const data = useMemo(
-    () =>
-      source.map((reco) =>
-        overrides[reco.id] ? { ...reco, estado: overrides[reco.id]! } : reco,
-      ),
-    [source, overrides],
-  )
-
-  void isLoading
+  const data = useMemo(() => {
+    const source: Recomendacion[] = live ?? []
+    return source.map((reco) =>
+      overrides[reco.id] ? { ...reco, estado: overrides[reco.id]! } : reco,
+    )
+  }, [live, overrides])
 
   const counts = useMemo(() => {
     const base: Record<TabValue, number> = {
@@ -82,6 +73,42 @@ export function RecoTable() {
     setOverrides((prev) => ({ ...prev, [id]: estado }))
   }
 
+  if (isLoading && data.length === 0) {
+    return (
+      <div className="bg-surface border-border-soft overflow-hidden rounded-2xl border">
+        <RecoTableSkeleton />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="bg-surface border-border-soft rounded-2xl border p-10 text-center">
+        <h3 className="font-display text-text text-lg font-bold">
+          {t('errorState.title')}
+        </h3>
+        <p className="text-text-secondary mt-2 text-sm">
+          {t('errorState.description')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-surface border-border-soft rounded-2xl border p-10 text-center">
+        <h3 className="font-display text-text text-lg font-bold">
+          {t('empty.title')}
+        </h3>
+        <p className="text-text-secondary mt-2 text-sm">
+          {reason === 'no_company'
+            ? t('empty.noCompanyDescription')
+            : t('empty.description')}
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <RecoTabs
@@ -120,6 +147,23 @@ export function RecoTable() {
         onUpdateEstado={updateEstado}
       />
     </div>
+  )
+}
+
+function RecoTableSkeleton() {
+  return (
+    <ul aria-hidden className="divide-border-soft divide-y">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <li key={i} className="flex items-center gap-4 px-5 py-4">
+          <span className="bg-surface-hover h-10 w-10 animate-pulse rounded-md" />
+          <div className="flex flex-1 flex-col gap-2">
+            <span className="bg-surface-hover h-4 w-1/3 animate-pulse rounded" />
+            <span className="bg-surface-hover h-3 w-2/3 animate-pulse rounded" />
+          </div>
+          <span className="bg-surface-hover h-6 w-12 animate-pulse rounded" />
+        </li>
+      ))}
+    </ul>
   )
 }
 

--- a/src/front/app/[locale]/app/_components/user-menu-loader.tsx
+++ b/src/front/app/[locale]/app/_components/user-menu-loader.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useCurrentUser } from '@/core/users/infrastructure/hooks/useCurrentUser'
+
+import { UserMenu } from './user-menu'
+
+/**
+ * Client-only wrapper para el `UserMenu` del header.
+ *
+ * Encapsula la suscripción a `useCurrentUser` (SWR) sin obligar al header
+ * entero a ser un Client Component. Mientras carga muestra un skeleton
+ * compacto del mismo tamaño que el botón del menú para evitar layout shift.
+ */
+export function UserMenuLoader() {
+  const { user, isLoading } = useCurrentUser()
+
+  if (isLoading || !user) {
+    return (
+      <div aria-hidden className="flex items-center gap-2 rounded-xl px-2 py-1">
+        <span className="bg-surface-hover h-9 w-9 animate-pulse rounded-md" />
+        <span className="bg-surface-hover hidden h-4 w-24 animate-pulse rounded sm:inline-block" />
+      </div>
+    )
+  }
+
+  return <UserMenu currentUser={user} />
+}

--- a/src/front/app/[locale]/app/_components/user-menu.tsx
+++ b/src/front/app/[locale]/app/_components/user-menu.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useTransition } from 'react'
 import { ChevronDown, LogOut, User } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { useSWRConfig } from 'swr'
 
 import { useRouter } from '@/i18n/navigation'
+import { createSupabaseBrowserClient } from '@/core/shared/infrastructure/supabase/client'
 
 import type { CurrentUser } from '../_data/types'
 
@@ -15,8 +17,22 @@ type Props = {
 export function UserMenu({ currentUser }: Props) {
   const t = useTranslations('App.Header.userMenu')
   const router = useRouter()
+  const { mutate } = useSWRConfig()
   const [open, setOpen] = useState(false)
+  const [isSigningOut, startSignOut] = useTransition()
   const containerRef = useRef<HTMLDivElement>(null)
+
+  function handleSignOut() {
+    setOpen(false)
+    startSignOut(async () => {
+      const supabase = createSupabaseBrowserClient()
+      await supabase.auth.signOut()
+      // Limpiamos la cache de SWR para que /api/me y /api/me/recommendations/*
+      // no devuelvan datos del usuario anterior tras login con otra cuenta.
+      await mutate(() => true, undefined, { revalidate: false })
+      router.push('/')
+    })
+  }
 
   useEffect(() => {
     if (!open) return
@@ -75,11 +91,9 @@ export function UserMenu({ currentUser }: Props) {
           <button
             type="button"
             role="menuitem"
-            onClick={() => {
-              setOpen(false)
-              router.push('/')
-            }}
-            className="text-error hover:bg-error/5 flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium transition-colors"
+            onClick={handleSignOut}
+            disabled={isSigningOut}
+            className="text-error hover:bg-error/5 flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
           >
             <LogOut className="h-4 w-4" />
             {t('logout')}

--- a/src/front/app/[locale]/app/recomendaciones/page.tsx
+++ b/src/front/app/[locale]/app/recomendaciones/page.tsx
@@ -2,10 +2,8 @@ import { Filter, ArrowDownUp } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { setRequestLocale } from 'next-intl/server'
 
-import { mockRecomendaciones } from '../_data/mock-recomendaciones'
-import { mockCurrentUser } from '../_data/mock-user'
-
 import { RecoFilters } from '../_components/reco-filters'
+import { RecoHeader } from '../_components/reco-header'
 import { RecoTable } from '../_components/reco-table'
 
 type Props = {
@@ -25,18 +23,7 @@ function RecomendacionesContent() {
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
       <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div>
-          <h1 className="font-display text-text text-3xl font-extrabold tracking-tight">
-            {t('title')}
-          </h1>
-          <p className="text-text-secondary mt-2 text-sm">
-            {t('subtitleTemplate', {
-              count: mockRecomendaciones.length,
-              empresa: mockCurrentUser.empresa,
-              tiempo: t('lastUpdated'),
-            })}
-          </p>
-        </div>
+        <RecoHeader />
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/src/front/app/[locale]/login/_components/login-form.tsx
+++ b/src/front/app/[locale]/login/_components/login-form.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Loader2, Lock, Mail } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import { Link, useRouter } from '@/i18n/navigation'
+import { createSupabaseBrowserClient } from '@/core/shared/infrastructure/supabase/client'
 
 import { Field, TextInput } from '../../registro/_components/registro-fields'
 
@@ -20,6 +21,7 @@ export function LoginForm() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errors, setErrors] = useState<Errors>({})
+  const [apiError, setApiError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 
   function validate(): boolean {
@@ -37,10 +39,23 @@ export function LoginForm() {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!validate()) return
-    startTransition(() => {
-      setTimeout(() => {
-        router.push('/app/recomendaciones')
-      }, 600)
+    setApiError(null)
+    startTransition(async () => {
+      const supabase = createSupabaseBrowserClient()
+      const { error } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      })
+      if (error) {
+        // Supabase devuelve "Invalid login credentials" para email/password
+        // incorrectos. Lo mapeamos a una clave i18n para no acoplar copy a inglés.
+        const isCredentialsError = /invalid.*credentials/i.test(error.message)
+        setApiError(
+          isCredentialsError ? tErrors('invalidCredentials') : error.message,
+        )
+        return
+      }
+      router.push('/app/recomendaciones')
     })
   }
 
@@ -104,6 +119,15 @@ export function LoginForm() {
           </div>
         )}
       </Field>
+
+      {apiError ? (
+        <div
+          role="alert"
+          className="bg-error/10 text-error rounded-lg border border-red-200 p-3 text-sm"
+        >
+          {apiError}
+        </div>
+      ) : null}
 
       <button
         type="submit"

--- a/src/front/app/api/me/route.ts
+++ b/src/front/app/api/me/route.ts
@@ -1,0 +1,45 @@
+import { serverLogger } from '@/core/shared/infrastructure/logger/serverLogger'
+import { createSupabaseServerClient } from '@/core/shared/infrastructure/supabase/server'
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization') ?? ''
+  const token = authHeader.toLowerCase().startsWith('bearer ')
+    ? authHeader.slice(7).trim()
+    : null
+
+  if (!token) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createSupabaseServerClient()
+  const { data: userResp, error: userErr } = await supabase.auth.getUser(token)
+  if (userErr || !userResp.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile, error: profileErr } = await supabase
+    .from('users')
+    .select('id, name, email, sector, barrio, municipio, company_id')
+    .eq('id', userResp.user.id)
+    .single()
+
+  if (profileErr || !profile) {
+    serverLogger.warn(
+      `[GET /api/me] No profile for auth user ${userResp.user.id}`,
+      profileErr,
+    )
+    return Response.json({ error: 'Profile not found' }, { status: 404 })
+  }
+
+  return Response.json({
+    user: {
+      id: profile.id,
+      name: profile.name,
+      email: profile.email,
+      sector: profile.sector,
+      barrio: profile.barrio,
+      municipio: profile.municipio,
+      companyId: profile.company_id,
+    },
+  })
+}

--- a/src/front/core/users/infrastructure/hooks/useCurrentUser.ts
+++ b/src/front/core/users/infrastructure/hooks/useCurrentUser.ts
@@ -1,0 +1,62 @@
+'use client'
+
+import useSWR from 'swr'
+
+import type { CurrentUser } from '@/app/[locale]/app/_data/types'
+
+export interface MeApiResponse {
+  user: {
+    id: string
+    name: string
+    email: string | null
+    sector: string | null
+    barrio: string | null
+    municipio: string | null
+    companyId: string | null
+  }
+}
+
+interface UseCurrentUserResult {
+  user: CurrentUser | undefined
+  isLoading: boolean
+  error: Error | undefined
+}
+
+/**
+ * Computa iniciales a partir del nombre del negocio. Usamos las primeras
+ * letras de las primeras dos palabras alfabéticas; si no hay, usamos las
+ * dos primeras letras del string. Suficiente para un avatar.
+ */
+function buildIniciales(name: string): string {
+  const words = name
+    .split(/\s+/)
+    .filter((w) => w.length > 0 && /[a-záéíóúñ]/i.test(w[0]))
+  if (words.length === 0) return name.slice(0, 2).toUpperCase()
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return `${words[0][0]}${words[1][0]}`.toUpperCase()
+}
+
+export function useCurrentUser(): UseCurrentUserResult {
+  const { data, error, isLoading } = useSWR<MeApiResponse>('/api/me', {
+    // El usuario actual no cambia mientras dura la sesión: evitamos refetch
+    // en focus para reducir ruido en la UI.
+    revalidateOnFocus: false,
+  })
+
+  const user: CurrentUser | undefined = data
+    ? {
+        id: data.user.id,
+        nombre: data.user.name,
+        empresa: data.user.name,
+        iniciales: buildIniciales(data.user.name),
+        sector: data.user.sector ?? '',
+        barrio: data.user.barrio ?? '',
+      }
+    : undefined
+
+  return {
+    user,
+    isLoading,
+    error: error instanceof Error ? error : undefined,
+  }
+}

--- a/src/front/messages/es.json
+++ b/src/front/messages/es.json
@@ -326,7 +326,8 @@
     "registerLink": "Regístrate gratis",
     "errors": {
       "invalidEmail": "Email inválido. Revisa el formato.",
-      "minLength": "La contraseña debe tener al menos 6 caracteres."
+      "minLength": "La contraseña debe tener al menos 6 caracteres.",
+      "invalidCredentials": "Email o contraseña incorrectos."
     }
   },
   "App": {
@@ -392,6 +393,16 @@
       },
       "footerTemplate": "Mostrando {visible} de {total}",
       "cargarMas": "cargar más",
+      "loading": "Buscando recomendaciones...",
+      "empty": {
+        "title": "Aún no tenemos recomendaciones para ti",
+        "description": "Vuelve más tarde — el conector está procesando tu cluster.",
+        "noCompanyDescription": "Estamos clasificando tu negocio. En unos minutos verás aquí tus primeros aliados y clientes potenciales."
+      },
+      "errorState": {
+        "title": "No pudimos cargar tus recomendaciones",
+        "description": "Reintenta en unos segundos. Si el problema persiste, escríbenos por WhatsApp."
+      },
       "Detail": {
         "close": "Cerrar detalle",
         "match": "Match",

--- a/src/front/proxy.ts
+++ b/src/front/proxy.ts
@@ -1,12 +1,62 @@
-import createMiddleware from 'next-intl/middleware'
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+import createIntlMiddleware from 'next-intl/middleware'
+
+import { env } from '@/core/shared/infrastructure/env'
+
 import { routing } from './i18n/routing'
 
-export default createMiddleware(routing)
+const handleI18n = createIntlMiddleware(routing)
+
+const PROTECTED_PREFIX = '/app'
+
+/**
+ * Proxy (Next.js 16) — composición de:
+ *   1) `next-intl` para resolución de locale.
+ *   2) Guard de sesión Supabase para `/app/*`.
+ *
+ * Usamos `@supabase/ssr` para leer/refrescar la sesión vía cookies. Si el
+ * usuario navega a una ruta protegida sin sesión, redirigimos a /login. La
+ * respuesta de Supabase puede traer cookies actualizadas (refresh token); las
+ * fusionamos con la respuesta de next-intl para no perderlas.
+ */
+export default async function proxy(request: NextRequest) {
+  const intlResponse = handleI18n(request)
+
+  const isProtected = request.nextUrl.pathname.startsWith(PROTECTED_PREFIX)
+  if (!isProtected) return intlResponse
+
+  const supabase = createServerClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value, options } of cookiesToSet) {
+            intlResponse.cookies.set(name, value, options)
+          }
+        },
+      },
+    },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = '/login'
+    redirectUrl.search = ''
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  return intlResponse
+}
 
 export const config = {
-  // Match all pathnames except:
-  // - API routes (/api)
-  // - Next.js internals (/_next, /_vercel)
-  // - Static files (files with extensions like .ico, .png, etc.)
   matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)',
 }


### PR DESCRIPTION
Replace mock user/recommendation fallbacks with end-to-end Supabase auth: proxy.ts now guards /app/* via session cookies, login uses signInWithPassword with i18n error mapping, user menu signs out and clears SWR cache, and a new /api/me BFF + useCurrentUser hook drive the app header and recomendaciones header. RecoTable now renders real loading/empty/error states instead of mock data.

Made-with: Cursor