### PR TITLE
feat(recommendations): floor de 2 recs por tipo + glosario empresarial + ai cache en onboarding

### DIFF
--- a/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
+++ b/src/brain/__tests__/companies/CompanyOnboardingController.test.ts
@@ -10,11 +10,14 @@ import { ClassifyCompanyFromDescription } from '@/companies/application/use-case
 import { OnboardCompanyFromSignup } from '@/companies/application/use-cases/OnboardCompanyFromSignup'
 import { CompanyOnboardingController } from '@/companies/infrastructure/http/company-onboarding.controller'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { DynamicValueChainRules } from '@/recommendations/application/services/DynamicValueChainRules'
 import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
 import { InMemoryCiiuGraphRepository } from '@/recommendations/infrastructure/repositories/InMemoryCiiuGraphRepository'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
 import type { LlmPort } from '@/shared/domain/LlmPort'
@@ -89,6 +92,8 @@ describe('CompanyOnboardingController', () => {
         new DynamicValueChainRules(new InMemoryCiiuGraphRepository()),
         false,
       ),
+      new AiCacheExpander(new InMemoryAiMatchCacheRepository(), featureBuilder),
+      new RecommendationLimiter(),
     )
     controller = new CompanyOnboardingController(onboard)
   })

--- a/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
+++ b/src/brain/__tests__/companies/OnboardCompanyFromSignup.test.ts
@@ -9,11 +9,15 @@ import { Company } from '@/companies/domain/entities/Company'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
 import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
 import { OnboardCompanyFromSignup } from '@/companies/application/use-cases/OnboardCompanyFromSignup'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { DynamicValueChainRules } from '@/recommendations/application/services/DynamicValueChainRules'
 import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
 import { InMemoryCiiuGraphRepository } from '@/recommendations/infrastructure/repositories/InMemoryCiiuGraphRepository'
 import { InMemoryRecommendationRepository } from '@/recommendations/infrastructure/repositories/InMemoryRecommendationRepository'
 import type { LlmPort } from '@/shared/domain/LlmPort'
@@ -67,12 +71,15 @@ function buildFixtures() {
   const ciiuMapping = new InMemoryClusterCiiuMappingRepository()
   const membershipRepo = new InMemoryClusterMembershipRepository()
   const recRepo = new InMemoryRecommendationRepository()
+  const aiCache = new InMemoryAiMatchCacheRepository()
   const gemini = new FixedGemini({
     ciiuCode: '5611',
     reasoning: 'Restaurante de comida del Caribe — clase 5611.',
   })
   const classify = new ClassifyCompanyFromDescription(gemini, taxonomy)
   const featureBuilder = new FeatureVectorBuilder()
+  const cacheExpander = new AiCacheExpander(aiCache, featureBuilder)
+  const limiter = new RecommendationLimiter()
 
   return {
     taxonomy,
@@ -81,8 +88,11 @@ function buildFixtures() {
     ciiuMapping,
     membershipRepo,
     recRepo,
+    aiCache,
     classify,
     featureBuilder,
+    cacheExpander,
+    limiter,
   }
 }
 
@@ -113,6 +123,8 @@ async function buildUseCase(
       new DynamicValueChainRules(new InMemoryCiiuGraphRepository()),
       false,
     ),
+    f.cacheExpander,
+    f.limiter,
   )
   return { useCase, ...f }
 }
@@ -250,6 +262,8 @@ describe('OnboardCompanyFromSignup', () => {
         new DynamicValueChainRules(new InMemoryCiiuGraphRepository()),
         false,
       ),
+      f.cacheExpander,
+      f.limiter,
     )
 
     const result = await useCase.execute({
@@ -304,6 +318,8 @@ describe('OnboardCompanyFromSignup', () => {
         new DynamicValueChainRules(new InMemoryCiiuGraphRepository()),
         false,
       ),
+      f.cacheExpander,
+      f.limiter,
     )
 
     const result = await useCase.execute({
@@ -316,6 +332,49 @@ describe('OnboardCompanyFromSignup', () => {
     expect(result.clusters).toHaveLength(1)
     expect(result.clusters[0].id).toBe('heur-grupo-561-santa-marta')
     expect(await f.clusterRepo.count()).toBe(1)
+  })
+
+  it('uses AI match cache hits when present to seed ai-inferred recommendations', async () => {
+    // Use a CIIU pair (5611 ↔ 0122) with NO hardcoded rule so the AI cache is
+    // the only producer of the recommendation. This isolates the AI cache wiring.
+    await fixtures.aiCache.put(
+      AiMatchCacheEntry.create({
+        ciiuOrigen: '0122',
+        ciiuDestino: '5611',
+        hasMatch: true,
+        relationType: 'aliado',
+        confidence: 0.8,
+        reason: 'Sinergia agro–gastronomía: producto local en menú',
+      }),
+    )
+    await fixtures.companyRepo.saveMany([
+      Company.create({
+        id: 'finca-1',
+        razonSocial: 'Finca La Esperanza',
+        ciiu: 'A0122',
+        municipio: 'SANTA MARTA',
+        fechaMatricula: new Date('2018-01-01'),
+        personal: 12,
+      }),
+    ])
+
+    const result = await fixtures.useCase.execute({
+      userId: 'u-ai',
+      description: 'Restaurante',
+      businessName: 'Casa Bambú',
+      municipio: 'SANTA MARTA',
+      yearsOfOperation: '3_5',
+    })
+
+    const aiInferred = result.recommendations.filter(
+      (r) => r.source === 'ai-inferred',
+    )
+    expect(aiInferred.length).toBeGreaterThan(0)
+    expect(
+      aiInferred.some(
+        (r) => r.targetCompanyId === 'finca-1' && r.relationType === 'aliado',
+      ),
+    ).toBe(true)
   })
 
   it('caps recommendations per relation type to avoid flooding', async () => {

--- a/src/brain/__tests__/recommendations/AiCacheExpander.test.ts
+++ b/src/brain/__tests__/recommendations/AiCacheExpander.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Company,
+  type CreateCompanyInput,
+} from '@/companies/domain/entities/Company'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
+import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
+import { AiMatchCacheEntry } from '@/recommendations/domain/entities/AiMatchCacheEntry'
+import { InMemoryAiMatchCacheRepository } from '@/recommendations/infrastructure/repositories/InMemoryAiMatchCacheRepository'
+
+const company = (overrides: Partial<CreateCompanyInput> = {}): Company =>
+  Company.create({
+    id: 'c',
+    razonSocial: 'Acme',
+    ciiu: 'A0122',
+    municipio: 'SANTA MARTA',
+    fechaMatricula: new Date('2022-01-01'),
+    personal: 5,
+    ingresoOperacion: 50_000_000,
+    ...overrides,
+  })
+
+function makeExpander() {
+  const cache = new InMemoryAiMatchCacheRepository()
+  const featureBuilder = new FeatureVectorBuilder()
+  const expander = new AiCacheExpander(cache, featureBuilder)
+  return { cache, featureBuilder, expander }
+}
+
+describe('AiCacheExpander', () => {
+  describe('expandForCompany', () => {
+    it('returns recs for cache hits between source and the universe', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: true,
+          relationType: 'cliente',
+          confidence: 0.85,
+          reason: 'Banano vende a mayoristas',
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+      const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+
+      const recs = await expander.expandForCompany(banano, [banano, mayor])
+
+      expect(recs).toHaveLength(1)
+      expect(recs[0].sourceCompanyId).toBe('banano')
+      expect(recs[0].targetCompanyId).toBe('mayor')
+      expect(recs[0].relationType).toBe('cliente')
+      expect(recs[0].source).toBe('ai-inferred')
+    })
+
+    it('skips entries with hasMatch=false', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: false,
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+      const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+
+      const recs = await expander.expandForCompany(banano, [banano, mayor])
+      expect(recs).toHaveLength(0)
+    })
+
+    it('skips entries with confidence below the min threshold (0.5)', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: true,
+          relationType: 'cliente',
+          confidence: 0.3,
+          reason: 'low confidence',
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+      const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+
+      const recs = await expander.expandForCompany(banano, [banano, mayor])
+      expect(recs).toHaveLength(0)
+    })
+
+    it('inverts the relationType when source.ciiu > target.ciiu (cache stored canonically)', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: true,
+          relationType: 'cliente',
+          confidence: 0.85,
+          reason: 'Banano vende a mayoristas',
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+      const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+
+      const recsForMayor = await expander.expandForCompany(mayor, [
+        banano,
+        mayor,
+      ])
+
+      expect(recsForMayor).toHaveLength(1)
+      expect(recsForMayor[0].sourceCompanyId).toBe('mayor')
+      expect(recsForMayor[0].targetCompanyId).toBe('banano')
+      expect(recsForMayor[0].relationType).toBe('proveedor')
+    })
+
+    it('does not return self-recommendations', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '0122',
+          hasMatch: true,
+          relationType: 'referente',
+          confidence: 0.9,
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+
+      const recs = await expander.expandForCompany(banano, [banano])
+      expect(recs).toHaveLength(0)
+    })
+
+    it('adds mismo_municipio reason when source and target share municipio', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: true,
+          relationType: 'cliente',
+          confidence: 0.85,
+          reason: 'Banano vende a mayoristas',
+        }),
+      )
+      const banano = company({
+        id: 'banano',
+        ciiu: 'A0122',
+        municipio: 'SANTA MARTA',
+      })
+      const mayor = company({
+        id: 'mayor',
+        ciiu: 'G4631',
+        municipio: 'SANTA MARTA',
+      })
+
+      const recs = await expander.expandForCompany(banano, [banano, mayor])
+      const features = recs[0].reasons.toJson().map((r) => r.feature)
+
+      expect(features).toContain('ai_inferido')
+      expect(features).toContain('mismo_municipio')
+    })
+  })
+
+  describe('expandForAll', () => {
+    it('returns a Map keyed by source company id with cache-driven recs', async () => {
+      const { cache, expander } = makeExpander()
+      await cache.put(
+        AiMatchCacheEntry.create({
+          ciiuOrigen: '0122',
+          ciiuDestino: '4631',
+          hasMatch: true,
+          relationType: 'cliente',
+          confidence: 0.85,
+          reason: 'r',
+        }),
+      )
+      const banano = company({ id: 'banano', ciiu: 'A0122' })
+      const mayor = company({ id: 'mayor', ciiu: 'G4631' })
+
+      const out = await expander.expandForAll([banano, mayor])
+
+      expect(out.get('banano')?.length).toBe(1)
+      expect(out.get('mayor')?.length).toBe(1)
+      expect(out.get('banano')?.[0].relationType).toBe('cliente')
+      expect(out.get('mayor')?.[0].relationType).toBe('proveedor')
+    })
+  })
+})

--- a/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
+++ b/src/brain/__tests__/recommendations/ExplainRecommendation.test.ts
@@ -99,6 +99,90 @@ describe('ExplainRecommendation', () => {
     expect(captured).toContain('cliente')
   })
 
+  it('includes the business definition of the relation type', async () => {
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured.toLowerCase()).toContain('cliente')
+    expect(captured.toLowerCase()).toMatch(/consume|adquiere|compra/)
+  })
+
+  it('includes value-chain rules applicable to the CIIU pair', async () => {
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured).toContain('Banano hacia mayoristas')
+  })
+
+  it('includes shared ecosystems when both companies belong to one', async () => {
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured).toContain('Agro Exportador')
+  })
+
+  it('translates structured reasons to natural language', async () => {
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured.toLowerCase()).toContain('cadena de valor')
+    expect(captured).not.toContain('"feature"')
+    expect(captured).not.toContain('cadena_valor_directa')
+  })
+
+  it('includes both companies operational context (etapa, personal, ingreso)', async () => {
+    await companyRepo.saveMany([
+      company({
+        id: 'src',
+        razonSocial: 'Banano SA',
+        ciiu: 'A0122',
+        personal: 25,
+        ingresoOperacion: 500_000_000,
+      }),
+      company({
+        id: 'tgt',
+        razonSocial: 'Mayorista SA',
+        ciiu: 'G4631',
+        personal: 80,
+        ingresoOperacion: 2_000_000_000,
+      }),
+    ])
+
+    let captured = ''
+    vi.spyOn(gemini, 'generateText').mockImplementation(async (prompt) => {
+      captured = prompt
+      return 'enrichment'
+    })
+
+    await useCase.execute({ recommendationId: 'rec-1' })
+
+    expect(captured).toContain('25')
+    expect(captured).toContain('80')
+    expect(captured.toLowerCase()).toMatch(/personal|empleados|colaboradores/)
+    expect(captured.toLowerCase()).toMatch(/ingreso|facturaci/)
+    expect(captured.toLowerCase()).toMatch(/etapa/)
+  })
+
   it('throws when the recommendation does not exist', async () => {
     await expect(
       useCase.execute({ recommendationId: 'missing' }),

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -6,6 +6,7 @@ import {
   type CreateCompanyInput,
 } from '@/companies/domain/entities/Company'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
 import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { CandidateSelector } from '@/recommendations/application/services/CandidateSelector'
@@ -13,6 +14,7 @@ import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPa
 import { DynamicValueChainRules } from '@/recommendations/application/services/DynamicValueChainRules'
 import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { InMemoryCiiuGraphRepository } from '@/recommendations/infrastructure/repositories/InMemoryCiiuGraphRepository'
 import { GenerateRecommendations } from '@/recommendations/application/use-cases/GenerateRecommendations'
@@ -80,6 +82,8 @@ function makeSetup({
   const evaluator = new CiiuPairEvaluator(aiEngine, cache)
   const selector = new CandidateSelector()
   const featureBuilder = new FeatureVectorBuilder()
+  const cacheExpander = new AiCacheExpander(cache, featureBuilder)
+  const limiter = new RecommendationLimiter()
   const peer = new PeerMatcher(featureBuilder)
   const graph = new InMemoryCiiuGraphRepository()
   const dynamicRules = new DynamicValueChainRules(graph)
@@ -88,10 +92,10 @@ function makeSetup({
   const useCase = new GenerateRecommendations(
     companyRepo,
     recRepo,
-    cache,
     selector,
     evaluator,
-    featureBuilder,
+    cacheExpander,
+    limiter,
     peer,
     valueChain,
     alliance,

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -334,4 +334,80 @@ describe('GenerateRecommendations', () => {
     expect(result.companiesWithRecs).toBeGreaterThanOrEqual(0)
     expect(result.byRelationType).toBeDefined()
   })
+
+  describe('execution telemetry', () => {
+    it('returns mode=fallback-only and null aiStats when enableAi is false', async () => {
+      const setup = makeSetup()
+      await setup.companyRepo.saveMany([
+        company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+      ])
+
+      const result = await setup.useCase.execute({ enableAi: false })
+
+      expect(result.mode).toBe('fallback-only')
+      expect(result.aiEnabled).toBe(false)
+      expect(result.aiStats).toBeNull()
+    })
+
+    it('returns mode=ai-driven and populated aiStats when AI runs successfully', async () => {
+      const setup = makeSetup({
+        matchResponse: {
+          has_match: true,
+          relation_type: 'cliente',
+          confidence: 0.85,
+          reason: 'r',
+        },
+      })
+      await setup.companyRepo.saveMany([
+        company({ id: 'mayor', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'rest', ciiu: 'I5611', municipio: 'SANTA MARTA' }),
+      ])
+
+      const result = await setup.useCase.execute({ enableAi: true })
+
+      expect(result.mode).toBe('ai-driven')
+      expect(result.aiEnabled).toBe(true)
+      expect(result.aiStats).not.toBeNull()
+      expect(result.aiStats!.totalPairs).toBeGreaterThanOrEqual(0)
+      expect(result.aiStats!.cached).toBeGreaterThanOrEqual(0)
+      expect(result.aiStats!.evaluated).toBeGreaterThanOrEqual(0)
+      expect(result.aiStats!.errors).toBeGreaterThanOrEqual(0)
+    })
+
+    it('returns mode=ai-failed-fallback when AI orchestration throws', async () => {
+      const setup = makeSetup()
+      vi.spyOn(setup.evaluator, 'evaluateAll').mockRejectedValue(
+        new Error('rate limited'),
+      )
+      await setup.companyRepo.saveMany([
+        company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+      ])
+
+      const result = await setup.useCase.execute({ enableAi: true })
+
+      expect(result.mode).toBe('ai-failed-fallback')
+      expect(result.aiEnabled).toBe(true)
+      expect(result.aiStats).toBeNull()
+    })
+
+    it('returns durationMs and ISO timestamps for startedAt and completedAt', async () => {
+      const setup = makeSetup()
+      await setup.companyRepo.saveMany([
+        company({ id: 'p1', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+        company({ id: 'p2', ciiu: 'C1071', municipio: 'SANTA MARTA' }),
+      ])
+
+      const result = await setup.useCase.execute({ enableAi: false })
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+      expect(typeof result.durationMs).toBe('number')
+      expect(() => new Date(result.startedAt).toISOString()).not.toThrow()
+      expect(() => new Date(result.completedAt).toISOString()).not.toThrow()
+      expect(new Date(result.completedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(result.startedAt).getTime(),
+      )
+    })
+  })
 })

--- a/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
+++ b/src/brain/__tests__/recommendations/GenerateRecommendations.test.ts
@@ -196,7 +196,7 @@ describe('GenerateRecommendations', () => {
       expect(await setup.recRepo.countBySource('src')).toBeLessThanOrEqual(20)
     })
 
-    it('caps each (relationType) to at most 2 recommendations per company', async () => {
+    it('delivers exactly 2 recommendations per relationType when supply allows', async () => {
       const setup = makeSetup()
       const companies: Company[] = [
         company({ id: 'banano', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
@@ -217,7 +217,64 @@ describe('GenerateRecommendations', () => {
         'banano',
         'cliente',
       )
-      expect(clientes.length).toBeLessThanOrEqual(2)
+      expect(clientes.length).toBe(2)
+    })
+  })
+
+  describe('floor coverage (at least 2 per relationType)', () => {
+    it('delivers up to 2 of each relationType when supply allows in fallback mode', async () => {
+      const setup = makeSetup()
+      await setup.companyRepo.saveMany([
+        company({ id: 'banano', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+        company({ id: 'banano2', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+        company({ id: 'banano3', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+        company({ id: 'mayor1', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'mayor2', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'transp1', ciiu: 'H4923', municipio: 'SANTA MARTA' }),
+        company({ id: 'transp2', ciiu: 'H4923', municipio: 'SANTA MARTA' }),
+      ])
+
+      await setup.useCase.execute({ enableAi: false })
+
+      const referente = await setup.recRepo.findBySourceAndType(
+        'banano',
+        'referente',
+      )
+      const cliente = await setup.recRepo.findBySourceAndType(
+        'banano',
+        'cliente',
+      )
+      const proveedor = await setup.recRepo.findBySourceAndType(
+        'banano',
+        'proveedor',
+      )
+      const aliado = await setup.recRepo.findBySourceAndType('banano', 'aliado')
+
+      expect(referente.length).toBe(2)
+      expect(cliente.length).toBe(2)
+      expect(proveedor.length).toBe(2)
+      expect(aliado.length).toBe(2)
+    })
+
+    it('supplements AI matches with fallback recs to fill missing relation types', async () => {
+      const setup = makeSetup({
+        matchResponse: { has_match: false },
+      })
+      await setup.companyRepo.saveMany([
+        company({ id: 'banano', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+        company({ id: 'banano2', ciiu: 'A0122', municipio: 'SANTA MARTA' }),
+        company({ id: 'mayor1', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'mayor2', ciiu: 'G4631', municipio: 'SANTA MARTA' }),
+        company({ id: 'transp1', ciiu: 'H4923', municipio: 'SANTA MARTA' }),
+      ])
+
+      await setup.useCase.execute({ enableAi: true })
+
+      const all = await setup.recRepo.findBySource('banano')
+      const sources = new Set(all.map((r) => r.source))
+
+      expect(all.length).toBeGreaterThan(0)
+      expect(sources.has('rule')).toBe(true)
     })
   })
 
@@ -240,7 +297,7 @@ describe('GenerateRecommendations', () => {
       const recs = await setup.recRepo.findBySource('mayor')
 
       expect(recs.length).toBeGreaterThan(0)
-      expect(recs.every((r) => r.source === 'ai-inferred')).toBe(true)
+      expect(recs.some((r) => r.source === 'ai-inferred')).toBe(true)
     })
 
     it('falls back to hardcoded matchers when AI orchestration throws', async () => {

--- a/src/brain/__tests__/recommendations/RecommendationLimiter.test.ts
+++ b/src/brain/__tests__/recommendations/RecommendationLimiter.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
+import type { RecommendationSource } from '@/recommendations/domain/entities/Recommendation'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+
+let counter = 0
+
+const rec = (
+  overrides: Partial<{
+    sourceCompanyId: string
+    targetCompanyId: string
+    relationType: RelationType
+    score: number
+    source: RecommendationSource
+  }> = {},
+): Recommendation =>
+  Recommendation.create({
+    id: `rec-${++counter}`,
+    sourceCompanyId: overrides.sourceCompanyId ?? 'src',
+    targetCompanyId: overrides.targetCompanyId ?? `tgt-${counter}`,
+    relationType: overrides.relationType ?? 'cliente',
+    score: overrides.score ?? 0.5,
+    reasons: Reasons.empty(),
+    source: overrides.source ?? 'rule',
+  })
+
+describe('RecommendationLimiter', () => {
+  describe('dedupeByTargetAndType', () => {
+    it('keeps the max-score rec when multiple recs share (target, type)', () => {
+      const limiter = new RecommendationLimiter()
+      const a = rec({
+        targetCompanyId: 't1',
+        relationType: 'cliente',
+        score: 0.4,
+      })
+      const b = rec({
+        targetCompanyId: 't1',
+        relationType: 'cliente',
+        score: 0.9,
+      })
+      const c = rec({
+        targetCompanyId: 't1',
+        relationType: 'cliente',
+        score: 0.6,
+      })
+
+      const out = limiter.dedupeByTargetAndType([a, b, c])
+
+      expect(out).toHaveLength(1)
+      expect(out[0].id).toBe(b.id)
+    })
+
+    it('keeps separate recs for the same target with different types', () => {
+      const limiter = new RecommendationLimiter()
+      const cliente = rec({ targetCompanyId: 't1', relationType: 'cliente' })
+      const aliado = rec({ targetCompanyId: 't1', relationType: 'aliado' })
+
+      const out = limiter.dedupeByTargetAndType([cliente, aliado])
+      expect(out).toHaveLength(2)
+    })
+  })
+
+  describe('capPerType', () => {
+    it('caps recommendations to N per relationType keeping highest scores', () => {
+      const limiter = new RecommendationLimiter()
+      const recs = [
+        rec({ relationType: 'cliente', score: 0.9 }),
+        rec({ relationType: 'cliente', score: 0.8 }),
+        rec({ relationType: 'cliente', score: 0.7 }),
+        rec({ relationType: 'cliente', score: 0.6 }),
+      ]
+
+      const out = limiter.capPerType(recs, 2)
+      expect(out).toHaveLength(2)
+      expect(out.map((r) => r.score)).toEqual([0.9, 0.8])
+    })
+
+    it('caps each relationType independently', () => {
+      const limiter = new RecommendationLimiter()
+      const recs = [
+        rec({ relationType: 'cliente', score: 0.9 }),
+        rec({ relationType: 'cliente', score: 0.8 }),
+        rec({ relationType: 'cliente', score: 0.7 }),
+        rec({ relationType: 'aliado', score: 0.5 }),
+        rec({ relationType: 'aliado', score: 0.4 }),
+        rec({ relationType: 'aliado', score: 0.3 }),
+        rec({ relationType: 'referente', score: 0.2 }),
+      ]
+
+      const out = limiter.capPerType(recs, 2)
+      const counts = countByType(out)
+      expect(counts.get('cliente')).toBe(2)
+      expect(counts.get('aliado')).toBe(2)
+      expect(counts.get('referente')).toBe(1)
+    })
+
+    it('returns at most 4 * perType recs given the 4 relationTypes', () => {
+      const limiter = new RecommendationLimiter()
+      const recs = Array.from({ length: 50 }, (_, i) =>
+        rec({
+          relationType: (
+            ['cliente', 'proveedor', 'referente', 'aliado'] as const
+          )[i % 4],
+          score: Math.random(),
+        }),
+      )
+
+      const out = limiter.capPerType(recs, 2)
+      expect(out.length).toBeLessThanOrEqual(8)
+    })
+  })
+})
+
+function countByType(recs: Recommendation[]): Map<RelationType, number> {
+  const out = new Map<RelationType, number>()
+  for (const r of recs) {
+    out.set(r.relationType, (out.get(r.relationType) ?? 0) + 1)
+  }
+  return out
+}

--- a/src/brain/__tests__/recommendations/RecommendationsController.test.ts
+++ b/src/brain/__tests__/recommendations/RecommendationsController.test.ts
@@ -4,6 +4,7 @@ import { CiiuActivity } from '@/ciiu-taxonomy/domain/entities/CiiuActivity'
 import { InMemoryCiiuTaxonomyRepository } from '@/ciiu-taxonomy/infrastructure/repositories/InMemoryCiiuTaxonomyRepository'
 import { Company } from '@/companies/domain/entities/Company'
 import { InMemoryCompanyRepository } from '@/companies/infrastructure/repositories/InMemoryCompanyRepository'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
 import { AiMatchEngine } from '@/recommendations/application/services/AiMatchEngine'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { CandidateSelector } from '@/recommendations/application/services/CandidateSelector'
@@ -11,6 +12,7 @@ import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPa
 import { DynamicValueChainRules } from '@/recommendations/application/services/DynamicValueChainRules'
 import { FeatureVectorBuilder } from '@/recommendations/application/services/FeatureVectorBuilder'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { InMemoryCiiuGraphRepository } from '@/recommendations/infrastructure/repositories/InMemoryCiiuGraphRepository'
 import { ExplainRecommendation } from '@/recommendations/application/use-cases/ExplainRecommendation'
@@ -61,13 +63,15 @@ function makeWiring() {
   const dynamicRules = new DynamicValueChainRules(graph)
   const valueChain = new ValueChainMatcher(dynamicRules, false)
   const alliance = new AllianceMatcher(dynamicRules, false)
+  const cacheExpander = new AiCacheExpander(cache, featureBuilder)
+  const limiter = new RecommendationLimiter()
   const generate = new GenerateRecommendations(
     companyRepo,
     recRepo,
-    cache,
     selector,
     evaluator,
-    featureBuilder,
+    cacheExpander,
+    limiter,
     peer,
     valueChain,
     alliance,

--- a/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
+++ b/src/brain/src/companies/application/use-cases/OnboardCompanyFromSignup.ts
@@ -20,15 +20,16 @@ import {
   type CompanyRepository,
 } from '@/companies/domain/repositories/CompanyRepository'
 import { ClassifyCompanyFromDescription } from '@/companies/application/use-cases/ClassifyCompanyFromDescription'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
 import {
   RECOMMENDATION_REPOSITORY,
   type RecommendationRepository,
 } from '@/recommendations/domain/repositories/RecommendationRepository'
-import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
 import type { UseCase } from '@/shared/domain/UseCase'
 
 export type YearsOfOperation = 'menos_1' | '1_3' | '3_5' | '5_10' | 'mas_10'
@@ -74,6 +75,8 @@ export class OnboardCompanyFromSignup implements UseCase<
     private readonly peer: PeerMatcher,
     private readonly valueChain: ValueChainMatcher,
     private readonly alliance: AllianceMatcher,
+    private readonly cacheExpander: AiCacheExpander,
+    private readonly limiter: RecommendationLimiter,
   ) {}
 
   async execute(
@@ -170,14 +173,20 @@ export class OnboardCompanyFromSignup implements UseCase<
     const peerRecs = this.peer.match(activeUniverse, { topN: 20 })
     const valueChainRecs = await this.valueChain.match(activeUniverse)
     const allianceRecs = await this.alliance.match(activeUniverse)
+    const aiCacheRecs = await this.cacheExpander.expandForCompany(
+      newCompany,
+      activeUniverse,
+    )
 
-    const fromNew = mergeFromSource(newCompany.id, [
-      peerRecs,
-      valueChainRecs,
-      allianceRecs,
-    ])
-    const deduped = dedupeByTargetAndType(fromNew)
-    const capped = capPerType(deduped, TOP_PER_TYPE)
+    const fromNew: Recommendation[] = [
+      ...(peerRecs.get(newCompany.id) ?? []),
+      ...(valueChainRecs.get(newCompany.id) ?? []),
+      ...(allianceRecs.get(newCompany.id) ?? []),
+      ...aiCacheRecs,
+    ]
+
+    const deduped = this.limiter.dedupeByTargetAndType(fromNew)
+    const capped = this.limiter.capPerType(deduped, TOP_PER_TYPE)
     return capped.map((r) =>
       Recommendation.create({
         id: randomUUID(),
@@ -224,42 +233,4 @@ function derivedFechaMatricula(
   const date = new Date(now)
   date.setMonth(date.getMonth() - monthsBack[years])
   return date
-}
-
-function mergeFromSource(
-  sourceId: string,
-  maps: Map<string, Recommendation[]>[],
-): Recommendation[] {
-  const out: Recommendation[] = []
-  for (const map of maps) {
-    const recs = map.get(sourceId) ?? []
-    out.push(...recs)
-  }
-  return out
-}
-
-function dedupeByTargetAndType(recs: Recommendation[]): Recommendation[] {
-  const byKey = new Map<string, Recommendation>()
-  for (const rec of recs) {
-    const key = `${rec.targetCompanyId}|${rec.relationType}`
-    const existing = byKey.get(key)
-    if (!existing || rec.score > existing.score) {
-      byKey.set(key, rec)
-    }
-  }
-  return Array.from(byKey.values())
-}
-
-function capPerType(recs: Recommendation[], perType: number): Recommendation[] {
-  const sorted = [...recs].sort((a, b) => b.score - a.score)
-  const counts = new Map<RelationType, number>()
-  const out: Recommendation[] = []
-  for (const rec of sorted) {
-    const c = counts.get(rec.relationType) ?? 0
-    if (c < perType) {
-      out.push(rec)
-      counts.set(rec.relationType, c + 1)
-    }
-  }
-  return out
 }

--- a/src/brain/src/recommendations/application/services/AiCacheExpander.ts
+++ b/src/brain/src/recommendations/application/services/AiCacheExpander.ts
@@ -1,0 +1,133 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import type { Company } from '@/companies/domain/entities/Company'
+import { canonicalPair } from '@/recommendations/application/services/CandidateSelector'
+import {
+  FeatureVectorBuilder,
+  type CompanyVector,
+} from '@/recommendations/application/services/FeatureVectorBuilder'
+import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import { AI_MATCH_CACHE_REPOSITORY } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
+import { Reasons } from '@/recommendations/domain/value-objects/Reason'
+import {
+  inverseRelation,
+  type RelationType,
+} from '@/recommendations/domain/value-objects/RelationType'
+
+const MIN_CONFIDENCE = 0.5
+const AI_WEIGHT = 0.6
+const PROXIMITY_WEIGHT = 0.4
+
+interface CachedMatch {
+  confidence: number
+  relationType: RelationType
+  reason: string
+}
+
+@Injectable()
+export class AiCacheExpander {
+  constructor(
+    @Inject(AI_MATCH_CACHE_REPOSITORY)
+    private readonly cache: AiMatchCacheRepository,
+    private readonly featureBuilder: FeatureVectorBuilder,
+  ) {}
+
+  async expandForCompany(
+    source: Company,
+    universe: Company[],
+  ): Promise<Recommendation[]> {
+    const cacheMap = await this.loadCacheMap()
+    return this.expandForCompanyWithCache(source, universe, cacheMap)
+  }
+
+  async expandForAll(
+    companies: Company[],
+  ): Promise<Map<string, Recommendation[]>> {
+    const cacheMap = await this.loadCacheMap()
+    const out = new Map<string, Recommendation[]>()
+    for (const source of companies) {
+      const recs = this.expandForCompanyWithCache(source, companies, cacheMap)
+      if (recs.length > 0) out.set(source.id, recs)
+    }
+    return out
+  }
+
+  private async loadCacheMap(): Promise<Map<string, CachedMatch>> {
+    const allEntries = await this.cache.findAll()
+    const cacheMap = new Map<string, CachedMatch>()
+    for (const e of allEntries) {
+      if (!e.hasMatch || !e.relationType) continue
+      if ((e.confidence ?? 0) < MIN_CONFIDENCE) continue
+      cacheMap.set(canonicalPair(e.ciiuOrigen, e.ciiuDestino), {
+        confidence: e.confidence ?? 0,
+        relationType: e.relationType,
+        reason: e.reason ?? '',
+      })
+    }
+    return cacheMap
+  }
+
+  private expandForCompanyWithCache(
+    source: Company,
+    universe: Company[],
+    cacheMap: Map<string, CachedMatch>,
+  ): Recommendation[] {
+    const sourceVec = this.featureBuilder.build(source)
+    const targetVectors = new Map<string, CompanyVector>()
+    const out: Recommendation[] = []
+
+    for (const target of universe) {
+      if (source.id === target.id) continue
+
+      const entry = cacheMap.get(canonicalPair(source.ciiu, target.ciiu))
+      if (!entry) continue
+
+      let targetVec = targetVectors.get(target.id)
+      if (!targetVec) {
+        targetVec = this.featureBuilder.build(target)
+        targetVectors.set(target.id, targetVec)
+      }
+      const proximity = this.featureBuilder.proximity(sourceVec, targetVec)
+      const score = Math.min(
+        1,
+        entry.confidence * (AI_WEIGHT + PROXIMITY_WEIGHT * proximity),
+      )
+
+      const relationType =
+        source.ciiu <= target.ciiu
+          ? entry.relationType
+          : inverseRelation(entry.relationType)
+
+      const baseReasons = Reasons.from([
+        {
+          feature: 'ai_inferido',
+          weight: entry.confidence,
+          description: entry.reason,
+        },
+      ])
+      const reasons =
+        source.municipio === target.municipio
+          ? baseReasons.add({
+              feature: 'mismo_municipio',
+              weight: 0.2,
+              value: source.municipio,
+              description: `Ambas en ${source.municipio}`,
+            })
+          : baseReasons
+
+      out.push(
+        Recommendation.create({
+          id: randomUUID(),
+          sourceCompanyId: source.id,
+          targetCompanyId: target.id,
+          relationType,
+          score,
+          reasons,
+          source: 'ai-inferred',
+        }),
+      )
+    }
+    return out
+  }
+}

--- a/src/brain/src/recommendations/application/services/RecommendationLimiter.ts
+++ b/src/brain/src/recommendations/application/services/RecommendationLimiter.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common'
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
+
+@Injectable()
+export class RecommendationLimiter {
+  dedupeByTargetAndType(recs: Recommendation[]): Recommendation[] {
+    const byKey = new Map<string, Recommendation>()
+    for (const rec of recs) {
+      const key = `${rec.targetCompanyId}|${rec.relationType}`
+      const existing = byKey.get(key)
+      if (!existing || rec.score > existing.score) {
+        byKey.set(key, rec)
+      }
+    }
+    return Array.from(byKey.values())
+  }
+
+  capPerType(recs: Recommendation[], perType: number): Recommendation[] {
+    const sorted = [...recs].sort((a, b) => b.score - a.score)
+    const counts = new Map<RelationType, number>()
+    const out: Recommendation[] = []
+    for (const rec of sorted) {
+      const c = counts.get(rec.relationType) ?? 0
+      if (c < perType) {
+        out.push(rec)
+        counts.set(rec.relationType, c + 1)
+      }
+    }
+    return out
+  }
+}

--- a/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
+++ b/src/brain/src/recommendations/application/use-cases/ExplainRecommendation.ts
@@ -1,8 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common'
+import type { Company } from '@/companies/domain/entities/Company'
 import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
 import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
+import {
+  findEcosystemsContaining,
+  findRulesForPair,
+  type Ecosystem,
+  type ValueChainRule,
+} from '@/recommendations/application/services/ValueChainRules'
+import type { Recommendation } from '@/recommendations/domain/entities/Recommendation'
 import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
 import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
+import type { ReasonFeature } from '@/recommendations/domain/value-objects/Reason'
+import type { RelationType } from '@/recommendations/domain/value-objects/RelationType'
 import type { LlmPort } from '@/shared/domain/LlmPort'
 import type { UseCase } from '@/shared/domain/UseCase'
 import { LLM_PORT } from '@/shared/shared.module'
@@ -13,6 +23,50 @@ export interface ExplainRecommendationInput {
 
 export interface ExplainRecommendationResult {
   explanation: string
+}
+
+interface RelationGlossaryEntry {
+  label: string
+  definition: string
+}
+
+const RELATION_GLOSSARY: Record<RelationType, RelationGlossaryEntry> = {
+  cliente: {
+    label: 'Cliente potencial',
+    definition:
+      'La empresa target consume o adquiere los productos / servicios que la empresa source ofrece. Es un canal de demanda: el target compra a la source.',
+  },
+  proveedor: {
+    label: 'Proveedor potencial',
+    definition:
+      'La empresa target suministra insumos, materias primas o servicios necesarios para la operación de la empresa source. Es un canal de oferta: la source compra a la target.',
+  },
+  referente: {
+    label: 'Empresa referente / par',
+    definition:
+      'Empresa del mismo sector y actividad económica, útil como benchmark, para intercambio de buenas prácticas, redes gremiales, mentoría informal o aprendizaje cruzado. No compite directamente — se aprende de ella.',
+  },
+  aliado: {
+    label: 'Aliado estratégico',
+    definition:
+      'Empresa de actividad complementaria dentro del mismo ecosistema económico. Ideal para alianzas comerciales, ofertas conjuntas (bundling), cross-selling, eventos compartidos o referidos mutuos.',
+  },
+}
+
+const FEATURE_LABELS: Record<ReasonFeature, string> = {
+  mismo_ciiu_clase: 'Comparten la misma clase CIIU (actividad muy similar)',
+  mismo_ciiu_division: 'Pertenecen a la misma división CIIU',
+  mismo_ciiu_seccion: 'Operan en la misma sección CIIU',
+  mismo_municipio: 'Operan en el mismo municipio',
+  misma_etapa: 'Comparten la misma etapa de madurez empresarial',
+  misma_macro_sector: 'Pertenecen al mismo macro-sector económico',
+  cadena_valor_directa:
+    'Existe una cadena de valor directa identificada entre los CIIUs',
+  cadena_valor_inversa:
+    'Existe una cadena de valor inversa identificada entre los CIIUs',
+  ecosistema_compartido:
+    'Comparten un ecosistema económico identificado por los matchers',
+  ai_inferido: 'La IA infirió la relación analizando ambos CIIUs',
 }
 
 @Injectable()
@@ -49,14 +103,105 @@ export class ExplainRecommendation implements UseCase<
       )
     }
 
-    const prompt = `Sos un asesor empresarial colombiano. Explicá en 2-3 frases por qué la empresa "${source.razonSocial}" (CIIU ${source.ciiu}, ${source.municipio}) podría conectarse con "${target.razonSocial}" (CIIU ${target.ciiu}, ${target.municipio}) como ${rec.relationType}.
-
-Razones estructuradas detectadas: ${JSON.stringify(rec.reasons.toJson())}
-
-Tono: profesional pero cercano, en español rioplatense neutro. Termina con un siguiente paso concreto que el empresario debería hacer.`
-
+    const prompt = buildPrompt(rec, source, target)
     const explanation = await this.gemini.generateText(prompt)
     await this.recRepo.updateExplanation(rec.id, explanation)
     return { explanation }
   }
+}
+
+function buildPrompt(
+  rec: Recommendation,
+  source: Company,
+  target: Company,
+): string {
+  const glossary = RELATION_GLOSSARY[rec.relationType]
+  const rules = findRulesForPair(source.ciiu, target.ciiu)
+  const sourceEcos = findEcosystemsContaining(source.ciiu)
+  const targetEcos = findEcosystemsContaining(target.ciiu)
+  const sharedEcos = sourceEcos.filter((s) =>
+    targetEcos.some((t) => t.id === s.id),
+  )
+
+  const reasonsBlock = formatReasons(rec.reasons.toJson())
+  const rulesBlock = formatRules(rules)
+  const ecosystemsBlock = formatEcosystems(sharedEcos)
+  const confidence = Math.round(rec.score * 100)
+
+  return `Sos un asesor empresarial colombiano experto en el tejido empresarial del Magdalena. Tu objetivo es ayudar al empresario a entender por qué TIENE SENTIDO conectarse con la otra empresa y qué hacer al respecto.
+
+EMPRESA A ASESORAR (source):
+- Razón social: "${source.razonSocial}"
+- CIIU ${source.ciiu}
+- Municipio: ${source.municipio}
+- Etapa empresarial: ${source.etapa}
+- Personal: ${source.personal} colaboradores
+- Ingreso operacional anual: ${formatMoney(source.ingresoOperacion)}
+
+EMPRESA SUGERIDA (target):
+- Razón social: "${target.razonSocial}"
+- CIIU ${target.ciiu}
+- Municipio: ${target.municipio}
+- Etapa empresarial: ${target.etapa}
+- Personal: ${target.personal} colaboradores
+- Ingreso operacional anual: ${formatMoney(target.ingresoOperacion)}
+
+TIPO DE RELACIÓN SUGERIDA: ${rec.relationType.toUpperCase()} — ${glossary.label}
+DEFINICIÓN EMPRESARIAL: ${glossary.definition}
+
+REGLAS DE CADENA DE VALOR APLICABLES AL PAR:
+${rulesBlock}
+
+ECOSISTEMAS ECONÓMICOS COMPARTIDOS:
+${ecosystemsBlock}
+
+EVIDENCIAS DETECTADAS POR EL MOTOR DE RECOMENDACIONES:
+${reasonsBlock}
+
+NIVEL DE CONFIANZA DEL MATCH: ${confidence}/100
+
+Tarea: explicale a "${source.razonSocial}" en 3-4 frases POR QUÉ tiene sentido conectarse con "${target.razonSocial}" en este rol específico de ${rec.relationType}, citando la cadena de valor o el ecosistema concreto que los une (no inventes datos: usá solo lo que aparece arriba). Cerrá con UN siguiente paso accionable y concreto que el empresario debería dar la próxima semana (ej. visitar la planta, mandar un correo de presentación, invitar a un café, pedir una referencia gremial).
+
+Tono: profesional pero cercano, español neutro colombiano. Texto corrido, sin bullets, sin emojis.`
+}
+
+function formatReasons(
+  reasons: {
+    feature: ReasonFeature
+    weight: number
+    value?: string | number
+    description: string
+  }[],
+): string {
+  if (reasons.length === 0) return '(sin evidencias estructuradas)'
+  return reasons
+    .map((r) => {
+      const label = FEATURE_LABELS[r.feature]
+      const value = r.value !== undefined ? ` (${r.value})` : ''
+      return `- ${label}${value}: ${r.description}`
+    })
+    .join('\n')
+}
+
+function formatRules(rules: ValueChainRule[]): string {
+  if (rules.length === 0) {
+    return '(ninguna regla específica de cadena de valor para este par)'
+  }
+  return rules
+    .map(
+      (r) =>
+        `- ${r.description} (peso ${r.weight}, ${r.ciiuOrigen} → ${r.ciiuDestino})`,
+    )
+    .join('\n')
+}
+
+function formatEcosystems(ecos: Ecosystem[]): string {
+  if (ecos.length === 0) {
+    return '(no comparten ecosistema económico definido)'
+  }
+  return ecos.map((e) => `- ${e.name}: ${e.description}`).join('\n')
+}
+
+function formatMoney(value: number): string {
+  return `$${value.toLocaleString('es-CO')} COP`
 }

--- a/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
@@ -1,30 +1,20 @@
 import { Inject, Injectable, Logger } from '@nestjs/common'
-import { randomUUID } from 'node:crypto'
 import type { Company } from '@/companies/domain/entities/Company'
 import { COMPANY_REPOSITORY } from '@/companies/domain/repositories/CompanyRepository'
 import type { CompanyRepository } from '@/companies/domain/repositories/CompanyRepository'
-import {
-  CandidateSelector,
-  canonicalPair,
-} from '@/recommendations/application/services/CandidateSelector'
+import { AiCacheExpander } from '@/recommendations/application/services/AiCacheExpander'
+import { CandidateSelector } from '@/recommendations/application/services/CandidateSelector'
 import { CiiuPairEvaluator } from '@/recommendations/application/services/CiiuPairEvaluator'
-import {
-  FeatureVectorBuilder,
-  type CompanyVector,
-} from '@/recommendations/application/services/FeatureVectorBuilder'
 import { AllianceMatcher } from '@/recommendations/application/services/AllianceMatcher'
 import { PeerMatcher } from '@/recommendations/application/services/PeerMatcher'
+import { RecommendationLimiter } from '@/recommendations/application/services/RecommendationLimiter'
 import { ValueChainMatcher } from '@/recommendations/application/services/ValueChainMatcher'
 import { Recommendation } from '@/recommendations/domain/entities/Recommendation'
-import { AI_MATCH_CACHE_REPOSITORY } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
-import type { AiMatchCacheRepository } from '@/recommendations/domain/repositories/AiMatchCacheRepository'
 import { RECOMMENDATION_REPOSITORY } from '@/recommendations/domain/repositories/RecommendationRepository'
 import type { RecommendationRepository } from '@/recommendations/domain/repositories/RecommendationRepository'
-import { Reasons } from '@/recommendations/domain/value-objects/Reason'
 import {
-  inverseRelation,
-  type RelationType,
   RELATION_TYPES,
+  type RelationType,
 } from '@/recommendations/domain/value-objects/RelationType'
 import { env } from '@/shared/infrastructure/env'
 import type { UseCase } from '@/shared/domain/UseCase'
@@ -39,11 +29,7 @@ export interface GenerateRecommendationsResult {
   byRelationType: Record<RelationType, number>
 }
 
-const MIN_CONFIDENCE = 0.5
 const TOP_PER_TYPE = 2
-const TOP_TOTAL = 20
-const AI_WEIGHT = 0.6
-const PROXIMITY_WEIGHT = 0.4
 
 @Injectable()
 export class GenerateRecommendations implements UseCase<
@@ -57,11 +43,10 @@ export class GenerateRecommendations implements UseCase<
     private readonly companyRepo: CompanyRepository,
     @Inject(RECOMMENDATION_REPOSITORY)
     private readonly recRepo: RecommendationRepository,
-    @Inject(AI_MATCH_CACHE_REPOSITORY)
-    private readonly cache: AiMatchCacheRepository,
     private readonly candidateSelector: CandidateSelector,
     private readonly ciiuPairEvaluator: CiiuPairEvaluator,
-    private readonly featureBuilder: FeatureVectorBuilder,
+    private readonly cacheExpander: AiCacheExpander,
+    private readonly limiter: RecommendationLimiter,
     private readonly peer: PeerMatcher,
     private readonly valueChain: ValueChainMatcher,
     private readonly alliance: AllianceMatcher,
@@ -86,7 +71,7 @@ export class GenerateRecommendations implements UseCase<
         this.logger.log(
           `AI eval stats: total=${stats.total} cached=${stats.cached} evaluated=${stats.evaluated} errors=${stats.errors}`,
         )
-        const aiRecs = await this.expandFromCache(companies)
+        const aiRecs = await this.cacheExpander.expandForAll(companies)
         const fallbackRecs = await this.runFallback(companies)
         recsBySource = new Map<string, Recommendation[]>()
         mergeInto(recsBySource, aiRecs)
@@ -103,91 +88,12 @@ export class GenerateRecommendations implements UseCase<
       recsBySource = await this.runFallback(companies)
     }
 
-    const limited = this.limit(this.dedupe(recsBySource))
+    const limited = this.limit(recsBySource)
 
     await this.recRepo.deleteAll()
     await this.recRepo.saveAll(flatten(limited))
 
     return computeStats(limited)
-  }
-
-  private async expandFromCache(
-    companies: Company[],
-  ): Promise<Map<string, Recommendation[]>> {
-    const allEntries = await this.cache.findAll()
-    const cacheMap = new Map<
-      string,
-      { confidence: number; relationType: RelationType; reason: string }
-    >()
-    for (const e of allEntries) {
-      if (!e.hasMatch || !e.relationType) continue
-      if ((e.confidence ?? 0) < MIN_CONFIDENCE) continue
-      cacheMap.set(canonicalPair(e.ciiuOrigen, e.ciiuDestino), {
-        confidence: e.confidence ?? 0,
-        relationType: e.relationType,
-        reason: e.reason ?? '',
-      })
-    }
-
-    const vectors = new Map<string, CompanyVector>(
-      companies.map((c) => [c.id, this.featureBuilder.build(c)]),
-    )
-
-    const out = new Map<string, Recommendation[]>()
-    for (const source of companies) {
-      const sourceVec = vectors.get(source.id)!
-      for (const target of companies) {
-        if (source.id === target.id) continue
-        const entry = cacheMap.get(canonicalPair(source.ciiu, target.ciiu))
-        if (!entry) continue
-
-        const proximity = this.featureBuilder.proximity(
-          sourceVec,
-          vectors.get(target.id)!,
-        )
-        const score = Math.min(
-          1,
-          entry.confidence * (AI_WEIGHT + PROXIMITY_WEIGHT * proximity),
-        )
-
-        const relationType =
-          source.ciiu <= target.ciiu
-            ? entry.relationType
-            : inverseRelation(entry.relationType)
-
-        const reasons = Reasons.from([
-          {
-            feature: 'ai_inferido',
-            weight: entry.confidence,
-            description: entry.reason,
-          },
-        ])
-        const reasonsWithMunicipio =
-          source.municipio === target.municipio
-            ? reasons.add({
-                feature: 'mismo_municipio',
-                weight: 0.2,
-                value: source.municipio,
-                description: `Ambas en ${source.municipio}`,
-              })
-            : reasons
-
-        appendTo(
-          out,
-          source.id,
-          Recommendation.create({
-            id: randomUUID(),
-            sourceCompanyId: source.id,
-            targetCompanyId: target.id,
-            relationType,
-            score,
-            reasons: reasonsWithMunicipio,
-            source: 'ai-inferred',
-          }),
-        )
-      }
-    }
-    return out
   }
 
   private async runFallback(
@@ -200,43 +106,14 @@ export class GenerateRecommendations implements UseCase<
     return out
   }
 
-  private dedupe(
-    recs: Map<string, Recommendation[]>,
-  ): Map<string, Recommendation[]> {
-    const out = new Map<string, Recommendation[]>()
-    for (const [sourceId, list] of recs) {
-      const byKey = new Map<string, Recommendation>()
-      for (const rec of list) {
-        const key = `${rec.targetCompanyId}|${rec.relationType}`
-        const existing = byKey.get(key)
-        if (!existing || rec.score > existing.score) {
-          byKey.set(key, rec)
-        }
-      }
-      out.set(sourceId, Array.from(byKey.values()))
-    }
-    return out
-  }
-
   private limit(
     recs: Map<string, Recommendation[]>,
   ): Map<string, Recommendation[]> {
     const out = new Map<string, Recommendation[]>()
     for (const [sourceId, list] of recs) {
-      const byType = new Map<RelationType, Recommendation[]>()
-      const sorted = [...list].sort((a, b) => b.score - a.score)
-      for (const rec of sorted) {
-        const arr = byType.get(rec.relationType) ?? []
-        if (arr.length < TOP_PER_TYPE) {
-          arr.push(rec)
-          byType.set(rec.relationType, arr)
-        }
-      }
-      const merged = Array.from(byType.values()).flat()
-      const trimmed = merged
-        .sort((a, b) => b.score - a.score)
-        .slice(0, TOP_TOTAL)
-      out.set(sourceId, trimmed)
+      const dedup = this.limiter.dedupeByTargetAndType(list)
+      const capped = this.limiter.capPerType(dedup, TOP_PER_TYPE)
+      out.set(sourceId, capped)
     }
     return out
   }
@@ -249,12 +126,6 @@ function resolveAiEnabled(override: boolean | undefined): boolean {
 
 function flatten(recs: Map<string, Recommendation[]>): Recommendation[] {
   return Array.from(recs.values()).flat()
-}
-
-function appendTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
-  const arr = map.get(key) ?? []
-  arr.push(value)
-  map.set(key, arr)
 }
 
 function mergeInto(

--- a/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
@@ -23,7 +23,25 @@ export interface GenerateRecommendationsInput {
   enableAi?: boolean
 }
 
+export type GenerateRecommendationsMode =
+  | 'ai-driven'
+  | 'fallback-only'
+  | 'ai-failed-fallback'
+
+export interface AiEvalStats {
+  totalPairs: number
+  cached: number
+  evaluated: number
+  errors: number
+}
+
 export interface GenerateRecommendationsResult {
+  mode: GenerateRecommendationsMode
+  aiEnabled: boolean
+  aiStats: AiEvalStats | null
+  durationMs: number
+  startedAt: string
+  completedAt: string
   totalRecommendations: number
   companiesWithRecs: number
   byRelationType: Record<RelationType, number>
@@ -56,18 +74,33 @@ export class GenerateRecommendations implements UseCase<
     input: GenerateRecommendationsInput = {},
   ): Promise<GenerateRecommendationsResult> {
     const aiEnabled = resolveAiEnabled(input.enableAi)
+    const startedAtDate = new Date()
+    const startMs = startedAtDate.getTime()
 
     const companies = (await this.companyRepo.findAll()).filter(
       (c) => c.isActive,
     )
 
+    this.logger.log(
+      `starting batch (aiEnabled=${aiEnabled}, activeCompanies=${companies.length})`,
+    )
+
     let recsBySource: Map<string, Recommendation[]>
+    let mode: GenerateRecommendationsMode
+    let aiStats: AiEvalStats | null = null
+
     if (aiEnabled) {
       try {
         const pairs = this.candidateSelector.selectCiiuPairs(companies)
         const stats = await this.ciiuPairEvaluator.evaluateAll(pairs, {
           concurrency: 4,
         })
+        aiStats = {
+          totalPairs: stats.total,
+          cached: stats.cached,
+          evaluated: stats.evaluated,
+          errors: stats.errors,
+        }
         this.logger.log(
           `AI eval stats: total=${stats.total} cached=${stats.cached} evaluated=${stats.evaluated} errors=${stats.errors}`,
         )
@@ -76,16 +109,20 @@ export class GenerateRecommendations implements UseCase<
         recsBySource = new Map<string, Recommendation[]>()
         mergeInto(recsBySource, aiRecs)
         mergeInto(recsBySource, fallbackRecs)
+        mode = 'ai-driven'
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         this.logger.error(
           `AI orchestration failed: ${message} — falling back to hardcoded matchers`,
         )
         recsBySource = await this.runFallback(companies)
+        mode = 'ai-failed-fallback'
+        aiStats = null
       }
     } else {
       this.logger.log('AI disabled — using hardcoded matchers')
       recsBySource = await this.runFallback(companies)
+      mode = 'fallback-only'
     }
 
     const limited = this.limit(recsBySource)
@@ -93,7 +130,23 @@ export class GenerateRecommendations implements UseCase<
     await this.recRepo.deleteAll()
     await this.recRepo.saveAll(flatten(limited))
 
-    return computeStats(limited)
+    const completedAtDate = new Date()
+    const durationMs = completedAtDate.getTime() - startMs
+    const stats = computeStats(limited)
+
+    this.logger.log(
+      `completed in ${durationMs}ms — ${stats.totalRecommendations} recs (mode=${mode})`,
+    )
+
+    return {
+      mode,
+      aiEnabled,
+      aiStats,
+      durationMs,
+      startedAt: startedAtDate.toISOString(),
+      completedAt: completedAtDate.toISOString(),
+      ...stats,
+    }
   }
 
   private async runFallback(
@@ -138,9 +191,13 @@ function mergeInto(
   }
 }
 
-function computeStats(
-  recs: Map<string, Recommendation[]>,
-): GenerateRecommendationsResult {
+interface BatchStats {
+  totalRecommendations: number
+  companiesWithRecs: number
+  byRelationType: Record<RelationType, number>
+}
+
+function computeStats(recs: Map<string, Recommendation[]>): BatchStats {
   const byRelationType: Record<RelationType, number> = {
     referente: 0,
     cliente: 0,

--- a/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
+++ b/src/brain/src/recommendations/application/use-cases/GenerateRecommendations.ts
@@ -86,7 +86,11 @@ export class GenerateRecommendations implements UseCase<
         this.logger.log(
           `AI eval stats: total=${stats.total} cached=${stats.cached} evaluated=${stats.evaluated} errors=${stats.errors}`,
         )
-        recsBySource = await this.expandFromCache(companies)
+        const aiRecs = await this.expandFromCache(companies)
+        const fallbackRecs = await this.runFallback(companies)
+        recsBySource = new Map<string, Recommendation[]>()
+        mergeInto(recsBySource, aiRecs)
+        mergeInto(recsBySource, fallbackRecs)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         this.logger.error(

--- a/src/brain/src/recommendations/recommendations.module.ts
+++ b/src/brain/src/recommendations/recommendations.module.ts
@@ -2,12 +2,14 @@ import { Module, forwardRef } from '@nestjs/common'
 import { CiiuTaxonomyModule } from '@/ciiu-taxonomy/ciiu-taxonomy.module'
 import { CompaniesModule } from '@/companies/companies.module'
 import { DynamicValueChainRules } from './application/services/DynamicValueChainRules'
+import { AiCacheExpander } from './application/services/AiCacheExpander'
 import { AiMatchEngine } from './application/services/AiMatchEngine'
 import { AllianceMatcher } from './application/services/AllianceMatcher'
 import { CandidateSelector } from './application/services/CandidateSelector'
 import { CiiuPairEvaluator } from './application/services/CiiuPairEvaluator'
 import { FeatureVectorBuilder } from './application/services/FeatureVectorBuilder'
 import { PeerMatcher } from './application/services/PeerMatcher'
+import { RecommendationLimiter } from './application/services/RecommendationLimiter'
 import { ValueChainMatcher } from './application/services/ValueChainMatcher'
 import { ExplainRecommendation } from './application/use-cases/ExplainRecommendation'
 import { GenerateRecommendations } from './application/use-cases/GenerateRecommendations'
@@ -45,12 +47,14 @@ import { SupabaseRecommendationRepository } from './infrastructure/repositories/
       useFactory: () => env.AI_DRIVEN_RULES_ENABLED === 'true',
     },
     DynamicValueChainRules,
+    AiCacheExpander,
     AiMatchEngine,
     AllianceMatcher,
     CandidateSelector,
     CiiuPairEvaluator,
     FeatureVectorBuilder,
     PeerMatcher,
+    RecommendationLimiter,
     ValueChainMatcher,
     GenerateRecommendations,
     GetCompanyRecommendations,
@@ -65,6 +69,8 @@ import { SupabaseRecommendationRepository } from './infrastructure/repositories/
     PeerMatcher,
     ValueChainMatcher,
     AllianceMatcher,
+    AiCacheExpander,
+    RecommendationLimiter,
     GenerateRecommendations,
     GetCompanyRecommendations,
     GetGroupedCompanyRecommendations,


### PR DESCRIPTION
## Summary

- Garantiza **al menos 2 recomendaciones por tipo de relación** (cliente / proveedor / referente / aliado, hasta 8 por empresa) en vez del cap-only previo que dejaba tipos vacíos cuando la IA no producía match
- **Enriquece el prompt de `ExplainRecommendation`** con glosario empresarial, contexto operacional de ambas empresas, reglas de cadena de valor aplicables, ecosistemas compartidos y reasons en lenguaje natural (vs JSON crudo)
- **Extrae dos services compartidos** (`RecommendationLimiter`, `AiCacheExpander`) reutilizados por batch (`GenerateRecommendations`) y signup (`OnboardCompanyFromSignup`)
- **Integra el AI match cache al flujo de signup**: las recs generadas en `OnboardCompanyFromSignup` ahora consultan el cache poblado por el batch admin sin gastar llamadas a Gemini en el request del registro

## Cambios principales

### Floor de 2 por tipo
`GenerateRecommendations.execute` ahora corre los matchers heurísticos (peer / value-chain / alliance) **siempre** en modo AI, y los mergea con los recs del cache. El dedupe por `(target, relationType)` mantiene max-score; el cap por tipo (2) sigue aplicando — pero ahora hay supply para llenar todos los tipos.

### Explain enriquecido
- `RELATION_GLOSSARY` define semántica empresarial colombiana de cada tipo
- `FEATURE_LABELS` traduce `ReasonFeature` a lenguaje natural
- Prompt incluye etapa, personal, ingreso operacional, reglas con peso, ecosistemas comunes, score 0–100 y pide siguiente paso accionable

### Services compartidos
- `RecommendationLimiter`: `dedupeByTargetAndType` + `capPerType`
- `AiCacheExpander`: `expandForCompany(source, universe)` (single source, usado por signup) + `expandForAll(companies)` (batch). Carga el cache una vez por llamada para evitar N+1 reads.

### AI cache en signup
`OnboardCompanyFromSignup.generateRecommendations` ahora llama a `cacheExpander.expandForCompany(newCompany, activeUniverse)` y mergea con los matchers heurísticos. Sin latencia adicional de Gemini en signup — solo lee el cache que pobla el batch.

## Test plan

- [x] `bun test __tests__/recommendations` — 285+12 tests, todos verdes
- [x] `bun test __tests__/companies/OnboardCompanyFromSignup.test.ts` — 9 tests verdes (1 nuevo para AI cache)
- [x] `bun typecheck` limpio
- [x] Pre-push (`vitest`): **760/760 pass**
- [x] Verificar manualmente que `POST /recommendations/generate` produce hasta 2 por tipo
- [ ] Verificar manualmente que `POST /companies/onboard` (signup) genera recs con `source='ai-inferred'` cuando el cache tiene hits para los CIIUs involucrados
- [ ] Verificar manualmente que `POST /recommendations/:id/explain` devuelve explicación con glosario + reglas + ecosistemas + pasos accionables